### PR TITLE
Serialise float and lambda YAML values in /json-config

### DIFF
--- a/esphome_device_builder/helpers/json.py
+++ b/esphome_device_builder/helpers/json.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import orjson
 from aiohttp import web
+from esphome.core import Lambda
 
 from .origin import request_origin_allowed
 
@@ -38,6 +39,21 @@ def dumps(obj: Any) -> bytes:
     return orjson.dumps(obj)
 
 
+def _json_default(obj: Any) -> Any:
+    """Orjson fallback for ESPHome's ``yaml_util`` types orjson rejects.
+
+    orjson serialises ``str`` / ``int`` / ``dict`` / ``list`` subclasses
+    natively but rejects ``float`` subclasses (``EFloat``) and ``Lambda``,
+    so a config with a float or a ``!lambda`` would 500 ``/json-config``.
+    Downcast ``EFloat`` to ``float`` and render ``Lambda`` as its source.
+    """
+    if isinstance(obj, float):
+        return float(obj)
+    if isinstance(obj, Lambda):
+        return str(obj)
+    raise TypeError
+
+
 def dumps_str_non_str_keys(obj: Any) -> str:
     """
     Serialise *obj* allowing dict keys whose type isn't *exactly* ``str``.
@@ -48,7 +64,9 @@ def dumps_str_non_str_keys(obj: Any) -> str:
     Dict key must be str``. ESPHome's ``yaml_util`` returns dicts
     whose keys are ``EStr`` (a ``str`` subclass that carries
     source-position info), which is what the legacy
-    ``/json-config`` endpoint feeds in.
+    ``/json-config`` endpoint feeds in. The ``_json_default`` hook
+    additionally tolerates the ``yaml_util`` value types orjson rejects
+    — ``EFloat`` (a ``float`` subclass) and ``Lambda`` (#1765).
 
     Use this helper for that endpoint (and only there); the strict
     default of ``dumps`` still catches the more common bug shape —
@@ -59,7 +77,7 @@ def dumps_str_non_str_keys(obj: Any) -> str:
     ``web.json_response(dumps=...)`` (which expects a ``str``-
     returning callable, like ``dumps_str``).
     """
-    return orjson.dumps(obj, option=orjson.OPT_NON_STR_KEYS).decode()
+    return orjson.dumps(obj, option=orjson.OPT_NON_STR_KEYS, default=_json_default).decode()
 
 
 def dumps_str(obj: Any) -> str:

--- a/tests/api/test_legacy.py
+++ b/tests/api/test_legacy.py
@@ -400,6 +400,50 @@ async def test_json_config_returns_parsed_yaml(
     assert body["esphome"]["platform"] == "ESP32"
 
 
+async def test_json_config_serialises_float_values(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """A float in the YAML round-trips instead of 500ing the endpoint.
+
+    ``yaml_util.load_yaml`` wraps scalars in ``EFloat`` (a ``float``
+    subclass orjson won't serialise natively); HA's encryption-key
+    detection broke on the resulting 500 (#1765).
+    """
+    (tmp_path / "floaty.yaml").write_text(
+        "sensor:\n  - platform: adc\n    pin: GPIO01\n    filters:\n      - delta: 0.1\n",
+        encoding="utf-8",
+    )
+    client = await aiohttp_client(_make_app(tmp_path))
+
+    resp = await client.get("/json-config", params={"configuration": "floaty.yaml"})
+
+    assert resp.status == 200
+    body = await resp.json()
+    assert body["sensor"][0]["filters"][0]["delta"] == 0.1
+
+
+async def test_json_config_serialises_lambda_values(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """A ``!lambda`` renders as its source instead of 500ing the endpoint.
+
+    Raw ``load_yaml`` yields an ``esphome.core.Lambda`` orjson can't
+    serialise; the same HA encryption-key detection breaks if any
+    pervasive ``!lambda`` 500s the config fetch (#1765).
+    """
+    (tmp_path / "lammy.yaml").write_text(
+        "sensor:\n  - platform: template\n    lambda: !lambda 'return 1.0;'\n",
+        encoding="utf-8",
+    )
+    client = await aiohttp_client(_make_app(tmp_path))
+
+    resp = await client.get("/json-config", params={"configuration": "lammy.yaml"})
+
+    assert resp.status == 200
+    body = await resp.json()
+    assert body["sensor"][0]["lambda"] == "return 1.0;"
+
+
 @pytest.mark.parametrize(
     "payload",
     ["../etc/passwd", "../../etc/passwd", "/absolute/path"],

--- a/tests/test_helpers_json.py
+++ b/tests/test_helpers_json.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from aiohttp import web
+from esphome.core import Lambda
 from pytest_aiohttp.plugin import AiohttpClient
 
 from esphome_device_builder.helpers.json import (
@@ -25,6 +26,12 @@ from esphome_device_builder.helpers.json import (
 
 class _StrSubclass(str):
     """Stand-in for ESPHome's ``EStr`` (a ``str`` subclass)."""
+
+    __slots__ = ()
+
+
+class _FloatSubclass(float):
+    """Stand-in for ESPHome's ``EFloat`` (a ``float`` subclass)."""
 
     __slots__ = ()
 
@@ -68,6 +75,36 @@ def test_dumps_str_non_str_keys_serialises_plain_str_keys() -> None:
     out = dumps_str_non_str_keys({"plain": 1, "nested": {"x": 2}})
     assert isinstance(out, str)
     assert loads(out) == {"plain": 1, "nested": {"x": 2}}
+
+
+def test_dumps_str_non_str_keys_serialises_float_subclass_values() -> None:
+    """``dumps_str_non_str_keys`` tolerates ``float``-subclass values.
+
+    orjson serialises ``str``/``int`` subclasses natively but rejects
+    ``float`` ones, so a YAML config with a float (``EFloat``) 500'd
+    ``/json-config`` until the ``_json_default`` hook downcast it (#1765).
+    """
+    out = dumps_str_non_str_keys({_StrSubclass("delta"): _FloatSubclass(0.1)})
+    assert isinstance(out, str)
+    assert loads(out) == {"delta": 0.1}
+
+
+def test_dumps_str_non_str_keys_serialises_lambda_values() -> None:
+    """``dumps_str_non_str_keys`` renders a ``!lambda`` as its source string.
+
+    Raw ``load_yaml`` turns ``!lambda`` into an ``esphome.core.Lambda``,
+    which orjson can't serialise; ``_json_default`` stringifies it so a
+    config with a lambda doesn't 500 ``/json-config`` either (#1765).
+    """
+    out = dumps_str_non_str_keys({_StrSubclass("lambda"): Lambda("return 1.0;")})
+    assert isinstance(out, str)
+    assert loads(out) == {"lambda": "return 1.0;"}
+
+
+def test_dumps_str_non_str_keys_rejects_unhandled_type() -> None:
+    """``_json_default`` re-raises for genuinely unknown types, keeping orjson strict."""
+    with pytest.raises(TypeError):
+        dumps_str_non_str_keys({"x": object()})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this implement/fix?

`GET /json-config?configuration=<file>` returned **500** whenever the YAML
config contained a float (e.g. a `filters: - delta: 0.1`) or a `!lambda`, with
`TypeError: Type is not JSON serializable: EFloat` / `... Lambda`. Home
Assistant's ESPHome config flow uses this endpoint to auto-detect the API
encryption key, so the 500 dropped HA back to manually prompting the user.

**Root cause:** `api/legacy.py:legacy_json_config` parses with ESPHome's
`yaml_util.load_yaml`, which wraps every scalar in a source-position subclass
(`EInt`/`EFloat`/`EStr`/`EDict`/`EList`) and turns `!lambda` into a
`esphome.core.Lambda`. It then serialises via `dumps_str_non_str_keys` (orjson).
orjson serialises `str`/`int`/`dict`/`list` subclasses **natively but not
`float` subclasses, and not `Lambda`** — so `EStr` keys and `EInt` values pass,
but any `EFloat` value or `!lambda` raises.

The legacy Tornado dashboard never hit this: it shells out to
`esphome config --show-secrets`, re-parses the subprocess stdout with a *plain*
pyyaml loader (`SafeLoaderIgnoreUnknown`) — which yields vanilla `float`/`str`
(no E-types) and renders unknown tags like `!lambda` as plain strings via
`ignore_unknown` — then dumps with stdlib `json`. Nothing non-JSON-native ever
reaches the serialiser. Our lighter raw-load + orjson path (no subprocess) is
what surfaces these types; the raw load is intentional, so the fix stays on it.

**Fix:** a `_json_default` orjson hook that downcasts a `float` subclass to
plain `float` and renders `Lambda` as its source string, wired into
`dumps_str_non_str_keys` (the only caller feeding raw E-typed YAML). `default`
fires only for types orjson can't already handle, so `EInt`/`EStr`/`EDict`/
`EList` are untouched; genuinely unknown types still raise, keeping orjson
strict for every other call site. `esphome.core` is already in the eager import
graph, so the top-level `Lambda` import adds no cold-start cost.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

Fixes #1765
