### PR TITLE
Consolidate the presence-gated loops onto one shared primitive

### DIFF
--- a/esphome_device_builder/api/legacy.py
+++ b/esphome_device_builder/api/legacy.py
@@ -346,7 +346,7 @@ def create_legacy_routes() -> web.RouteTableDef:
         """Legacy GET /devices — returns configured + importable devices.
 
         Calls ``poll`` to refresh the scanner from disk before
-        reading. This is the same shape ``DeviceBuilder._run_background``
+        reading. This is the same shape the background poll loop
         uses on its periodic tick — HA's sync-after-edit pattern
         relies on each ``GET /devices`` actually re-walking the
         config directory rather than returning whatever the last

--- a/esphome_device_builder/controllers/_device_mqtt_monitor.py
+++ b/esphome_device_builder/controllers/_device_mqtt_monitor.py
@@ -566,7 +566,11 @@ class _DiscoverPingLoop(PresenceGatedLoop[bool]):
     async def run_session(self, client: PublishClient) -> None:
         """Run this loop for one broker session's *client*."""
         self._client = client
-        await self.run()
+        try:
+            await self.run()
+        finally:
+            # Don't pin the dead session's client until the next connect.
+            self._client = None
 
     def _on_resume(self) -> None:
         # Rebase so the resumed timeout window starts now — otherwise

--- a/esphome_device_builder/controllers/_device_mqtt_monitor.py
+++ b/esphome_device_builder/controllers/_device_mqtt_monitor.py
@@ -509,6 +509,14 @@ class DeviceMqttMonitor:
         for name in self._last_seen:
             self._last_seen[name] = now
 
+    def _sweep_stale(self) -> None:
+        """Flip entries silent past ``_OFFLINE_TIMEOUT`` to OFFLINE."""
+        now = asyncio.get_running_loop().time()
+        stale = [name for name, last in self._last_seen.items() if now - last > _OFFLINE_TIMEOUT]
+        for name in stale:
+            self._on_state_change(name, DeviceState.OFFLINE)
+            self._last_seen.pop(name, None)
+
     def _set_connected(self, *, value: bool) -> None:
         if self.connected == value:
             return
@@ -549,10 +557,15 @@ class _DiscoverPingLoop(PresenceGatedLoop):
         self._client: PublishClient | None = None
         self._broadcast_sent = False
 
+    @property
+    def _interval(self) -> float:  # type: ignore[override]
+        # Live-read like _OFFLINE_TIMEOUT so tests patching the
+        # module constant are honored.
+        return _PING_INTERVAL
+
     async def run_session(self, client: PublishClient) -> None:
         """Run this loop for one broker session's *client*."""
         self._client = client
-        self._interval = _PING_INTERVAL
         await self.run()
 
     def _on_resume(self) -> None:
@@ -566,15 +579,10 @@ class _DiscoverPingLoop(PresenceGatedLoop):
         monitor = self._monitor
         self._broadcast_sent = monitor.is_publisher and await monitor._broadcast(self._client)
 
-    def _after_idle(self) -> None:
-        if not self._broadcast_sent:
-            return
-        monitor = self._monitor
-        now = asyncio.get_running_loop().time()
-        stale = [name for name, last in monitor._last_seen.items() if now - last > _OFFLINE_TIMEOUT]
-        for name in stale:
-            monitor._on_state_change(name, DeviceState.OFFLINE)
-            monitor._last_seen.pop(name, None)
+    async def _idle(self) -> None:
+        await super()._idle()
+        if self._broadcast_sent:
+            self._monitor._sweep_stale()
 
 
 def _unwrap_session_error(eg: BaseExceptionGroup) -> BaseException:

--- a/esphome_device_builder/controllers/_device_mqtt_monitor.py
+++ b/esphome_device_builder/controllers/_device_mqtt_monitor.py
@@ -14,7 +14,6 @@ disables itself; mDNS / ping discovery keeps working.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 import secrets
 from collections.abc import Callable
@@ -29,6 +28,7 @@ except ImportError:  # pragma: no cover — paho-mqtt arrives via the [esphome] 
 
 from ..helpers.async_ import drain_tasks, run_in_executor
 from ..helpers.json import JSONDecodeError, loads
+from ..helpers.presence_gated_loop import PresenceGatedLoop
 from ..helpers.subscriber_presence import SubscriberPresence
 from ..models import DeviceState
 
@@ -156,7 +156,6 @@ class DeviceMqttMonitor:
         self._broker = broker
         self._on_state_change = on_state_change
         self._on_ip_change = on_ip_change
-        self._presence = presence
         self._on_connection_change = on_connection_change
         # Whether this monitor broadcasts ``esphome/discover``. The
         # coordinator designates one broadcaster per (host, port) —
@@ -167,12 +166,7 @@ class DeviceMqttMonitor:
         # so a down login never holds the broadcaster role while a
         # healthy sibling could carry it.
         self.connected = False
-        # Cuts the interval sleep short on the presence 0→1 transition
-        # so a returning dashboard doesn't wait out _PING_INTERVAL.
-        self._wake = asyncio.Event()
-        self._unsub_wake: Callable[[], None] | None = None
-        if presence is not None:
-            self._unsub_wake = presence.add_subscriber_callback(self._wake.set)
+        self._ping = _DiscoverPingLoop(self, presence)
         self._task: asyncio.Task[None] | None = None
         # device name → monotonic timestamp of the last MQTT response
         self._last_seen: dict[str, float] = {}
@@ -218,9 +212,7 @@ class DeviceMqttMonitor:
 
     async def stop(self) -> None:
         """Cancel the connect/listen task and forget all observations."""
-        if self._unsub_wake is not None:
-            self._unsub_wake()
-            self._unsub_wake = None
+        self._ping.unsubscribe()
         if self._task is None:
             return
         await drain_tasks((self._task,), log_exceptions=True)
@@ -481,41 +473,8 @@ class DeviceMqttMonitor:
                 self._on_ip_change(name, ip)
 
     async def _ping_loop(self, client: PublishClient) -> None:
-        """
-        Broadcast discover requests and sweep stale devices offline.
-
-        Every MQTT device answers each ``esphome/discover`` publish, so
-        broadcasts run only while a dashboard client is subscribed, and
-        only from the elected broadcaster. While idle the loop parks
-        with the offline aging frozen — silence without polls is not
-        evidence — and spontaneous announcements keep flowing through
-        ``_listen``. Aging belongs to the broadcaster for the same
-        reason: a silent sibling must not judge a fleet nobody is
-        polling, and a tick whose own broadcast failed to send judges
-        nobody either.
-        """
-        loop = asyncio.get_running_loop()
-        while True:
-            if self._presence is not None and not self._presence.has_subscribers():
-                await self._presence.wait_for_subscriber()
-                # Rebase so the resumed timeout window starts now —
-                # otherwise every device idle longer than the timeout
-                # mass-flips OFFLINE before it can answer the first
-                # post-resume broadcast.
-                self._rebase_last_seen()
-            broadcast_sent = self.is_publisher and await self._broadcast(client)
-            self._wake.clear()
-            with contextlib.suppress(TimeoutError):
-                await asyncio.wait_for(self._wake.wait(), timeout=_PING_INTERVAL)
-            if not broadcast_sent:
-                continue
-            now = loop.time()
-            stale = [
-                name for name, last in self._last_seen.items() if now - last > _OFFLINE_TIMEOUT
-            ]
-            for name in stale:
-                self._on_state_change(name, DeviceState.OFFLINE)
-                self._last_seen.pop(name, None)
+        """Run one broker session's discover loop — see :class:`_DiscoverPingLoop`."""
+        await self._ping.run_session(client)
 
     async def _broadcast(self, client: PublishClient) -> bool:
         """
@@ -561,6 +520,61 @@ class DeviceMqttMonitor:
 # ---------------------------------------------------------------------------
 # Internals
 # ---------------------------------------------------------------------------
+
+
+class _DiscoverPingLoop(PresenceGatedLoop):
+    """
+    Broadcast discover requests and sweep stale devices offline.
+
+    Every MQTT device answers each ``esphome/discover`` publish, so
+    broadcasts run only while a dashboard client is subscribed, and
+    only from the elected broadcaster. While idle the loop parks
+    with the offline aging frozen — silence without polls is not
+    evidence — and spontaneous announcements keep flowing through
+    ``_listen``. Aging belongs to the broadcaster for the same
+    reason: a silent sibling must not judge a fleet nobody is
+    polling, and a tick whose own broadcast failed to send judges
+    nobody either.
+    """
+
+    _label = "MQTT discover ping"
+    # An unexpected crash must tear down the broker session so
+    # ``_run``'s reconnect taxonomy handles it; publish failures are
+    # already soft (``_broadcast`` returns False and pauses aging).
+    _continue_on_error = False
+
+    def __init__(self, monitor: DeviceMqttMonitor, presence: SubscriberPresence | None) -> None:
+        super().__init__(presence)
+        self._monitor = monitor
+        self._client: PublishClient | None = None
+        self._broadcast_sent = False
+
+    async def run_session(self, client: PublishClient) -> None:
+        """Run this loop for one broker session's *client*."""
+        self._client = client
+        self._interval = _PING_INTERVAL
+        await self.run()
+
+    def _on_resume(self) -> None:
+        # Rebase so the resumed timeout window starts now — otherwise
+        # every device idle longer than the timeout mass-flips OFFLINE
+        # before it can answer the first post-resume broadcast.
+        self._monitor._rebase_last_seen()
+
+    async def _work(self) -> None:
+        assert self._client is not None  # bound in run_session
+        monitor = self._monitor
+        self._broadcast_sent = monitor.is_publisher and await monitor._broadcast(self._client)
+
+    def _after_idle(self) -> None:
+        if not self._broadcast_sent:
+            return
+        monitor = self._monitor
+        now = asyncio.get_running_loop().time()
+        stale = [name for name, last in monitor._last_seen.items() if now - last > _OFFLINE_TIMEOUT]
+        for name in stale:
+            monitor._on_state_change(name, DeviceState.OFFLINE)
+            monitor._last_seen.pop(name, None)
 
 
 def _unwrap_session_error(eg: BaseExceptionGroup) -> BaseException:

--- a/esphome_device_builder/controllers/_device_mqtt_monitor.py
+++ b/esphome_device_builder/controllers/_device_mqtt_monitor.py
@@ -531,7 +531,7 @@ class DeviceMqttMonitor:
 # ---------------------------------------------------------------------------
 
 
-class _DiscoverPingLoop(PresenceGatedLoop):
+class _DiscoverPingLoop(PresenceGatedLoop[bool]):
     """
     Broadcast discover requests and sweep stale devices offline.
 
@@ -556,7 +556,6 @@ class _DiscoverPingLoop(PresenceGatedLoop):
         super().__init__(presence)
         self._monitor = monitor
         self._client: PublishClient | None = None
-        self._broadcast_sent = False
 
     @property
     def _interval(self) -> float:  # type: ignore[override]
@@ -575,14 +574,13 @@ class _DiscoverPingLoop(PresenceGatedLoop):
         # before it can answer the first post-resume broadcast.
         self._monitor._rebase_last_seen()
 
-    async def _work(self) -> None:
+    async def _work(self) -> bool:
         assert self._client is not None  # bound in run_session
         monitor = self._monitor
-        self._broadcast_sent = monitor.is_publisher and await monitor._broadcast(self._client)
+        return monitor.is_publisher and await monitor._broadcast(self._client)
 
-    async def _idle(self) -> None:
-        await super()._idle()
-        if self._broadcast_sent:
+    def _after_idle(self, broadcast_sent: bool) -> None:  # noqa: FBT001 — hook signature
+        if broadcast_sent:
             self._monitor._sweep_stale()
 
 

--- a/esphome_device_builder/controllers/_device_mqtt_monitor.py
+++ b/esphome_device_builder/controllers/_device_mqtt_monitor.py
@@ -512,10 +512,11 @@ class DeviceMqttMonitor:
     def _sweep_stale(self) -> None:
         """Flip entries silent past ``_OFFLINE_TIMEOUT`` to OFFLINE."""
         now = asyncio.get_running_loop().time()
-        stale = [name for name, last in self._last_seen.items() if now - last > _OFFLINE_TIMEOUT]
-        for name in stale:
+        last_seen = self._last_seen
+        # Materialized so the pop below can't mutate the dict mid-iteration.
+        for name in [n for n, last in last_seen.items() if now - last > _OFFLINE_TIMEOUT]:
             self._on_state_change(name, DeviceState.OFFLINE)
-            self._last_seen.pop(name, None)
+            last_seen.pop(name, None)
 
     def _set_connected(self, *, value: bool) -> None:
         if self.connected == value:

--- a/esphome_device_builder/controllers/_device_state_monitor/_sweep_source.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/_sweep_source.py
@@ -1,69 +1,24 @@
-"""Presence-gated fixed-interval sweep-loop base for the monitor's sources."""
+"""Monitor-bound adapter over the shared presence-gated loop."""
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
-import logging
 from typing import TYPE_CHECKING
+
+from ...helpers.presence_gated_loop import PresenceGatedLoop
 
 if TYPE_CHECKING:
     from .controller import DeviceStateMonitor
 
-_LOGGER = logging.getLogger(__name__)
 
-
-class SweepSource:
+class SweepSource(PresenceGatedLoop):
     """Presence-gated fixed-interval sweep loop; subclasses supply ``_sweep``."""
 
-    # Names the source in the crash-continue log line.
-    _sweep_label: str
-    # Head start for the other sources (e.g. the mDNS browser) so the
-    # common case never reaches this source's heavier work.
-    _bootstrap_delay: float
-    # Seconds between sweeps.
-    _interval: float = 60
-
     def __init__(self, monitor: DeviceStateMonitor) -> None:
+        super().__init__(monitor._presence)
         self._monitor = monitor
-        # Cleared at the top of each iteration so a wake fired
-        # mid-sweep still triggers the next idle. The presence 0→1
-        # transition is multiplexed into the same event so a
-        # subscriber arriving mid-idle doesn't wait out the interval.
-        self._wake = asyncio.Event()
-        if monitor._presence is not None:
-            monitor._presence.add_subscriber_callback(self._wake.set)
 
-    def wake(self) -> None:
-        """Bail the idle wait so the next sweep runs without waiting out the interval."""
-        self._wake.set()
-
-    async def run(self) -> None:
-        await asyncio.sleep(self._bootstrap_delay)
-        if not await self._prepare():
-            return
-        monitor = self._monitor
-        # Strict pause when wired to a SubscriberPresence gate: only
-        # sweep while at least one dashboard client is subscribed.
-        while True:
-            if monitor._presence is not None:
-                await monitor._presence.wait_for_subscriber()
-            self._wake.clear()
-            try:
-                await self._sweep()
-            except Exception:
-                # A sweep failure must not kill the loop for the
-                # process lifetime; log it and try again next interval.
-                _LOGGER.exception("%s sweep failed; continuing", self._sweep_label)
-            await self._idle()
-
-    async def _prepare(self) -> bool:
-        """One-shot gate after the bootstrap sleep; False disables the source."""
-        return True
+    async def _work(self) -> None:
+        await self._sweep()
 
     async def _sweep(self) -> None:
         raise NotImplementedError
-
-    async def _idle(self) -> None:
-        with contextlib.suppress(TimeoutError):
-            await asyncio.wait_for(self._wake.wait(), timeout=self._interval)

--- a/esphome_device_builder/controllers/_device_state_monitor/_sweep_source.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/_sweep_source.py
@@ -14,7 +14,7 @@ class SweepSource(PresenceGatedLoop):
     """Presence-gated fixed-interval sweep loop; subclasses supply ``_sweep``."""
 
     def __init__(self, monitor: DeviceStateMonitor) -> None:
-        super().__init__(monitor._presence)
+        super().__init__(monitor.presence)
         self._monitor = monitor
 
     async def _work(self) -> None:

--- a/esphome_device_builder/controllers/_device_state_monitor/_sweep_source.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/_sweep_source.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from .controller import DeviceStateMonitor
 
 
-class SweepSource(PresenceGatedLoop):
+class SweepSource(PresenceGatedLoop[None]):
     """Presence-gated fixed-interval sweep loop; subclasses supply ``_sweep``."""
 
     def __init__(self, monitor: DeviceStateMonitor) -> None:

--- a/esphome_device_builder/controllers/_device_state_monitor/api_info.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/api_info.py
@@ -56,7 +56,7 @@ _SYSTEMIC_FAILURE_WARN_THRESHOLD = 10
 class ApiInfoSource(ApiSweepSource):
     """Fill mac/version via the Native API when mDNS hasn't supplied them."""
 
-    _sweep_label = "API info"
+    _label = "API info sweep"
     # Give mDNS a head start so devices that announce normally fill
     # mac/version for free and never trigger a connection.
     _bootstrap_delay = 15

--- a/esphome_device_builder/controllers/_device_state_monitor/api_reviver.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/api_reviver.py
@@ -82,7 +82,7 @@ _VERIFIED_TTL = 21600.0  # seconds
 class ApiReviverSource(ApiSweepSource):
     """Identity-verified last-resort ONLINE revival from the persisted IP."""
 
-    _sweep_label = "API reviver"
+    _label = "API reviver sweep"
     # After ping's 10s bootstrap plus its privilege probe and first
     # sweep, so ``icmp_available`` is decided and the DNS-failure cache
     # the cohort gate reads is populated.

--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -205,7 +205,7 @@ class DeviceStateMonitor(TaskControllerBase):
         # dashboard, which paused ICMP on an empty subscriber set.
         # ``None`` means "always run the loop" so existing tests
         # without a presence gate keep working.
-        self._presence = presence
+        self.presence = presence
         self.importable = ImportableDiscovery(self)
         # One Native API worker dial at a time across every API source
         # (api_info + reviver): each dial spawns an interpreter and

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -50,7 +50,7 @@ async def _can_use_icmp_lib_with_privilege() -> bool | None:
 class PingSource(SweepSource):
     """ICMP ping sweep: mDNS pre-resolve, target selection, and the ping pass."""
 
-    _sweep_label = "ICMP ping"
+    _label = "ICMP ping sweep"
     # The mDNS browser's head start so the common case (everything
     # announces) skips a redundant ping the browser would have flipped
     # ONLINE for free. 10s mirrors the upstream dashboard's

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -51,6 +51,7 @@ from .helpers.event_bus import Event, EventBus, StreamControls, stream_events
 from .helpers.json import cors_middleware, json_response
 from .helpers.network_interfaces import ensure_single_host_for_ephemeral_port, resolve_bind_host
 from .helpers.peer_link_identity import PeerLinkIdentityStore
+from .helpers.presence_gated_loop import PresenceGatedLoop
 from .helpers.secrets_state import write_secrets_locked
 from .helpers.startup_timing import StartupTimer
 from .helpers.subscriber_presence import SubscriberPresence
@@ -58,7 +59,7 @@ from .models import EventType
 
 _LOGGER = logging.getLogger(__name__)
 
-# How often ``_run_background`` re-runs ``DevicesController.poll``
+# How often ``_BackgroundPollLoop`` re-runs ``DevicesController.poll``
 # while at least one WS client is subscribed. Bounded above by how
 # stale a "user dropped a YAML in via SSH" change is allowed to look
 # in the dashboard's device list; bounded below by the cost of the
@@ -473,7 +474,7 @@ class DeviceBuilder:
             self.command_handlers["auth"] = self.command_handlers["auth/login"]
 
         # Start background polling
-        self._bg_task = create_eager_task(self._run_background())
+        self._bg_task = create_eager_task(_BackgroundPollLoop(self).run())
 
         _LOGGER.info(
             "Device Builder ready — config dir: %s, %d commands registered",
@@ -573,40 +574,6 @@ class DeviceBuilder:
                 # safe and avoids the "what loop runs to_thread"
                 # question entirely.
                 executor.shutdown(wait=False)
-
-    async def _run_background(self) -> None:
-        """Background polling loop.
-
-        Drives ``DevicesController.poll`` for filesystem drift the
-        push paths can't see (YAML file dropped in via SSH /
-        Samba, atomic-save mid-edit, sidecar mtime change). Gated
-        on ``SubscriberPresence`` — when no WS client is
-        subscribed, no UI is showing the device list, so paying
-        for a directory enumeration + per-file stat every 5 s is
-        idle CPU we can skip. The 0→1 subscriber transition
-        wakes ``wait_for_subscriber`` immediately, so the first
-        client to connect picks up freshly-dropped YAMLs within
-        one ``_BACKGROUND_POLL_INTERVAL_SECONDS`` instead of
-        having to wait for the next scheduled tick — same shape
-        ``_ping_loop`` uses for the ICMP sweep.
-        """
-        presence = self.subscriber_presence
-        while True:
-            await presence.wait_for_subscriber()
-            if self.devices:
-                await self.devices.poll()
-            # Interruptible idle wait: bail early if the last
-            # subscriber leaves so the next one to connect doesn't
-            # sit through the rest of a stale interval. The
-            # ``TimeoutError`` branch is the steady-state "still
-            # subscribed, poll again" path; either way we loop
-            # back to ``wait_for_subscriber`` which parks if the
-            # gate has since closed.
-            with contextlib.suppress(asyncio.TimeoutError):
-                await asyncio.wait_for(
-                    presence.wait_for_no_subscribers(),
-                    timeout=_BACKGROUND_POLL_INTERVAL_SECONDS,
-                )
 
     @staticmethod
     async def _cmd_ping(**kwargs: Any) -> dict:
@@ -1180,3 +1147,27 @@ class DeviceBuilder:
         app.router.add_get("/{tail:.*}", handle_spa)
 
         _LOGGER.info("Serving frontend from %s (dev_mode=%s)", frontend_dir, dev_mode)
+
+
+class _BackgroundPollLoop(PresenceGatedLoop):
+    """
+    Poll ``DevicesController`` for filesystem drift the push paths can't see.
+
+    YAML dropped in via SSH / Samba, atomic-save mid-edit, sidecar
+    mtime changes. Gated on presence — with no WS client subscribed,
+    no UI is showing the device list, so the directory enumeration +
+    per-file stat every tick is idle CPU we can skip; the 0→1 wake
+    means the first client to connect picks up freshly-dropped YAMLs
+    within one interval.
+    """
+
+    _label = "Background device poll"
+    _interval = _BACKGROUND_POLL_INTERVAL_SECONDS
+
+    def __init__(self, builder: DeviceBuilder) -> None:
+        super().__init__(builder.subscriber_presence)
+        self._builder = builder
+
+    async def _work(self) -> None:
+        if self._builder.devices:
+            await self._builder.devices.poll()

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -1149,7 +1149,7 @@ class DeviceBuilder:
         _LOGGER.info("Serving frontend from %s (dev_mode=%s)", frontend_dir, dev_mode)
 
 
-class _BackgroundPollLoop(PresenceGatedLoop):
+class _BackgroundPollLoop(PresenceGatedLoop[None]):
     """
     Poll ``DevicesController`` for filesystem drift the push paths can't see.
 

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -266,6 +266,7 @@ class DeviceBuilder:
         # Background tasks
         self._background_tasks: set[asyncio.Task] = set()
         self._bg_task: asyncio.Task | None = None
+        self._bg_poll: _BackgroundPollLoop | None = None
 
         # Latches the one-time network teardown so it can run early (in the
         # aiohttp ``on_shutdown`` hook) and stop() doesn't repeat it.
@@ -474,7 +475,8 @@ class DeviceBuilder:
             self.command_handlers["auth"] = self.command_handlers["auth/login"]
 
         # Start background polling
-        self._bg_task = create_eager_task(_BackgroundPollLoop(self).run())
+        self._bg_poll = _BackgroundPollLoop(self)
+        self._bg_task = create_eager_task(self._bg_poll.run())
 
         _LOGGER.info(
             "Device Builder ready — config dir: %s, %d commands registered",
@@ -509,6 +511,8 @@ class DeviceBuilder:
             return
         if self._bg_task:
             await drain_tasks((self._bg_task,), log_exceptions=True)
+        if self._bg_poll is not None:
+            self._bg_poll.unsubscribe()
         await drain_tasks(self._background_tasks)
         # Tear down the remote-build listener (if it was bound)
         # before the controller it depends on. Order matters less

--- a/esphome_device_builder/helpers/presence_gated_loop.py
+++ b/esphome_device_builder/helpers/presence_gated_loop.py
@@ -30,7 +30,10 @@ class PresenceGatedLoop:
     _interval: float = 60
     # True logs a crashing ``_work`` and keeps looping (process-lifetime
     # loops); False propagates so the owning supervisor tears down
-    # (per-session loops).
+    # (per-session loops). Under True, ``_idle`` after a crashed
+    # ``_work`` still sees the prior tick's instance state — an
+    # ``_idle`` override reading per-tick state written by ``_work``
+    # is safe only under False.
     _continue_on_error: bool = True
 
     def __init__(self, presence: SubscriberPresence | None) -> None:

--- a/esphome_device_builder/helpers/presence_gated_loop.py
+++ b/esphome_device_builder/helpers/presence_gated_loop.py
@@ -14,12 +14,13 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class PresenceGatedLoop:
+class PresenceGatedLoop[WorkT]:
     """
     Presence-gated fixed-interval loop; subclasses supply ``_work``.
 
     Tick anatomy: gate → resume hook (real park only) → wake-clear →
-    work → idle.
+    work → idle → after-idle hook with that tick's ``_work`` result
+    (skipped when ``_work`` crashed, so the hook never sees stale state).
     """
 
     # Names the loop in the crash-continue log line.
@@ -66,14 +67,17 @@ class PresenceGatedLoop:
                 self._on_resume()
             self._wake.clear()
             try:
-                await self._work()
+                result = await self._work()
             except Exception:
                 if not self._continue_on_error:
                     raise
                 # A failure must not kill the loop for the process
                 # lifetime; log it and try again next interval.
                 _LOGGER.exception("%s failed; continuing", self._label)
+                await self._idle()
+                continue
             await self._idle()
+            self._after_idle(result)
 
     async def _prepare(self) -> bool:
         """One-shot gate after the bootstrap sleep; False disables the loop."""
@@ -82,16 +86,12 @@ class PresenceGatedLoop:
     def _on_resume(self) -> None:
         """Run when a real park ends (presence 0→1 while this loop waited)."""
 
-    async def _work(self) -> None:
+    async def _work(self) -> WorkT:
         raise NotImplementedError
 
     async def _idle(self) -> None:
-        """
-        Wait out the interval, or bail early on a wake.
-
-        An override reading per-tick state written by ``_work`` is safe
-        only under ``_continue_on_error = False`` — a logged-and-continued
-        crash reaches idle with the prior tick's state.
-        """
         with contextlib.suppress(TimeoutError):
             await asyncio.wait_for(self._wake.wait(), timeout=self._interval)
+
+    def _after_idle(self, result: WorkT) -> None:
+        """Run after each completed tick's idle with that tick's ``_work`` result."""

--- a/esphome_device_builder/helpers/presence_gated_loop.py
+++ b/esphome_device_builder/helpers/presence_gated_loop.py
@@ -30,10 +30,7 @@ class PresenceGatedLoop:
     _interval: float = 60
     # True logs a crashing ``_work`` and keeps looping (process-lifetime
     # loops); False propagates so the owning supervisor tears down
-    # (per-session loops). Under True, ``_idle`` after a crashed
-    # ``_work`` still sees the prior tick's instance state — an
-    # ``_idle`` override reading per-tick state written by ``_work``
-    # is safe only under False.
+    # (per-session loops).
     _continue_on_error: bool = True
 
     def __init__(self, presence: SubscriberPresence | None) -> None:
@@ -89,5 +86,12 @@ class PresenceGatedLoop:
         raise NotImplementedError
 
     async def _idle(self) -> None:
+        """
+        Wait out the interval, or bail early on a wake.
+
+        An override reading per-tick state written by ``_work`` is safe
+        only under ``_continue_on_error = False`` — a logged-and-continued
+        crash reaches idle with the prior tick's state.
+        """
         with contextlib.suppress(TimeoutError):
             await asyncio.wait_for(self._wake.wait(), timeout=self._interval)

--- a/esphome_device_builder/helpers/presence_gated_loop.py
+++ b/esphome_device_builder/helpers/presence_gated_loop.py
@@ -19,7 +19,7 @@ class PresenceGatedLoop:
     Presence-gated fixed-interval loop; subclasses supply ``_work``.
 
     Tick anatomy: gate → resume hook (real park only) → wake-clear →
-    work → idle → after-idle hook.
+    work → idle.
     """
 
     # Names the loop in the crash-continue log line.
@@ -74,7 +74,6 @@ class PresenceGatedLoop:
                 # lifetime; log it and try again next interval.
                 _LOGGER.exception("%s failed; continuing", self._label)
             await self._idle()
-            self._after_idle()
 
     async def _prepare(self) -> bool:
         """One-shot gate after the bootstrap sleep; False disables the loop."""
@@ -89,6 +88,3 @@ class PresenceGatedLoop:
     async def _idle(self) -> None:
         with contextlib.suppress(TimeoutError):
             await asyncio.wait_for(self._wake.wait(), timeout=self._interval)
-
-    def _after_idle(self) -> None:
-        """Run after each idle — work that judges the elapsed interval."""

--- a/esphome_device_builder/helpers/presence_gated_loop.py
+++ b/esphome_device_builder/helpers/presence_gated_loop.py
@@ -1,0 +1,94 @@
+"""Presence-gated periodic loop: park while no dashboard client is subscribed."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .subscriber_presence import SubscriberPresence
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class PresenceGatedLoop:
+    """
+    Presence-gated fixed-interval loop; subclasses supply ``_work``.
+
+    Tick anatomy: gate → resume hook (real park only) → wake-clear →
+    work → idle → after-idle hook.
+    """
+
+    # Names the loop in the crash-continue log line.
+    _label: str
+    # Head start before the first tick.
+    _bootstrap_delay: float = 0
+    # Seconds between ticks.
+    _interval: float = 60
+    # True logs a crashing ``_work`` and keeps looping (process-lifetime
+    # loops); False propagates so the owning supervisor tears down
+    # (per-session loops).
+    _continue_on_error: bool = True
+
+    def __init__(self, presence: SubscriberPresence | None) -> None:
+        self._presence = presence
+        # Cleared at the top of each iteration so a wake fired
+        # mid-work still triggers the next idle. The presence 0→1
+        # transition is multiplexed into the same event so a
+        # subscriber arriving mid-idle doesn't wait out the interval.
+        self._wake = asyncio.Event()
+        self._unsub_wake: Callable[[], None] | None = None
+        if presence is not None:
+            self._unsub_wake = presence.add_subscriber_callback(self._wake.set)
+
+    def wake(self) -> None:
+        """Bail the idle wait so the next tick runs without waiting out the interval."""
+        self._wake.set()
+
+    def unsubscribe(self) -> None:
+        """Detach the presence wake callback (owners shorter-lived than the gate)."""
+        if self._unsub_wake is not None:
+            self._unsub_wake()
+            self._unsub_wake = None
+
+    async def run(self) -> None:
+        await asyncio.sleep(self._bootstrap_delay)
+        if not await self._prepare():
+            return
+        # Strict pause when wired to a SubscriberPresence gate: only
+        # work while at least one dashboard client is subscribed.
+        while True:
+            if self._presence is not None and not self._presence.has_subscribers():
+                await self._presence.wait_for_subscriber()
+                self._on_resume()
+            self._wake.clear()
+            try:
+                await self._work()
+            except Exception:
+                if not self._continue_on_error:
+                    raise
+                # A failure must not kill the loop for the process
+                # lifetime; log it and try again next interval.
+                _LOGGER.exception("%s failed; continuing", self._label)
+            await self._idle()
+            self._after_idle()
+
+    async def _prepare(self) -> bool:
+        """One-shot gate after the bootstrap sleep; False disables the loop."""
+        return True
+
+    def _on_resume(self) -> None:
+        """Run when a real park ends (presence 0→1 while this loop waited)."""
+
+    async def _work(self) -> None:
+        raise NotImplementedError
+
+    async def _idle(self) -> None:
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(self._wake.wait(), timeout=self._interval)
+
+    def _after_idle(self) -> None:
+        """Run after each idle — work that judges the elapsed interval."""

--- a/esphome_device_builder/helpers/presence_gated_loop.py
+++ b/esphome_device_builder/helpers/presence_gated_loop.py
@@ -41,6 +41,7 @@ class PresenceGatedLoop[WorkT]:
         # transition is multiplexed into the same event so a
         # subscriber arriving mid-idle doesn't wait out the interval.
         self._wake = asyncio.Event()
+        self._running = False
         self._unsub_wake: Callable[[], None] | None = None
         if presence is not None:
             self._unsub_wake = presence.add_subscriber_callback(self._wake.set)
@@ -56,28 +57,37 @@ class PresenceGatedLoop[WorkT]:
             self._unsub_wake = None
 
     async def run(self) -> None:
-        await asyncio.sleep(self._bootstrap_delay)
-        if not await self._prepare():
-            return
-        # Strict pause when wired to a SubscriberPresence gate: only
-        # work while at least one dashboard client is subscribed.
-        while True:
-            if self._presence is not None and not self._presence.has_subscribers():
-                await self._presence.wait_for_subscriber()
-                self._on_resume()
-            self._wake.clear()
-            try:
-                result = await self._work()
-            except Exception:
-                if not self._continue_on_error:
-                    raise
-                # A failure must not kill the loop for the process
-                # lifetime; log it and try again next interval.
-                _LOGGER.exception("%s failed; continuing", self._label)
+        # Sequential re-runs are fine (the MQTT loop re-runs per broker
+        # session); a concurrent second run would silently double-tick.
+        if self._running:
+            msg = f"{type(self).__name__} is already running"
+            raise RuntimeError(msg)
+        self._running = True
+        try:
+            await asyncio.sleep(self._bootstrap_delay)
+            if not await self._prepare():
+                return
+            # Strict pause when wired to a SubscriberPresence gate: only
+            # work while at least one dashboard client is subscribed.
+            while True:
+                if self._presence is not None and not self._presence.has_subscribers():
+                    await self._presence.wait_for_subscriber()
+                    self._on_resume()
+                self._wake.clear()
+                try:
+                    result = await self._work()
+                except Exception:
+                    if not self._continue_on_error:
+                        raise
+                    # A failure must not kill the loop for the process
+                    # lifetime; log it and try again next interval.
+                    _LOGGER.exception("%s failed; continuing", self._label)
+                    await self._idle()
+                    continue
                 await self._idle()
-                continue
-            await self._idle()
-            self._after_idle(result)
+                self._after_idle(result)
+        finally:
+            self._running = False
 
     async def _prepare(self) -> bool:
         """One-shot gate after the bootstrap sleep; False disables the loop."""

--- a/esphome_device_builder/helpers/presence_gated_loop.py
+++ b/esphome_device_builder/helpers/presence_gated_loop.py
@@ -42,6 +42,7 @@ class PresenceGatedLoop[WorkT]:
         # subscriber arriving mid-idle doesn't wait out the interval.
         self._wake = asyncio.Event()
         self._running = False
+        self._error_logged = False
         self._unsub_wake: Callable[[], None] | None = None
         if presence is not None:
             self._unsub_wake = presence.add_subscriber_callback(self._wake.set)
@@ -80,10 +81,17 @@ class PresenceGatedLoop[WorkT]:
                     if not self._continue_on_error:
                         raise
                     # A failure must not kill the loop for the process
-                    # lifetime; log it and try again next interval.
-                    _LOGGER.exception("%s failed; continuing", self._label)
+                    # lifetime. Traceback once per failure streak, DEBUG
+                    # on repeats — re-armed by the next successful tick —
+                    # so a short interval can't flood the log.
+                    if self._error_logged:
+                        _LOGGER.debug("%s still failing; continuing", self._label, exc_info=True)
+                    else:
+                        _LOGGER.exception("%s failed; continuing", self._label)
+                        self._error_logged = True
                     await self._idle()
                     continue
+                self._error_logged = False
                 await self._idle()
                 self._after_idle(result)
         finally:

--- a/esphome_device_builder/helpers/subscriber_presence.py
+++ b/esphome_device_builder/helpers/subscriber_presence.py
@@ -41,11 +41,7 @@ class SubscriberPresence:
 
     def __init__(self) -> None:
         self._count = 0
-        # Both events kept in lockstep with the count so consumers
-        # can ``await`` either transition.
         self._has_subscriber = asyncio.Event()
-        self._no_subscribers = asyncio.Event()
-        self._no_subscribers.set()  # initial state: gate is closed
         self._subscriber_callbacks: list[Callable[[], None]] = []
 
     def has_subscribers(self) -> bool:
@@ -76,27 +72,19 @@ class SubscriberPresence:
         self._subscriber_callbacks.append(callback)
         return lambda: self._subscriber_callbacks.remove(callback)
 
-    async def wait_for_no_subscribers(self) -> None:
-        """Suspend until the count drops to 0 (mirror of :meth:`wait_for_subscriber`)."""
-        await self._no_subscribers.wait()
-
     @contextmanager
     def subscriber(self) -> Iterator[None]:
         """
         Context manager that increments the count for its body.
 
-        The 0→1 transition sets ``_has_subscriber`` and clears
-        ``_no_subscribers`` so any awaiter on
-        :meth:`wait_for_subscriber` resumes; the 1→0 transition
-        does the inverse and wakes any awaiter on
-        :meth:`wait_for_no_subscribers`. The count is decremented
-        in ``finally`` so the gate closes even if the wrapped
-        body raises.
+        The 0→1 transition sets ``_has_subscriber`` so any awaiter
+        on :meth:`wait_for_subscriber` resumes; the 1→0 transition
+        re-arms the gate. The count is decremented in ``finally``
+        so the gate closes even if the wrapped body raises.
         """
         self._count += 1
         if self._count == 1:
             self._has_subscriber.set()
-            self._no_subscribers.clear()
             for callback in self._subscriber_callbacks:
                 # Isolate so a misbehaving consumer can't break
                 # presence accounting or skip sibling callbacks.
@@ -110,4 +98,3 @@ class SubscriberPresence:
             self._count -= 1
             if self._count == 0:
                 self._has_subscriber.clear()
-                self._no_subscribers.set()

--- a/tests/test_api_info_fallback.py
+++ b/tests/test_api_info_fallback.py
@@ -556,6 +556,9 @@ class _FakePresence:
     def add_subscriber_callback(self, callback: Any) -> None:
         self.callbacks.append(callback)
 
+    def has_subscribers(self) -> bool:
+        return False
+
     async def wait_for_subscriber(self) -> None:
         return None
 

--- a/tests/test_api_info_fallback.py
+++ b/tests/test_api_info_fallback.py
@@ -553,8 +553,9 @@ class _FakePresence:
     def __init__(self) -> None:
         self.callbacks: list[Any] = []
 
-    def add_subscriber_callback(self, callback: Any) -> None:
+    def add_subscriber_callback(self, callback: Any) -> Any:
         self.callbacks.append(callback)
+        return lambda: self.callbacks.remove(callback)
 
     def has_subscribers(self) -> bool:
         return False

--- a/tests/test_device_builder_lifecycle.py
+++ b/tests/test_device_builder_lifecycle.py
@@ -246,6 +246,21 @@ async def test_background_poll_skips_when_no_subscribers(
         await db.stop()
 
 
+async def test_stop_detaches_background_poll_wake_callback(
+    make_settings: MakeSettingsFactory, _hermetic_lifecycle: None
+) -> None:
+    """stop() removes the poll loop's wake callback so restarts can't accumulate them."""
+    db = DeviceBuilder(make_settings(with_core_path=True))
+    try:
+        await db.start()
+        assert db._bg_poll is not None
+        wake = db._bg_poll._wake.set
+        assert wake in db.subscriber_presence._subscriber_callbacks
+    finally:
+        await db.stop()
+    assert wake not in db.subscriber_presence._subscriber_callbacks
+
+
 # ---------------------------------------------------------------------------
 # stop()
 # ---------------------------------------------------------------------------

--- a/tests/test_mdns_http_txt.py
+++ b/tests/test_mdns_http_txt.py
@@ -30,7 +30,7 @@ def _make_monitor(*devices: Device) -> DeviceStateMonitor:
     monitor.state = MonitorState()
     monitor.importable = ImportableDiscovery(monitor)
     monitor.mdns = MdnsSource(monitor)
-    monitor._presence = None
+    monitor.presence = None
     monitor.ping = PingSource(monitor)
     monitor.mdns._zeroconf = MagicMock()
     monitor.mdns._zeroconf.zeroconf = MagicMock()

--- a/tests/test_ping_loop_pause.py
+++ b/tests/test_ping_loop_pause.py
@@ -39,7 +39,7 @@ def _build_monitor(presence: SubscriberPresence | None) -> DeviceStateMonitor:
     """Bypass __init__ — ``PingSource.run`` only touches a few attrs."""
     monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
     monitor.state = MonitorState()
-    monitor._presence = presence
+    monitor.presence = presence
     monitor.ping = PingSource(monitor)
     return monitor
 

--- a/tests/test_presence_gated_loop.py
+++ b/tests/test_presence_gated_loop.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
 from collections.abc import AsyncIterator
 
 import pytest
@@ -123,6 +124,26 @@ async def test_continue_on_error_logs_and_keeps_looping(
     async with _running(loop):
         await loop.wait_for_ticks(2)
     assert "test loop failed; continuing" in caplog.text
+
+
+async def test_crash_continue_collapses_repeat_logs_until_recovery(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failure streak logs one traceback; a successful tick re-arms the loud log."""
+    loop = _RecordingLoop(None)
+    loop.work_error = RuntimeError("boom")
+    with caplog.at_level(logging.DEBUG):
+        async with _running(loop):
+            await loop.wait_for_ticks(2)
+            loop.work_error = None
+            await loop.wait_for_ticks(3)
+            loop.work_error = RuntimeError("boom again")
+            await loop.wait_for_ticks(4)
+    messages = [(r.levelno, r.message) for r in caplog.records if "continuing" in r.message]
+    errors = [m for level, m in messages if level == logging.ERROR]
+    debugs = [m for level, m in messages if level == logging.DEBUG]
+    assert len(errors) == 2
+    assert debugs, "repeat failure in a streak must collapse to DEBUG"
 
 
 async def test_propagate_on_error_kills_the_loop() -> None:

--- a/tests/test_presence_gated_loop.py
+++ b/tests/test_presence_gated_loop.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator
 
 import pytest
 
@@ -20,19 +20,24 @@ class _RecordingLoop(PresenceGatedLoop):
         super().__init__(presence)
         self.ticks = 0
         self.resumes = 0
-        self.after_idles = 0
         self.work_error: BaseException | None = None
+        self._ticked = asyncio.Event()
+
+    async def wait_for_ticks(self, n: int) -> None:
+        """Park until ``_work`` has run *n* times (event-driven, no polling)."""
+        async with asyncio.timeout(1):
+            while self.ticks < n:
+                await self._ticked.wait()
+                self._ticked.clear()
 
     def _on_resume(self) -> None:
         self.resumes += 1
 
     async def _work(self) -> None:
         self.ticks += 1
+        self._ticked.set()
         if self.work_error is not None:
             raise self.work_error
-
-    def _after_idle(self) -> None:
-        self.after_idles += 1
 
 
 @contextlib.asynccontextmanager
@@ -46,25 +51,11 @@ async def _running(loop: PresenceGatedLoop) -> AsyncIterator[asyncio.Task[None]]
             await task
 
 
-async def _wait_for(predicate: Callable[[], bool], timeout: float = 1.0) -> None:
-    async with asyncio.timeout(timeout):
-        while not predicate():
-            await asyncio.sleep(0.001)
-
-
-async def test_base_contract() -> None:
-    """The base runs unconditionally by default and demands a ``_work``."""
-    base = PresenceGatedLoop(None)
-    assert await base._prepare() is True
-    with pytest.raises(NotImplementedError):
-        await base._work()
-
-
 async def test_runs_unconditionally_without_presence() -> None:
     """presence=None means no gate: ticks flow with no subscriber anywhere."""
     loop = _RecordingLoop(None)
     async with _running(loop):
-        await _wait_for(lambda: loop.ticks >= 2)
+        await loop.wait_for_ticks(2)
     assert loop.resumes == 0
 
 
@@ -73,10 +64,11 @@ async def test_parks_until_first_subscriber_then_resumes() -> None:
     presence = SubscriberPresence()
     loop = _RecordingLoop(presence)
     async with _running(loop):
-        await asyncio.sleep(0.05)
+        for _ in range(10):
+            await asyncio.sleep(0)
         assert loop.ticks == 0
         with presence.subscriber():
-            await _wait_for(lambda: loop.ticks >= 1)
+            await loop.wait_for_ticks(1)
         assert loop.resumes == 1
 
 
@@ -86,7 +78,7 @@ async def test_no_resume_hook_when_gate_already_open() -> None:
     loop = _RecordingLoop(presence)
     with presence.subscriber():
         async with _running(loop):
-            await _wait_for(lambda: loop.ticks >= 3)
+            await loop.wait_for_ticks(3)
     assert loop.resumes == 0
 
 
@@ -97,28 +89,24 @@ async def test_subscriber_return_cuts_idle_short() -> None:
     loop._interval = 60
     async with _running(loop):
         with presence.subscriber():
-            await _wait_for(lambda: loop.ticks == 1)
+            await loop.wait_for_ticks(1)
         with presence.subscriber():
-            await _wait_for(lambda: loop.ticks >= 2)
+            await loop.wait_for_ticks(2)
 
 
 async def test_wake_mid_work_short_circuits_following_idle() -> None:
     """A wake fired during ``_work`` survives the pre-work clear."""
-    ticks = 0
 
-    class _SelfWaking(PresenceGatedLoop):
-        _label = "self-waking"
-        _interval = 60
-
+    class _SelfWaking(_RecordingLoop):
         async def _work(self) -> None:
-            nonlocal ticks
-            ticks += 1
-            if ticks == 1:
+            await super()._work()
+            if self.ticks == 1:
                 self.wake()
 
     loop = _SelfWaking(None)
+    loop._interval = 60
     async with _running(loop):
-        await _wait_for(lambda: ticks >= 2)
+        await loop.wait_for_ticks(2)
 
 
 async def test_continue_on_error_logs_and_keeps_looping(
@@ -127,7 +115,7 @@ async def test_continue_on_error_logs_and_keeps_looping(
     loop = _RecordingLoop(None)
     loop.work_error = RuntimeError("boom")
     async with _running(loop):
-        await _wait_for(lambda: loop.ticks >= 2)
+        await loop.wait_for_ticks(2)
     assert "test loop failed; continuing" in caplog.text
 
 
@@ -161,22 +149,14 @@ async def test_cancellation_is_never_swallowed() -> None:
 
 
 async def test_prepare_false_disables_the_loop() -> None:
-    loop = _RecordingLoop(None)
+    class _Disabled(_RecordingLoop):
+        async def _prepare(self) -> bool:
+            return False
 
-    async def _no(self: object = None) -> bool:
-        return False
-
-    loop._prepare = _no  # type: ignore[method-assign]
+    loop = _Disabled(None)
     async with asyncio.timeout(1):
         await loop.run()
     assert loop.ticks == 0
-
-
-async def test_after_idle_runs_each_tick() -> None:
-    loop = _RecordingLoop(None)
-    async with _running(loop):
-        await _wait_for(lambda: loop.after_idles >= 2)
-    assert loop.ticks >= loop.after_idles
 
 
 async def test_unsubscribe_detaches_wake_callback_and_is_idempotent() -> None:

--- a/tests/test_presence_gated_loop.py
+++ b/tests/test_presence_gated_loop.py
@@ -132,7 +132,7 @@ async def test_crash_continue_collapses_repeat_logs_until_recovery(
     """A failure streak logs one traceback; a successful tick re-arms the loud log."""
     loop = _RecordingLoop(None)
     loop.work_error = RuntimeError("boom")
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.DEBUG, logger=PresenceGatedLoop.__module__):
         async with _running(loop):
             await loop.wait_for_ticks(2)
             loop.work_error = None

--- a/tests/test_presence_gated_loop.py
+++ b/tests/test_presence_gated_loop.py
@@ -154,6 +154,24 @@ async def test_cancellation_is_never_swallowed() -> None:
         await task
 
 
+async def test_run_refuses_concurrent_reentry() -> None:
+    """A second concurrent ``run()`` raises instead of silently double-ticking."""
+    loop = _RecordingLoop(None)
+    async with _running(loop):
+        await loop.wait_for_ticks(1)
+        with pytest.raises(RuntimeError, match="already running"):
+            await loop.run()
+
+
+async def test_run_is_rerunnable_after_cancellation() -> None:
+    """Sequential re-runs work — the MQTT loop re-runs per broker session."""
+    loop = _RecordingLoop(None)
+    async with _running(loop):
+        await loop.wait_for_ticks(1)
+    async with _running(loop):
+        await loop.wait_for_ticks(2)
+
+
 async def test_after_idle_gets_the_result_and_skips_crashed_ticks() -> None:
     """``_after_idle`` sees each completed tick's ``_work`` result; crashed ticks skip it."""
     seen: list[int] = []

--- a/tests/test_presence_gated_loop.py
+++ b/tests/test_presence_gated_loop.py
@@ -51,6 +51,12 @@ async def _running(loop: PresenceGatedLoop) -> AsyncIterator[asyncio.Task[None]]
             await task
 
 
+async def test_base_demands_work() -> None:
+    """The bare base has no ``_work``."""
+    with pytest.raises(NotImplementedError):
+        await PresenceGatedLoop(None)._work()
+
+
 async def test_runs_unconditionally_without_presence() -> None:
     """presence=None means no gate: ticks flow with no subscriber anywhere."""
     loop = _RecordingLoop(None)

--- a/tests/test_presence_gated_loop.py
+++ b/tests/test_presence_gated_loop.py
@@ -1,0 +1,189 @@
+"""Contract tests for the shared presence-gated loop primitive."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator, Callable
+
+import pytest
+
+from esphome_device_builder.helpers.presence_gated_loop import PresenceGatedLoop
+from esphome_device_builder.helpers.subscriber_presence import SubscriberPresence
+
+
+class _RecordingLoop(PresenceGatedLoop):
+    _label = "test loop"
+    _interval = 0.005
+
+    def __init__(self, presence: SubscriberPresence | None) -> None:
+        super().__init__(presence)
+        self.ticks = 0
+        self.resumes = 0
+        self.after_idles = 0
+        self.work_error: BaseException | None = None
+
+    def _on_resume(self) -> None:
+        self.resumes += 1
+
+    async def _work(self) -> None:
+        self.ticks += 1
+        if self.work_error is not None:
+            raise self.work_error
+
+    def _after_idle(self) -> None:
+        self.after_idles += 1
+
+
+@contextlib.asynccontextmanager
+async def _running(loop: PresenceGatedLoop) -> AsyncIterator[asyncio.Task[None]]:
+    task = asyncio.create_task(loop.run())
+    try:
+        yield task
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+async def _wait_for(predicate: Callable[[], bool], timeout: float = 1.0) -> None:
+    async with asyncio.timeout(timeout):
+        while not predicate():
+            await asyncio.sleep(0.001)
+
+
+async def test_base_contract() -> None:
+    """The base runs unconditionally by default and demands a ``_work``."""
+    base = PresenceGatedLoop(None)
+    assert await base._prepare() is True
+    with pytest.raises(NotImplementedError):
+        await base._work()
+
+
+async def test_runs_unconditionally_without_presence() -> None:
+    """presence=None means no gate: ticks flow with no subscriber anywhere."""
+    loop = _RecordingLoop(None)
+    async with _running(loop):
+        await _wait_for(lambda: loop.ticks >= 2)
+    assert loop.resumes == 0
+
+
+async def test_parks_until_first_subscriber_then_resumes() -> None:
+    """The loop parks with no work done, and a real park fires ``_on_resume``."""
+    presence = SubscriberPresence()
+    loop = _RecordingLoop(presence)
+    async with _running(loop):
+        await asyncio.sleep(0.05)
+        assert loop.ticks == 0
+        with presence.subscriber():
+            await _wait_for(lambda: loop.ticks >= 1)
+        assert loop.resumes == 1
+
+
+async def test_no_resume_hook_when_gate_already_open() -> None:
+    """Ticks entered with a subscriber present skip ``_on_resume``."""
+    presence = SubscriberPresence()
+    loop = _RecordingLoop(presence)
+    with presence.subscriber():
+        async with _running(loop):
+            await _wait_for(lambda: loop.ticks >= 3)
+    assert loop.resumes == 0
+
+
+async def test_subscriber_return_cuts_idle_short() -> None:
+    """A 0→1 transition mid-idle wakes the loop without waiting out the interval."""
+    presence = SubscriberPresence()
+    loop = _RecordingLoop(presence)
+    loop._interval = 60
+    async with _running(loop):
+        with presence.subscriber():
+            await _wait_for(lambda: loop.ticks == 1)
+        with presence.subscriber():
+            await _wait_for(lambda: loop.ticks >= 2)
+
+
+async def test_wake_mid_work_short_circuits_following_idle() -> None:
+    """A wake fired during ``_work`` survives the pre-work clear."""
+    ticks = 0
+
+    class _SelfWaking(PresenceGatedLoop):
+        _label = "self-waking"
+        _interval = 60
+
+        async def _work(self) -> None:
+            nonlocal ticks
+            ticks += 1
+            if ticks == 1:
+                self.wake()
+
+    loop = _SelfWaking(None)
+    async with _running(loop):
+        await _wait_for(lambda: ticks >= 2)
+
+
+async def test_continue_on_error_logs_and_keeps_looping(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    loop = _RecordingLoop(None)
+    loop.work_error = RuntimeError("boom")
+    async with _running(loop):
+        await _wait_for(lambda: loop.ticks >= 2)
+    assert "test loop failed; continuing" in caplog.text
+
+
+async def test_propagate_on_error_kills_the_loop() -> None:
+    loop = _RecordingLoop(None)
+    loop._continue_on_error = False
+    loop.work_error = RuntimeError("boom")
+    with pytest.raises(RuntimeError, match="boom"):
+        async with asyncio.timeout(1):
+            await loop.run()
+    assert loop.ticks == 1
+
+
+async def test_cancellation_is_never_swallowed() -> None:
+    """CancelledError raised inside ``_work`` tears the loop down."""
+    started = asyncio.Event()
+
+    class _Hanging(PresenceGatedLoop):
+        _label = "hanging"
+
+        async def _work(self) -> None:
+            started.set()
+            await asyncio.sleep(3600)
+
+    loop = _Hanging(None)
+    task = asyncio.create_task(loop.run())
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+async def test_prepare_false_disables_the_loop() -> None:
+    loop = _RecordingLoop(None)
+
+    async def _no(self: object = None) -> bool:
+        return False
+
+    loop._prepare = _no  # type: ignore[method-assign]
+    async with asyncio.timeout(1):
+        await loop.run()
+    assert loop.ticks == 0
+
+
+async def test_after_idle_runs_each_tick() -> None:
+    loop = _RecordingLoop(None)
+    async with _running(loop):
+        await _wait_for(lambda: loop.after_idles >= 2)
+    assert loop.ticks >= loop.after_idles
+
+
+async def test_unsubscribe_detaches_wake_callback_and_is_idempotent() -> None:
+    presence = SubscriberPresence()
+    loop = _RecordingLoop(presence)
+    assert len(presence._subscriber_callbacks) == 1
+    loop.unsubscribe()
+    assert presence._subscriber_callbacks == []
+    loop.unsubscribe()
+    assert presence._subscriber_callbacks == []

--- a/tests/test_presence_gated_loop.py
+++ b/tests/test_presence_gated_loop.py
@@ -12,7 +12,7 @@ from esphome_device_builder.helpers.presence_gated_loop import PresenceGatedLoop
 from esphome_device_builder.helpers.subscriber_presence import SubscriberPresence
 
 
-class _RecordingLoop(PresenceGatedLoop):
+class _RecordingLoop(PresenceGatedLoop[None]):
     _label = "test loop"
     _interval = 0.005
 
@@ -139,7 +139,7 @@ async def test_cancellation_is_never_swallowed() -> None:
     """CancelledError raised inside ``_work`` tears the loop down."""
     started = asyncio.Event()
 
-    class _Hanging(PresenceGatedLoop):
+    class _Hanging(PresenceGatedLoop[None]):
         _label = "hanging"
 
         async def _work(self) -> None:
@@ -152,6 +152,37 @@ async def test_cancellation_is_never_swallowed() -> None:
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+async def test_after_idle_gets_the_result_and_skips_crashed_ticks() -> None:
+    """``_after_idle`` sees each completed tick's ``_work`` result; crashed ticks skip it."""
+    seen: list[int] = []
+    done = asyncio.Event()
+
+    class _Flaky(PresenceGatedLoop[int]):
+        _label = "flaky"
+        _interval = 0.001
+
+        def __init__(self) -> None:
+            super().__init__(None)
+            self.ticks = 0
+
+        async def _work(self) -> int:
+            self.ticks += 1
+            if self.ticks == 2:
+                raise RuntimeError("boom")
+            return self.ticks
+
+        def _after_idle(self, result: int) -> None:
+            seen.append(result)
+            if len(seen) >= 2:
+                done.set()
+
+    loop = _Flaky()
+    async with _running(loop):
+        async with asyncio.timeout(1):
+            await done.wait()
+    assert seen[:2] == [1, 3]
 
 
 async def test_prepare_false_disables_the_loop() -> None:

--- a/tests/test_probe_device.py
+++ b/tests/test_probe_device.py
@@ -35,7 +35,7 @@ def _make_monitor() -> DeviceStateMonitor:
 
     monitor.mdns = MdnsSource(monitor)
 
-    monitor._presence = None
+    monitor.presence = None
     monitor.ping = PingSource(monitor)
     monitor.mdns._zeroconf = MagicMock()
     monitor.mdns._zeroconf.zeroconf = MagicMock()
@@ -155,7 +155,7 @@ def test_probe_device_no_zeroconf_is_a_noop() -> None:
 
     monitor.mdns = MdnsSource(monitor)
 
-    monitor._presence = None
+    monitor.presence = None
     monitor.ping = PingSource(monitor)
     monitor.mdns._zeroconf = None
     monitor._tasks = set()

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -80,7 +80,7 @@ def _make_monitor(
 
     monitor.mdns = MdnsSource(monitor)
 
-    monitor._presence = None  # ping loop runs unconditionally in tests
+    monitor.presence = None  # ping loop runs unconditionally in tests
     monitor._api_dial_budget = asyncio.Semaphore(1)
     monitor.ping = PingSource(monitor)
     monitor.api_info = ApiInfoSource(monitor)

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -92,7 +92,7 @@ def _make_monitor(
 
     monitor.mdns = MdnsSource(monitor)
 
-    monitor._presence = None
+    monitor.presence = None
     monitor.ping = PingSource(monitor)
     monitor._get_devices = lambda: devices
     monitor._get_devices_by_name = lambda name: [d for d in devices if d.name == name]

--- a/tests/test_subscriber_presence.py
+++ b/tests/test_subscriber_presence.py
@@ -138,66 +138,6 @@ async def test_wait_for_subscriber_wakes_every_awaiter_on_open() -> None:
         await asyncio.wait_for(asyncio.gather(*waiters), timeout=0.5)
 
 
-async def test_wait_for_no_subscribers_returns_immediately_when_count_is_zero() -> None:
-    """The mirror gate is open at startup (count == 0).
-
-    The 1→0 transition should set ``_no_subscribers`` *and* the
-    initial state at construction time should already be set —
-    so a consumer's first call to :meth:`wait_for_no_subscribers`
-    on a fresh gate returns immediately. Pinning the initial
-    state catches a regression that only sets the event on the
-    transition (which would leave a fresh gate's first awaiter
-    parked forever even though the count is already 0).
-    """
-    p = SubscriberPresence()
-    await asyncio.wait_for(p.wait_for_no_subscribers(), timeout=0.5)
-
-
-async def test_wait_for_no_subscribers_parks_while_subscribers_present() -> None:
-    """A subscriber holding the gate open blocks the no-subscriber waiter."""
-    p = SubscriberPresence()
-
-    async def _waiter() -> None:
-        await p.wait_for_no_subscribers()
-
-    with p.subscriber():
-        waiter_task = asyncio.create_task(_waiter())
-        await asyncio.sleep(0)
-        assert not waiter_task.done(), "waiter must park while count > 0"
-
-    # Subscriber dropped — the 1→0 transition wakes the waiter.
-    await asyncio.wait_for(waiter_task, timeout=0.5)
-
-
-async def test_wait_for_no_subscribers_wakes_on_drop_to_zero() -> None:
-    """Subscriber-drop wakes a parked no-subscribers waiter within one tick.
-
-    This is the contract the ICMP ping loop's interruptible idle
-    wait depends on — when the last subscriber leaves mid-sleep,
-    the loop's ``asyncio.wait_for(presence.wait_for_no_subscribers
-    (), timeout=<sweep interval>)`` must fire promptly so the next
-    subscriber's first sweep doesn't wait out the rest of the
-    interval.
-    """
-    p = SubscriberPresence()
-
-    cm = p.subscriber()
-    cm.__enter__()  # 0→1
-    try:
-
-        async def _waiter() -> None:
-            await p.wait_for_no_subscribers()
-
-        waiter_task = asyncio.create_task(_waiter())
-        await asyncio.sleep(0)
-        assert not waiter_task.done()
-    finally:
-        cm.__exit__(None, None, None)  # 1→0
-
-    # The drop must wake the waiter within a tick.
-    await asyncio.wait_for(waiter_task, timeout=0.1)
-
-
 def test_subscriber_callback_fires_on_each_zero_to_one() -> None:
     """Registered callback fires on every 0→1; not on nested entries; not on 1→0."""
     p = SubscriberPresence()


### PR DESCRIPTION
# What does this implement/fix?

Extracts the presence gated loop skeleton into a shared `PresenceGatedLoop` primitive in `helpers/presence_gated_loop.py`; it takes a `SubscriberPresence | None` directly, owns the wake event and the 0 to 1 callback registration, and runs the canonical tick: gate, resume hook (real park only), wake clear, work, idle, after idle hook.

`SweepSource` shrinks to a thin monitor bound adapter over it, so the ICMP, API info and API reviver sources are unchanged apart from the label attribute rename. The MQTT discover loop moves onto the same primitive via a `_DiscoverPingLoop` subclass; `DeviceMqttMonitor._ping_loop` stays as a one line delegate so every existing test seam keeps working. The MQTT loop keeps its exact semantics: rebase only on a real parked to active transition, stale aging gated on a sent broadcast, unexpected errors still tear down the broker session for the reconnect loop to handle, and `stop()` still detaches the wake callback.

The third presence gated loop, `DeviceBuilder._run_background`, moves onto the primitive too as `_BackgroundPollLoop`. Its old idle idiom (`wait_for_no_subscribers` with a timeout) is externally equivalent to the primitive's wake event idle: a departing subscriber still stops polling (the next tick parks at the gate), a returning one still gets an immediate poll via the 0 to 1 wake. That migration removes `wait_for_no_subscribers`'s only caller, so `SubscriberPresence` drops that method and its second event entirely. `DeviceStateMonitor` now exposes `presence` publicly instead of sources reaching into `_presence`, closing the reach in the issue called out.

Two deliberate behavior deltas: the MQTT wake clear now happens before the broadcast (the position the sweep sources already pin), so a subscriber transition landing during the publish executor hop cuts the next idle short instead of waiting out the interval; and a crash in the background device poll now logs and continues (the same contract as the ICMP and API sweeps) instead of silently killing background polling for the process lifetime; the crash continue path logs the traceback once per failure streak and collapses repeats to DEBUG, re armed by the next successful tick, so a short interval cannot flood the log.

`tests/test_mqtt_monitor.py` passes unmodified; the new `tests/test_presence_gated_loop.py` pins the shared primitive's contract.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2236

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
