### PR TITLE
Persist the expert_mode preference the frontend already writes

### DIFF
--- a/esphome_device_builder/models/preferences.py
+++ b/esphome_device_builder/models/preferences.py
@@ -46,6 +46,10 @@ class UserPreferences(DataClassORJSONMixin):
     navigator_visible: bool = True
     yaml_diff_button: bool = False
 
+    # Frontend "Expert Mode" master switch: gates the editor diff view, the
+    # device-navigator search box, and the command-palette YAML content search.
+    expert_mode: bool = False
+
     # Table view settings
     table_page_size: int = 25
     table_column_visibility: dict[str, bool] = field(default_factory=dict)

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -747,6 +747,15 @@ async def test_set_prefs_merges_partial_update(tmp_path: Path) -> None:
     assert controller.prefs.snapshot() == result
 
 
+async def test_set_prefs_persists_expert_mode(tmp_path: Path) -> None:
+    """The frontend's Expert Mode toggle round-trips through set/get prefs."""
+    controller = _make_controller(tmp_path)
+
+    result = await controller.set_prefs(expert_mode=True)
+    assert result.expert_mode is True
+    assert (await controller.get_prefs()).expert_mode is True
+
+
 async def test_set_prefs_concurrent_updates_do_not_lose_writes(tmp_path: Path) -> None:
     """Partial updates of distinct fields all survive on the RAM-canonical store.
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The frontend's Expert Mode toggle writes `expert_mode` via `config/set_preferences`, but the backend `UserPreferences` model never had the field, so mashumaro dropped it on write and `get_preferences` never returned it; the toggle reset to off on every reload. Adds `expert_mode: bool` to the model so the existing get/set path persists it. Backend only; the frontend already reads and writes the field.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
