### PR TITLE
Resubscribe on broker reconnect and move MQTT teardown off the event loop

### DIFF
--- a/esphome_device_builder/controllers/_device_mqtt_monitor.py
+++ b/esphome_device_builder/controllers/_device_mqtt_monitor.py
@@ -18,7 +18,7 @@ import contextlib
 import logging
 import secrets
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Protocol
 
 try:
@@ -44,6 +44,10 @@ _OFFLINE_TIMEOUT = 65.0  # two missed broadcasts + slack before OFFLINE
 _RECONNECT_DELAY = 5.0  # delay before reconnecting after broker errors
 _CONNECT_TIMEOUT = 10.0  # seconds to wait for CONNACK before giving up
 _DEFAULT_PORT = 1883
+# One taxonomy for "quiet reconnect": ``_run``'s except clause and the
+# session TaskGroup unwrap must agree, or a concurrent group stops
+# collapsing and degrades to the loud unexpected path.
+_EXPECTED_SESSION_ERRORS = (TimeoutError, OSError, ConnectionError)
 
 # Callbacks ignore the return value — typed as ``object`` so callers can
 # pass through the bool ``applied`` flag returned by
@@ -58,6 +62,12 @@ class PublishInfo(Protocol):
     rc: int
 
 
+class SubscribeClient(Protocol):
+    """The slice of paho's ``Client`` the CONNACK callback drives."""
+
+    def subscribe(self, topic: str) -> tuple[int, int]: ...
+
+
 class PublishClient(Protocol):
     """The slice of paho's ``Client`` the broadcast loop drives."""
 
@@ -68,6 +78,42 @@ class PublishClient(Protocol):
         payload: bytes | None = None,
         retain: bool = False,  # noqa: FBT001, FBT002
     ) -> PublishInfo: ...
+
+
+@dataclass
+class _SessionSignals:
+    """
+    Per-session handshake state shared with paho's thread callbacks.
+
+    ``connack_processed`` means "verdict recorded" — it is set on
+    rejection too, so a refused connect fails fast instead of waiting
+    out the connect timeout. ``failed`` is set alongside any ``errors``
+    append; paho's auto-reconnect re-fires ``on_connect`` after the
+    initial handshake, and a failure there must tear the session down,
+    not land in a list nobody re-reads.
+    """
+
+    connack_processed: asyncio.Event = field(default_factory=asyncio.Event)
+    failed: asyncio.Event = field(default_factory=asyncio.Event)
+    subscribed: asyncio.Event = field(default_factory=asyncio.Event)
+    suback_pending: asyncio.Event = field(default_factory=asyncio.Event)
+    errors: list[str] = field(default_factory=list)
+    messages: asyncio.Queue[Any] = field(default_factory=asyncio.Queue)
+
+    def record_verdict(self) -> None:
+        """Run on the loop thread: flag any failure, then open the gate."""
+        if self.errors:
+            self.failed.set()
+        self.connack_processed.set()
+
+    def begin_suback_wait(self) -> None:
+        """Run on the loop thread: a (re)connect just re-issued the subscribe.
+
+        Scheduled before the SUBACK can arrive (same FIFO bounce), so
+        the cleared latch always precedes its set.
+        """
+        self.subscribed.clear()
+        self.suback_pending.set()
 
 
 @dataclass(frozen=True)
@@ -205,7 +251,7 @@ class DeviceMqttMonitor:
                 await self._connect_and_listen(client_id)
             except asyncio.CancelledError:
                 raise
-            except (TimeoutError, OSError, ConnectionError) as err:
+            except _EXPECTED_SESSION_ERRORS as err:
                 self._log_reconnect_failure(err, expected=True)
             except Exception as err:  # noqa: BLE001 — reconnect loop must outlive any unexpected error
                 self._log_reconnect_failure(err, expected=False)
@@ -274,29 +320,58 @@ class DeviceMqttMonitor:
         )
         self._unexpected_error_logged = True
 
-    async def _connect_and_listen(self, client_id: str) -> None:
+    def _create_session_client(self, client_id: str, signals: _SessionSignals) -> Any:
         assert paho_mqtt is not None  # type narrowing — checked in start()
         loop = asyncio.get_running_loop()
 
-        message_queue: asyncio.Queue[Any] = asyncio.Queue()
-        connected = asyncio.Event()
-        connect_failed: list[int] = []
+        def on_connect(
+            connected_client: SubscribeClient, _userdata: object, _flags: object, rc: int
+        ) -> None:
+            # Runs on paho's thread, which swallows callback raises —
+            # every path must record its error and reach the set in the
+            # finally, or the awaiting side times out with no cause.
+            try:
+                if rc != 0:
+                    signals.errors.append(f"broker rejected connection (rc={rc})")
+                    return
+                # Subscribe from paho's own thread: its auto-reconnect
+                # re-fires this callback, so the subscription survives a
+                # broker blip our session logic never sees.
+                loop.call_soon_threadsafe(signals.begin_suback_wait)
+                result, _mid = connected_client.subscribe(_DISCOVER_TOPIC)
+                if result != 0:
+                    signals.errors.append(f"subscribe failed (rc={result})")
+            except Exception as err:  # noqa: BLE001 — paho's thread would swallow the raise
+                signals.errors.append(f"subscribe raised: {err!r}")
+            finally:
+                loop.call_soon_threadsafe(signals.record_verdict)
 
-        def on_connect(_client: Any, _userdata: Any, _flags: Any, rc: int) -> None:
-            if rc == 0:
-                loop.call_soon_threadsafe(connected.set)
+        def on_subscribe(
+            _client: Any, _userdata: object, _mid: int, granted_qos: tuple[int, ...]
+        ) -> None:
+            # A broker ACL denies the subscription via SUBACK 0x80 —
+            # ``subscribe()``'s rc cannot see it, and without this the
+            # monitor sits connected with discovery permanently dark.
+            if any(qos == 0x80 for qos in granted_qos):
+                signals.errors.append(f"subscription denied (granted qos={list(granted_qos)})")
+                loop.call_soon_threadsafe(signals.record_verdict)
             else:
-                connect_failed.append(rc)
-                loop.call_soon_threadsafe(connected.set)
+                loop.call_soon_threadsafe(signals.subscribed.set)
 
         def on_message(_client: Any, _userdata: Any, msg: Any) -> None:
-            loop.call_soon_threadsafe(message_queue.put_nowait, msg)
+            loop.call_soon_threadsafe(signals.messages.put_nowait, msg)
 
         client = paho_mqtt.Client(client_id=client_id, clean_session=True)
         client.on_connect = on_connect
+        client.on_subscribe = on_subscribe
         client.on_message = on_message
         if self._broker.username:
             client.username_pw_set(self._broker.username, self._broker.password or "")
+        return client
+
+    async def _connect_and_listen(self, client_id: str) -> None:
+        signals = _SessionSignals()
+        client = self._create_session_client(client_id, signals)
 
         def _connect_and_spin_up() -> None:
             client.connect(self._broker.host, self._broker.port)
@@ -306,10 +381,9 @@ class DeviceMqttMonitor:
 
         await run_in_executor(_connect_and_spin_up)
         try:
-            await asyncio.wait_for(connected.wait(), timeout=_CONNECT_TIMEOUT)
-            if connect_failed:
-                msg = f"broker rejected connection (rc={connect_failed[0]})"
-                raise ConnectionError(msg)
+            await asyncio.wait_for(signals.connack_processed.wait(), timeout=_CONNECT_TIMEOUT)
+            if signals.errors:
+                raise ConnectionError(signals.errors[0])
 
             _LOGGER.info("MQTT connected to %s:%s", self._broker.host, self._broker.port)
             # Signal to ``_run`` that this iteration achieved a real
@@ -321,17 +395,58 @@ class DeviceMqttMonitor:
             # production.
             self._connected_this_session = True
             self._set_connected(value=True)
-            client.subscribe(_DISCOVER_TOPIC)
 
-            async with asyncio.TaskGroup() as tg:
-                tg.create_task(self._listen(message_queue))
-                tg.create_task(self._ping_loop(client))
+            async def raise_when_session_failed() -> None:
+                await signals.failed.wait()
+                raise ConnectionError(signals.errors[-1])
+
+            async def require_suback() -> None:
+                # A broker that accepts a SUBSCRIBE but never SUBACKs
+                # would leave discovery dark until the keepalive kills
+                # the connection; bound the wait — re-armed for every
+                # reconnect handshake, not just the first.
+                while True:
+                    await signals.suback_pending.wait()
+                    signals.suback_pending.clear()
+                    try:
+                        async with asyncio.timeout(_CONNECT_TIMEOUT):
+                            await signals.subscribed.wait()
+                    except TimeoutError:
+                        msg = "no SUBACK for the discovery subscription"
+                        raise ConnectionError(msg) from None
+
+            try:
+                async with asyncio.TaskGroup() as tg:
+                    tg.create_task(self._listen(signals.messages))
+                    tg.create_task(self._ping_loop(client))
+                    tg.create_task(raise_when_session_failed())
+                    tg.create_task(require_suback())
+            except BaseExceptionGroup as eg:
+                # The TaskGroup wraps even a lone connection error;
+                # unwrap so ``_run``'s expected/quiet reconnect path
+                # keeps its flat except contract.
+                raise _unwrap_session_error(eg) from None
         finally:
-            # Synchronous teardown — paho's loop_stop joins its thread,
-            # usually under a second, so no need for run_in_executor here.
-            client.loop_stop()
-            client.disconnect()
-            self._set_connected(value=False)
+            # loop_stop joins paho's thread and disconnect touches its
+            # socket — keep both off the loop, even during cancellation.
+            def _teardown() -> None:
+                # paho's documented order: disconnect while the network
+                # thread still runs, so the DISCONNECT packet actually
+                # goes out. The join must run even if disconnect raises,
+                # or the thread (and its socket) leaks every reconnect.
+                try:
+                    client.disconnect()
+                finally:
+                    client.loop_stop()
+
+            try:
+                await run_in_executor(_teardown)
+            except Exception:
+                _LOGGER.exception("MQTT client teardown failed")
+            finally:
+                # The await is a cancellation point; the flag must
+                # clear even when a second cancel lands there.
+                self._set_connected(value=False)
 
     async def _listen(self, queue: asyncio.Queue[Any]) -> None:
         """Push discovery responses into the state and IP callbacks."""
@@ -446,6 +561,16 @@ class DeviceMqttMonitor:
 # ---------------------------------------------------------------------------
 # Internals
 # ---------------------------------------------------------------------------
+
+
+def _unwrap_session_error(eg: BaseExceptionGroup) -> BaseException:
+    """Return the first expected connection error inside *eg*, or *eg* itself."""
+    expected, rest = eg.split(_EXPECTED_SESSION_ERRORS)
+    if expected is not None and rest is None:
+        if len(expected.exceptions) > 1:
+            _LOGGER.debug("Collapsing concurrent session errors: %r", expected.exceptions)
+        return expected.exceptions[0]
+    return eg
 
 
 def _extract_ip(data: dict[str, Any]) -> str:

--- a/tests/e2e/slow/mqtt/test_mqtt_discovery_broker.py
+++ b/tests/e2e/slow/mqtt/test_mqtt_discovery_broker.py
@@ -56,6 +56,29 @@ async def _wait_for(condition: Callable[[], bool], timeout: float, what: str) ->
         await asyncio.sleep(0.05)
 
 
+async def _restart_mosquitto(tmp_path: Path, port: int) -> asyncio.subprocess.Process:
+    broker = await asyncio.create_subprocess_exec(
+        str(_MOSQUITTO),
+        "-c",
+        str(tmp_path / "mosquitto.conf"),
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    deadline = asyncio.get_running_loop().time() + 10.0
+    while True:
+        try:
+            _reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        except OSError:
+            if asyncio.get_running_loop().time() > deadline:
+                broker.terminate()
+                pytest.fail("mosquitto did not come back after restart")
+            await asyncio.sleep(0.05)
+        else:
+            writer.close()
+            await writer.wait_closed()
+            return broker
+
+
 async def _start_mosquitto(tmp_path: Path) -> tuple[asyncio.subprocess.Process, int]:
     passwd = tmp_path / "mosquitto-passwd"
     for index, (user, password) in enumerate(_LOGINS.items()):
@@ -68,27 +91,7 @@ async def _start_mosquitto(tmp_path: Path) -> tuple[asyncio.subprocess.Process, 
     port = _free_port()
     conf = tmp_path / "mosquitto.conf"
     conf.write_text(f"listener {port} 127.0.0.1\nallow_anonymous true\npassword_file {passwd}\n")
-    broker = await asyncio.create_subprocess_exec(
-        str(_MOSQUITTO),
-        "-c",
-        str(conf),
-        stdout=asyncio.subprocess.DEVNULL,
-        stderr=asyncio.subprocess.DEVNULL,
-    )
-
-    deadline = asyncio.get_running_loop().time() + 10.0
-    while True:
-        try:
-            _reader, writer = await asyncio.open_connection("127.0.0.1", port)
-        except OSError:
-            if asyncio.get_running_loop().time() > deadline:
-                broker.terminate()
-                pytest.fail("mosquitto did not start listening")
-            await asyncio.sleep(0.05)
-        else:
-            writer.close()
-            await writer.wait_closed()
-            return broker, port
+    return await _restart_mosquitto(tmp_path, port), port
 
 
 class _FakeMqttDevice:
@@ -132,6 +135,83 @@ class _BroadcastProbe:
     def stop(self) -> None:
         self._client.loop_stop()
         self._client.disconnect()
+
+
+@pytest.mark.timeout(60)
+async def test_broker_restart_resubscribes_and_recovers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A broker restart must not flip devices OFFLINE, and discovery must resume.
+
+    Pins the resubscribe-on-reconnect fix against real paho
+    auto-reconnect rather than a hand-fired callback.
+    """
+    monkeypatch.setattr(monitor_module, "_PING_INTERVAL", 0.25)
+    # Generous timeout: the outage itself must not age anyone out; the
+    # aging behaviour is pinned by the other test.
+    monkeypatch.setattr(monitor_module, "_OFFLINE_TIMEOUT", 30.0)
+
+    broker, port = await _start_mosquitto(tmp_path)
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    devices: list[Device] = []
+    fakes: list[_FakeMqttDevice] = []
+    for i in (1, 2):
+        name = f"dev{i}"
+        (config_dir / f"{name}.yaml").write_text(
+            f"esphome:\n  name: {name}\n"
+            f"mqtt:\n  broker: 127.0.0.1\n  port: {port}\n"
+            f"  username: alpha\n  password: {_LOGINS['alpha']}\n"
+        )
+        devices.append(
+            Device(name=name, friendly_name=name, configuration=f"{name}.yaml", uses_mqtt=True)
+        )
+        fakes.append(_FakeMqttDevice(name, f"10.0.1.{i}", port, "alpha", _LOGINS["alpha"]))
+
+    events: list[tuple[str, DeviceState]] = []
+    presence = SubscriberPresence()
+    coord = DeviceMqttCoordinator(
+        config_dir=config_dir,
+        get_devices=lambda: devices,
+        on_state_change=lambda n, s: events.append((n, s)),
+        on_ip_change=lambda *_: None,
+        presence=presence,
+    )
+
+    try:
+        await coord.reconcile()
+        with presence.subscriber():
+            await _wait_for(
+                lambda: {n for n, s in events if s == DeviceState.ONLINE} == {"dev1", "dev2"},
+                10.0,
+                "both devices ONLINE",
+            )
+
+            broker.terminate()
+            with contextlib.suppress(ProcessLookupError):
+                await broker.wait()
+            await asyncio.sleep(1.0)
+
+            # Same port so paho's auto-reconnect finds the new broker.
+            broker = await _restart_mosquitto(tmp_path, port)
+
+            events.clear()
+            await _wait_for(
+                lambda: {n for n, s in events if s == DeviceState.ONLINE} == {"dev1", "dev2"},
+                20.0,
+                "devices rediscovered after broker restart",
+            )
+        assert not [e for e in events if e[1] == DeviceState.OFFLINE], (
+            "broker outage must not flip devices OFFLINE"
+        )
+    finally:
+        await coord.stop()
+        for fake in fakes:
+            fake.stop()
+        broker.terminate()
+        with contextlib.suppress(ProcessLookupError):
+            await broker.wait()
 
 
 @pytest.mark.timeout(60)

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 from typing import Any, ClassVar
 from unittest.mock import patch
@@ -1805,7 +1805,51 @@ async def test_start_spawns_run_task_when_paho_available(
     assert monitor.running is False
 
 
-async def test_connect_and_listen_subscribes_publishes_and_runs_listen_ping(  # noqa: C901
+class _FakePahoClient:
+    """Configurable paho stand-in; subclasses override only what varies."""
+
+    connack_rc = 0
+
+    def __init__(self, client_id: str = "", clean_session: bool = True) -> None:
+        self.on_connect: Any = None
+        self.on_subscribe: Any = None
+        self.on_message: Any = None
+        self._record("init", (client_id, clean_session))
+
+    def _record(self, op: str, args: tuple[Any, ...]) -> None:
+        return None
+
+    def username_pw_set(self, username: str, password: str) -> None:
+        self._record("username_pw_set", (username, password))
+
+    def connect(self, host: str, port: int) -> None:
+        self._record("connect", (host, port))
+
+    def loop_start(self) -> None:
+        self._record("loop_start", ())
+        # Fire on_connect the way paho's network thread would; tests
+        # run it directly since the call reaches them via the executor.
+        self.on_connect(self, None, None, self.connack_rc)
+
+    def loop_stop(self) -> None:
+        self._record("loop_stop", ())
+
+    def subscribe(self, topic: str) -> tuple[int, int]:
+        self._record("subscribe", (topic,))
+        # Model a healthy broker: the SUBACK grants the subscription.
+        if self.on_subscribe is not None:
+            self.on_subscribe(self, None, 1, [0])
+        return (0, 1)
+
+    def publish(self, topic: str, payload: Any = None, retain: bool = False) -> _PublishInfo:
+        self._record("publish", (topic, payload, retain))
+        return _PublishInfo()
+
+    def disconnect(self) -> None:
+        self._record("disconnect", ())
+
+
+async def test_connect_and_listen_subscribes_publishes_and_runs_listen_ping(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``_connect_and_listen`` wires paho callbacks, subscribes, and runs the inner tasks.
@@ -1815,7 +1859,7 @@ async def test_connect_and_listen_subscribes_publishes_and_runs_listen_ping(  # 
     coroutines. Pin: ``connect`` / ``loop_start`` / ``subscribe``
     are called in order with no connect-time publish (broadcasts
     belong to the gated ping loop), the inner tasks fire, and
-    teardown runs ``loop_stop`` + ``disconnect`` even on cancel.
+    teardown runs ``disconnect`` + ``loop_stop`` even on cancel.
     """
     monitor = DeviceMqttMonitor(
         broker=MqttBrokerConfig(host="broker.local", port=1883, username="alice", password="x"),
@@ -1827,41 +1871,16 @@ async def test_connect_and_listen_subscribes_publishes_and_runs_listen_ping(  # 
     listen_started = asyncio.Event()
     ping_started = asyncio.Event()
 
-    class _FakeClient:
-        def __init__(self, client_id: str = "", clean_session: bool = True) -> None:
-            calls.append(("init", (client_id, clean_session)))
-            self.on_connect: Any = None
-            self.on_message: Any = None
-
-        def username_pw_set(self, username: str, password: str) -> None:
-            calls.append(("username_pw_set", (username, password)))
-
-        def connect(self, host: str, port: int) -> None:
-            calls.append(("connect", (host, port)))
+    class _FakeClient(_FakePahoClient):
+        def _record(self, op: str, args: tuple[Any, ...]) -> None:
+            calls.append((op, args))
 
         def loop_start(self) -> None:
-            calls.append(("loop_start", ()))
-            # Fire on_connect with rc=0 (success) on a thread-like
-            # callback. Production calls this from paho's network
-            # thread via call_soon_threadsafe; here we call it
-            # directly since we're already on the loop.
-            self.on_connect(self, None, None, 0)
-            # Fire one on_message so the inner queue-bridge
-            # closure (line 166) gets exercised.
+            super().loop_start()
+            # Fire one on_message so the queue-bridge closure gets
+            # exercised.
             fake_msg = type("M", (), {"topic": "x", "payload": b"", "retain": False})()
             self.on_message(self, None, fake_msg)
-
-        def loop_stop(self) -> None:
-            calls.append(("loop_stop", ()))
-
-        def subscribe(self, topic: str) -> None:
-            calls.append(("subscribe", (topic,)))
-
-        def publish(self, topic: str, payload: Any = None, retain: bool = False) -> None:
-            calls.append(("publish", (topic, payload, retain)))
-
-        def disconnect(self) -> None:
-            calls.append(("disconnect", ()))
 
     monkeypatch.setattr(monitor_module, "paho_mqtt", type("M", (), {"Client": _FakeClient}))
 
@@ -1886,19 +1905,332 @@ async def test_connect_and_listen_subscribes_publishes_and_runs_listen_ping(  # 
             await task
 
     op_names = [c[0] for c in calls]
-    # Ordered: init → username/pw → connect → loop_start → subscribe
-    # → loop_stop → disconnect. No publish here — the ping loop owns
-    # every broadcast so the subscriber gate can hold them all.
+    # Ordered: init → username/pw → connect → loop_start (whose CONNACK
+    # callback subscribes) → disconnect → loop_stop. No publish here —
+    # the ping loop owns every broadcast so the subscriber gate can
+    # hold them all.
     assert op_names == [
         "init",
         "username_pw_set",
         "connect",
         "loop_start",
         "subscribe",
-        "loop_stop",
         "disconnect",
+        "loop_stop",
     ]
     assert ("subscribe", ("esphome/discover/#",)) in calls
+
+
+def _fail_rc(_topic: str) -> tuple[int, int]:
+    return (7, 1)
+
+
+def _fail_raise(_topic: str) -> tuple[int, int]:
+    raise RuntimeError("boom")
+
+
+@pytest.mark.parametrize(
+    ("subscribe_impl", "match"),
+    [
+        pytest.param(_fail_rc, "subscribe failed \\(rc=7\\)", id="nonzero_rc"),
+        pytest.param(_fail_raise, "subscribe raised", id="raises"),
+    ],
+)
+async def test_subscribe_failure_fails_the_session_loud(
+    monkeypatch: pytest.MonkeyPatch,
+    subscribe_impl: Callable[[str], tuple[int, int]],
+    match: str,
+) -> None:
+    """A failed or raising subscribe surfaces as ConnectionError, never a silent timeout."""
+
+    class _FakeClient(_FakePahoClient):
+        def subscribe(self, topic: str) -> tuple[int, int]:
+            return subscribe_impl(topic)
+
+    monkeypatch.setattr(monitor_module, "paho_mqtt", type("M", (), {"Client": _FakeClient}))
+    monitor = DeviceMqttMonitor(
+        broker=MqttBrokerConfig(host="broker.local"),
+        on_state_change=lambda *_: None,
+        on_ip_change=lambda *_: None,
+    )
+    with pytest.raises(ConnectionError, match=match):
+        await monitor._connect_and_listen("test-id")
+
+
+async def test_reconnect_subscribe_failure_tears_the_session_down(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed re-subscribe on paho's auto-reconnect rebuilds the session, not a dead list."""
+    monitor = DeviceMqttMonitor(
+        broker=MqttBrokerConfig(host="broker.local"),
+        on_state_change=lambda *_: None,
+        on_ip_change=lambda *_: None,
+    )
+
+    session_running = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    instances: list[Any] = []
+
+    class _FakeClient(_FakePahoClient):
+        def __init__(self, client_id: str = "", clean_session: bool = True) -> None:
+            super().__init__(client_id, clean_session)
+            self.subscribe_calls = 0
+            instances.append(self)
+
+        def subscribe(self, topic: str) -> tuple[int, int]:
+            self.subscribe_calls += 1
+            return (0, 1) if self.subscribe_calls == 1 else (7, 2)
+
+        def publish(self, topic: str, payload: Any = None, retain: bool = False) -> _PublishInfo:
+            # The ping loop broadcasting proves the session TaskGroup
+            # is running, so the re-fired CONNACK below exercises the
+            # watcher path, not the initial handshake check.
+            loop.call_soon_threadsafe(session_running.set)
+            return _PublishInfo()
+
+    monkeypatch.setattr(monitor_module, "paho_mqtt", type("M", (), {"Client": _FakeClient}))
+
+    task = asyncio.create_task(monitor._connect_and_listen("test-id"))
+    await asyncio.wait_for(session_running.wait(), timeout=2.0)
+    # paho's auto-reconnect re-fires on_connect; this re-subscribe fails.
+    instances[0].on_connect(instances[0], None, None, 0)
+
+    with pytest.raises(ConnectionError, match="subscribe failed \\(rc=7\\)"):
+        await asyncio.wait_for(task, timeout=2.0)
+
+
+async def test_acl_denied_subscription_tears_the_session_down(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A SUBACK 0x80 (broker ACL denial) fails the session instead of going dark."""
+    monitor = DeviceMqttMonitor(
+        broker=MqttBrokerConfig(host="broker.local"),
+        on_state_change=lambda *_: None,
+        on_ip_change=lambda *_: None,
+    )
+
+    session_running = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    instances: list[Any] = []
+
+    class _FakeClient(_FakePahoClient):
+        def __init__(self, client_id: str = "", clean_session: bool = True) -> None:
+            super().__init__(client_id, clean_session)
+            instances.append(self)
+
+        def publish(self, topic: str, payload: Any = None, retain: bool = False) -> _PublishInfo:
+            loop.call_soon_threadsafe(session_running.set)
+            return _PublishInfo()
+
+    monkeypatch.setattr(monitor_module, "paho_mqtt", type("M", (), {"Client": _FakeClient}))
+
+    task = asyncio.create_task(monitor._connect_and_listen("test-id"))
+    await asyncio.wait_for(session_running.wait(), timeout=2.0)
+    # The broker's SUBACK arrives after the handshake looked healthy.
+    instances[0].on_subscribe(instances[0], None, 1, [0x80])
+
+    with pytest.raises(ConnectionError, match="subscription denied"):
+        await asyncio.wait_for(task, timeout=2.0)
+
+
+async def test_missing_suback_fails_the_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broker that never SUBACKs fails the session instead of staying dark."""
+    monkeypatch.setattr(monitor_module, "_CONNECT_TIMEOUT", 0.2)
+
+    monitor = DeviceMqttMonitor(
+        broker=MqttBrokerConfig(host="broker.local"),
+        on_state_change=lambda *_: None,
+        on_ip_change=lambda *_: None,
+    )
+
+    class _FakeClient(_FakePahoClient):
+        def subscribe(self, topic: str) -> tuple[int, int]:
+            return (0, 1)  # accepted, but no SUBACK ever arrives
+
+    monkeypatch.setattr(monitor_module, "paho_mqtt", type("M", (), {"Client": _FakeClient}))
+
+    with pytest.raises(ConnectionError, match="no SUBACK"):
+        await asyncio.wait_for(monitor._connect_and_listen("test-id"), timeout=2.0)
+
+
+async def test_missing_suback_on_reconnect_fails_the_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The SUBACK guard re-arms per handshake — a silent reconnect SUBACK also fails."""
+    monkeypatch.setattr(monitor_module, "_CONNECT_TIMEOUT", 0.3)
+
+    monitor = DeviceMqttMonitor(
+        broker=MqttBrokerConfig(host="broker.local"),
+        on_state_change=lambda *_: None,
+        on_ip_change=lambda *_: None,
+    )
+
+    session_running = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    instances: list[Any] = []
+
+    class _FakeClient(_FakePahoClient):
+        def __init__(self, client_id: str = "", clean_session: bool = True) -> None:
+            super().__init__(client_id, clean_session)
+            self.subscribe_calls = 0
+            instances.append(self)
+
+        def subscribe(self, topic: str) -> tuple[int, int]:
+            self.subscribe_calls += 1
+            if self.subscribe_calls == 1:
+                return super().subscribe(topic)  # healthy: SUBACK granted
+            return (0, 1)  # accepted, but the reconnect SUBACK never arrives
+
+        def publish(self, topic: str, payload: Any = None, retain: bool = False) -> _PublishInfo:
+            loop.call_soon_threadsafe(session_running.set)
+            return _PublishInfo()
+
+    monkeypatch.setattr(monitor_module, "paho_mqtt", type("M", (), {"Client": _FakeClient}))
+
+    task = asyncio.create_task(monitor._connect_and_listen("test-id"))
+    await asyncio.wait_for(session_running.wait(), timeout=2.0)
+    # paho's auto-reconnect re-fires on_connect; this handshake's
+    # SUBACK is silently dropped.
+    instances[0].on_connect(instances[0], None, None, 0)
+
+    with pytest.raises(ConnectionError, match="no SUBACK"):
+        await asyncio.wait_for(task, timeout=2.0)
+
+
+async def test_idle_monitor_still_applies_spontaneous_announcements() -> None:
+    """The listen path is not presence-gated — announcements apply while parked."""
+    presence = SubscriberPresence()
+    state_calls: list[tuple[str, DeviceState]] = []
+    monitor = DeviceMqttMonitor(
+        broker=MqttBrokerConfig(host="x"),
+        on_state_change=lambda n, s: state_calls.append((n, s)),
+        on_ip_change=lambda *_: None,
+        presence=presence,
+    )
+    assert not presence.has_subscribers()
+
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    await queue.put(
+        type(
+            "M",
+            (),
+            {
+                "topic": "esphome/discover/kitchen",
+                "payload": json.dumps({"name": "kitchen"}).encode(),
+                "retain": False,
+            },
+        )()
+    )
+    listen_task = asyncio.create_task(monitor._listen(queue))
+    try:
+        for _ in range(100):
+            if state_calls:
+                break
+            await asyncio.sleep(0.01)
+    finally:
+        listen_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await listen_task
+
+    assert state_calls == [("kitchen", DeviceState.ONLINE)]
+    assert "kitchen" in monitor._last_seen
+
+
+@pytest.mark.parametrize("failing_call", ["disconnect", "loop_stop"])
+async def test_teardown_failure_does_not_mask_the_session_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, failing_call: str
+) -> None:
+    """A raising teardown call is logged, its sibling still runs, and the session error surfaces."""
+    monitor = DeviceMqttMonitor(
+        broker=MqttBrokerConfig(host="broker.local"),
+        on_state_change=lambda *_: None,
+        on_ip_change=lambda *_: None,
+    )
+
+    torn_down: list[str] = []
+
+    class _FakeClient(_FakePahoClient):
+        connack_rc = 4  # "bad username/password" — any non-zero rejects
+
+        def _record(self, op: str, args: tuple[Any, ...]) -> None:
+            if op in ("disconnect", "loop_stop"):
+                torn_down.append(op)
+
+        def disconnect(self) -> None:
+            super().disconnect()
+            if failing_call == "disconnect":
+                raise RuntimeError("boom")
+
+        def loop_stop(self) -> None:
+            super().loop_stop()
+            if failing_call == "loop_stop":
+                raise RuntimeError("boom")
+
+    monkeypatch.setattr(monitor_module, "paho_mqtt", type("M", (), {"Client": _FakeClient}))
+
+    with (
+        caplog.at_level("ERROR", logger="esphome_device_builder.controllers._device_mqtt_monitor"),
+        pytest.raises(ConnectionError, match="rc=4"),
+    ):
+        await monitor._connect_and_listen("test-id")
+    assert monitor.connected is False
+    # A raising disconnect must not skip the thread join, or the paho
+    # thread leaks every reconnect cycle.
+    assert torn_down == ["disconnect", "loop_stop"]
+    assert any("teardown failed" in rec.message for rec in caplog.records)
+
+
+def test_unwrap_session_error_keeps_mixed_groups() -> None:
+    """Only a lone expected connection error unwraps; anything else stays grouped."""
+    lone = ExceptionGroup("g", [ConnectionError("x")])
+    assert isinstance(monitor_module._unwrap_session_error(lone), ConnectionError)
+    paired = ExceptionGroup("g", [ConnectionError("x"), OSError("y")])
+    assert isinstance(monitor_module._unwrap_session_error(paired), ConnectionError)
+    mixed = ExceptionGroup("g", [ConnectionError("x"), ValueError("y")])
+    assert monitor_module._unwrap_session_error(mixed) is mixed
+
+
+async def test_reconnect_refires_subscribe_via_on_connect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every CONNACK resubscribes, so paho's auto-reconnect can't lose the topic."""
+    monitor = DeviceMqttMonitor(
+        broker=MqttBrokerConfig(host="broker.local"),
+        on_state_change=lambda *_: None,
+        on_ip_change=lambda *_: None,
+    )
+
+    subscribes: list[str] = []
+    subscribed = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    instances: list[Any] = []
+
+    class _FakeClient(_FakePahoClient):
+        def __init__(self, client_id: str = "", clean_session: bool = True) -> None:
+            super().__init__(client_id, clean_session)
+            instances.append(self)
+
+        def subscribe(self, topic: str) -> tuple[int, int]:
+            subscribes.append(topic)
+            loop.call_soon_threadsafe(subscribed.set)
+            return (0, 1)
+
+    monkeypatch.setattr(monitor_module, "paho_mqtt", type("M", (), {"Client": _FakeClient}))
+
+    task = asyncio.create_task(monitor._connect_and_listen("test-id"))
+    try:
+        await asyncio.wait_for(subscribed.wait(), timeout=2.0)
+        assert subscribes == ["esphome/discover/#"]
+        # paho's auto-reconnect re-fires on_connect from its thread;
+        # the callback alone must re-establish the subscription.
+        instances[0].on_connect(instances[0], None, None, 0)
+        assert subscribes == ["esphome/discover/#", "esphome/discover/#"]
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
 
 
 async def test_connect_and_listen_raises_on_broker_rejection(
@@ -1919,37 +2251,20 @@ async def test_connect_and_listen_raises_on_broker_rejection(
 
     teardown_calls: list[str] = []
 
-    class _FakeClient:
-        def __init__(self, client_id: str = "", clean_session: bool = True) -> None:
-            self.on_connect: Any = None
-            self.on_message: Any = None
+    class _FakeClient(_FakePahoClient):
+        connack_rc = 4  # "bad username/password" — any non-zero rejects
 
-        def connect(self, host: str, port: int) -> None:
-            return None
-
-        def loop_start(self) -> None:
-            # rc=4 == "bad username/password" — any non-zero rejects.
-            self.on_connect(self, None, None, 4)
-
-        def loop_stop(self) -> None:
-            teardown_calls.append("loop_stop")
-
-        def subscribe(self, topic: str) -> None:
-            return None
-
-        def publish(self, *_args: Any, **_kwargs: Any) -> None:
-            return None
-
-        def disconnect(self) -> None:
-            teardown_calls.append("disconnect")
+        def _record(self, op: str, args: tuple[Any, ...]) -> None:
+            if op in ("loop_stop", "disconnect"):
+                teardown_calls.append(op)
 
     monkeypatch.setattr(monitor_module, "paho_mqtt", type("M", (), {"Client": _FakeClient}))
 
     with pytest.raises(ConnectionError, match="rc=4"):
         await monitor._connect_and_listen("test-id")
 
-    # Teardown ran even though we raised.
-    assert teardown_calls == ["loop_stop", "disconnect"]
+    # Teardown ran even though we raised, in paho's documented order.
+    assert teardown_calls == ["disconnect", "loop_stop"]
 
 
 async def test_run_reconnects_on_connect_and_listen_failure(


### PR DESCRIPTION
# What does this implement/fix?

Closes the reconnect hole and moves the remaining blocking teardown off the event loop. The subscribe moved into paho's `on_connect` callback, so it runs on paho's own thread and, critically, paho's auto reconnect re-fires it — previously a broker blip silently came back without the `esphome/discover/#` subscription and MQTT discovery went dark until a dashboard restart. Session teardown (`loop_stop`, which joins the network thread, and `disconnect`) now runs in the executor, disconnect first so the DISCONNECT packet goes out, with the thread join guaranteed even if disconnect raises.

Subscription health failures all surface loud through one session error channel instead of leaving the monitor connected with dark discovery: a rejected CONNACK, a failed or raising `subscribe()`, a broker ACL denying the subscription in the SUBACK (granted qos 0x80, which `subscribe()`'s rc cannot see), and a broker that never SUBACKs at all (bounded by the connect timeout). Any of them tears the session down and the reconnect loop rebuilds it cleanly.

An earlier revision of this PR ran paho directly on the event loop HA style; that was abandoned because native Windows must keep the Proactor loop (the compile pipeline needs asyncio subprocesses) and Proactor has no `add_reader`. paho's own network thread stays as the single transport; the blocking calls around it (connect, `loop_start`, publish in #2237; teardown here) live in the executor.

Verified against a real broker, including an e2e that restarts mosquitto mid watch and asserts no device flips OFFLINE during the outage and discovery resumes through paho's real auto reconnect.

**Related issue or feature (if applicable):**

- follows up #2237

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
