### PR TITLE
Bump esphome floor to 2026.5.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ version = "0.0.0" # Set by GH action on release
 
 [project.optional-dependencies]
 esphome = [
-  "esphome>=2024.1.0",
+  "esphome>=2026.5.3",
 ]
 test = [
   "blockbuster>=1.5.5,<1.6",


### PR DESCRIPTION
# What does this implement/fix?

Raise the optional `esphome` extra's floor from `>=2024.1.0` to `>=2026.5.3`. The component catalog was already synced from schema 2026.5.3 in #1319, so this aligns the declared minimum with the catalog's schema; a lean install can no longer pull an esphome older than the catalog was generated against.

Dependabot ignores `esphome` by design (bumping it needs a coordinated catalog re-sync), so this is the deliberate, manual release-time bump.

**Related issue or feature (if applicable):**

- n/a

## Types of changes

- [x] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
