### PR TITLE
Retarget the generated fallback-AP SSID on clone, rename, and friendly-name edits

### DIFF
--- a/esphome_device_builder/controllers/devices/mutations_clone.py
+++ b/esphome_device_builder/controllers/devices/mutations_clone.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, NoReturn
 
 from ...helpers.api import CommandError
 from ...helpers.async_ import run_in_executor
-from ...helpers.device_yaml import configuration_stem
+from ...helpers.device_yaml import configuration_stem, retarget_fallback_ap_ssid
 from ...helpers.yaml import (
     ESPHOME_FRIENDLY_NAME_PATH,
     ESPHOME_NAME_PATH,
@@ -127,6 +127,9 @@ async def clone_device(  # noqa: C901
     # No-op when the source uses ``!secret`` / ``${...}`` for
     # the key; those indirections stay shared with the source.
     new_content = rewrite_api_encryption_key(new_content, new_key)
+    # Retarget the generated fallback-AP ssid, which the leaf
+    # rewrites above don't reach.
+    new_content = retarget_fallback_ap_ssid(source_content, new_content)
 
     # Carry forward only a *user-picked* ``board_id`` since that's
     # the catalog-key indirection the user chose at wizard time and

--- a/esphome_device_builder/controllers/devices/mutations_simple.py
+++ b/esphome_device_builder/controllers/devices/mutations_simple.py
@@ -15,6 +15,7 @@ from ...helpers.device_yaml import (
     configuration_filename,
     parse_esphome_meta,
     resolved_device_name,
+    retarget_fallback_ap_ssid,
 )
 from ...helpers.hostname import default_mdns_address
 from ...helpers.storage_path import resolve_storage_path
@@ -236,6 +237,9 @@ async def rename_device(
     # Single rewrite + refusal point: offline, in-place, and the OTA chain
     # all retarget the name the same way.
     new_content = rewrite_rename_content(content, new_name, remedy=RENAME_REMEDY)
+    # Retarget a name-labelled fallback-AP ssid; a friendly-labelled
+    # one no-ops since its label is unchanged by a rename.
+    new_content = retarget_fallback_ap_ssid(content, new_content)
 
     # An in-place rename can't go through the OTA chain (same filename), so
     # it rewrites the name with no flash even when the caller wanted the OTA
@@ -404,6 +408,10 @@ async def edit_friendly_name(
         # (``esphome: !include ...``); the line-based walker
         # can't safely insert into either shape.
         raise CommandError(ErrorCode.INVALID_ARGS, str(exc)) from exc
+
+    # Retarget the generated fallback-AP ssid, which the leaf upsert
+    # doesn't reach.
+    new_content = retarget_fallback_ap_ssid(content, new_content)
 
     # Round-trip check: parse the rewritten YAML through the
     # same reader the scanner uses. Defends against the

--- a/esphome_device_builder/helpers/device_yaml/__init__.py
+++ b/esphome_device_builder/helpers/device_yaml/__init__.py
@@ -55,6 +55,7 @@ from ._parsing import (
     parse_esphome_meta,
     parse_platform_from_yaml,
     resolved_device_name,
+    retarget_fallback_ap_ssid,
     yaml_has_api_encryption,
     yaml_has_top_level_block,
 )
@@ -97,6 +98,7 @@ __all__ = [
     "parse_platform_from_yaml",
     "pending_changes_via_hash",
     "resolved_device_name",
+    "retarget_fallback_ap_ssid",
     "run_esphome_config",
     "yaml_has_api_encryption",
     "yaml_has_top_level_block",

--- a/esphome_device_builder/helpers/device_yaml/_generation.py
+++ b/esphome_device_builder/helpers/device_yaml/_generation.py
@@ -9,7 +9,12 @@ from typing import TYPE_CHECKING, Any
 
 from ...definitions import load_platform_capabilities_index
 from ...models.boards import RP2_CANONICAL_PLATFORM, Connectivity
-from ..yaml import _safe_yaml_scalar, generate_api_encryption_key, merge_component_yaml
+from ..yaml import (
+    _safe_yaml_scalar,
+    fallback_ap_ssid,
+    generate_api_encryption_key,
+    merge_component_yaml,
+)
 
 if TYPE_CHECKING:
     from ...models import BoardCatalogEntry, ComponentCatalogEntry
@@ -35,9 +40,6 @@ _WIFI_FIRST_PLATFORMS: frozenset[str] = frozenset(
 # Fallback-hotspot psk alphabet + length, mirroring esphome's wizard.
 _AP_PSK_ALPHABET = string.ascii_letters + string.digits
 _AP_PSK_LENGTH = 12
-
-# ESPHome's ``cv.ssid`` caps an AP ssid at 32 bytes.
-_AP_SSID_MAX_LEN = 32
 
 # Platforms supporting ``captive_portal:`` (esphome's ``cv.only_on``
 # allowlist). The fallback is emitted only here; a bare ``ap:`` without
@@ -537,20 +539,9 @@ def _fallback_recovery_lines(label: str, platform: str) -> list[str]:
     psk = "".join(secrets.choice(_AP_PSK_ALPHABET) for _ in range(_AP_PSK_LENGTH))
     return [
         "  ap:",
-        f"    ssid: {_safe_yaml_scalar(_fallback_ap_ssid(label))}",
+        f"    ssid: {_safe_yaml_scalar(fallback_ap_ssid(label))}",
         f'    password: "{psk}"',
         "",
         "captive_portal:",
         "",
     ]
-
-
-def _fallback_ap_ssid(label: str) -> str:
-    """AP ssid ``<label> Fallback Hotspot``; trims <label> so the marker survives the cap."""
-    base = label.strip() or "ESPHome"
-    suffix = " Fallback Hotspot"
-    # Trim the name, not the marker (esphome's wizard drops the whole
-    # marker here), so the recovery AP stays identifiable for long names.
-    if len(base) + len(suffix) > _AP_SSID_MAX_LEN:
-        base = base[: _AP_SSID_MAX_LEN - len(suffix)]
-    return f"{base}{suffix}"

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -10,7 +10,12 @@ from esphome import const
 from esphome.const import CONF_PACKAGES
 
 from ...models.boards import RP2_PLATFORM_ALIASES
-from ..yaml import _split_value_and_comment, _strip_yaml_quotes, parse_substitution_ref
+from ..yaml import (
+    _split_value_and_comment,
+    _strip_yaml_quotes,
+    parse_substitution_ref,
+    rewrite_fallback_ap_ssid,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -373,6 +378,23 @@ def resolved_device_name(yaml_content: str, configuration: str) -> str:
     if parsed and parse_substitution_ref(parsed) is None:
         return parsed
     return configuration_stem(configuration)
+
+
+def retarget_fallback_ap_ssid(old_yaml: str, new_yaml: str) -> str:
+    """
+    Follow the device identity into *new_yaml*'s generated fallback-AP ssid.
+
+    Both labels resolve through :func:`parse_esphome_meta` (friendly name
+    first, then name) so substitution-driven identities compare correctly;
+    a customized ssid or an indirection is left untouched.
+    """
+    return rewrite_fallback_ap_ssid(new_yaml, device_ap_label(old_yaml), device_ap_label(new_yaml))
+
+
+def device_ap_label(yaml_content: str) -> str | None:
+    """Return the label the generator derives the fallback-AP SSID from."""
+    meta = parse_esphome_meta(yaml_content)
+    return meta.friendly_name or meta.name
 
 
 def extract_esphome_meta_from_config(

--- a/esphome_device_builder/helpers/yaml/__init__.py
+++ b/esphome_device_builder/helpers/yaml/__init__.py
@@ -42,6 +42,8 @@ except AttributeError:  # pragma: no cover
 # intentional re-exports (PEP 484) so external callers'
 # ``from .helpers.yaml import X`` keeps working unchanged across
 # the split arc.
+from .ap_ssid import fallback_ap_ssid as fallback_ap_ssid
+from .ap_ssid import rewrite_fallback_ap_ssid as rewrite_fallback_ap_ssid
 from .api_encryption import generate_api_encryption_key as generate_api_encryption_key
 from .api_encryption import rewrite_api_encryption_key as rewrite_api_encryption_key
 from .component import _mapping_body_to_list_item as _mapping_body_to_list_item

--- a/esphome_device_builder/helpers/yaml/ap_ssid.py
+++ b/esphome_device_builder/helpers/yaml/ap_ssid.py
@@ -1,0 +1,47 @@
+"""Fallback-AP SSID derivation and the identity-following rewrite."""
+
+from __future__ import annotations
+
+from .scalar import (
+    _safe_yaml_scalar,
+    _strip_yaml_quotes,
+    is_plain_literal_scalar,
+    rewrite_yaml_scalar,
+)
+
+# ESPHome's ``cv.ssid`` caps an AP ssid at 32 bytes.
+_AP_SSID_MAX_LEN = 32
+
+_WIFI_AP_SSID_PATH = ("wifi", "ap", "ssid")
+
+
+def fallback_ap_ssid(label: str) -> str:
+    """AP ssid ``<label> Fallback Hotspot``; trims <label> so the marker survives the cap."""
+    base = label.strip() or "ESPHome"
+    suffix = " Fallback Hotspot"
+    # Trim the name, not the marker (esphome's wizard drops the whole
+    # marker here), so the recovery AP stays identifiable for long names.
+    if len(base) + len(suffix) > _AP_SSID_MAX_LEN:
+        base = base[: _AP_SSID_MAX_LEN - len(suffix)]
+    return f"{base}{suffix}"
+
+
+def rewrite_fallback_ap_ssid(yaml_text: str, old_label: str | None, new_label: str | None) -> str:
+    """
+    Retarget a generator-shaped ``wifi.ap.ssid`` from *old_label* to *new_label*.
+
+    Rewrites only when the current value is exactly the fallback SSID
+    :func:`fallback_ap_ssid` derives from *old_label*; a customized SSID
+    or a ``!secret`` / ``${...}`` indirection stays untouched.
+    """
+    if not old_label or not new_label or old_label == new_label:
+        return yaml_text
+
+    def _swap(raw: str) -> str | None:
+        if not is_plain_literal_scalar(raw):
+            return None
+        if _strip_yaml_quotes(raw) != fallback_ap_ssid(old_label):
+            return None
+        return _safe_yaml_scalar(fallback_ap_ssid(new_label))
+
+    return rewrite_yaml_scalar(yaml_text, _WIFI_AP_SSID_PATH, _swap)

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -762,3 +762,15 @@ def attach_reloading_scanner(
     scanner = ReloadingScanner(config_dir, devices)
     controller._scanner = scanner
     return scanner
+
+
+def wifi_ap_block(ssid: str) -> str:
+    """Return a ``wifi:`` block carrying the generator's fallback-AP recovery shape."""
+    return (
+        "wifi:\n"
+        "  ssid: !secret wifi_ssid\n"
+        "  password: !secret wifi_password\n\n"
+        "  ap:\n"
+        f"    ssid: {ssid}\n"
+        '    password: "abc123def456"\n'
+    )

--- a/tests/controllers/devices/test_clone.py
+++ b/tests/controllers/devices/test_clone.py
@@ -49,6 +49,17 @@ wifi:
   password: !secret wifi_password
 """
 
+AP_SOURCE_YAML = (
+    SOURCE_YAML
+    + """
+  ap:
+    ssid: Kitchen Lamp Fallback Hotspot
+    password: "abc123def456"
+
+captive_portal:
+"""
+)
+
 
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")
 async def test_clone_device_writes_new_yaml_and_swaps_name_friendly_key(
@@ -105,6 +116,55 @@ async def test_clone_device_uses_explicit_friendly_name_when_provided(
 
     new_yaml = (tmp_path / "bedroom-bulb.yaml").read_text("utf-8")
     assert "friendly_name: Bedroom Reading Lamp\n" in new_yaml
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_clone_device_retargets_generated_fallback_ap_ssid(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """The generated fallback-AP ssid follows the clone's identity (#2245)."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    (tmp_path / "kitchen.yaml").write_text(AP_SOURCE_YAML, "utf-8")
+
+    await ctrl.clone_device(
+        configuration="kitchen.yaml",
+        new_name="bedroom-bulb",
+        new_friendly_name="Bedroom Bulb",
+    )
+
+    new_yaml = (tmp_path / "bedroom-bulb.yaml").read_text("utf-8")
+    assert "    ssid: Bedroom Bulb Fallback Hotspot\n" in new_yaml
+    assert "Kitchen Lamp Fallback Hotspot" not in new_yaml
+    # The AP password stays shared with the source.
+    assert '    password: "abc123def456"\n' in new_yaml
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_clone_device_retargets_ap_ssid_from_substitution_friendly(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A substitution-driven friendly name still resolves for the old-label match."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    source = AP_SOURCE_YAML.replace(
+        "esphome:\n  name: kitchen\n  friendly_name: Kitchen Lamp\n",
+        "substitutions:\n  label: Kitchen Lamp\n\n"
+        "esphome:\n  name: kitchen\n  friendly_name: ${label}\n",
+    )
+    (tmp_path / "kitchen.yaml").write_text(source, "utf-8")
+
+    await ctrl.clone_device(
+        configuration="kitchen.yaml",
+        new_name="bedroom-bulb",
+        new_friendly_name="Bedroom Bulb",
+    )
+
+    new_yaml = (tmp_path / "bedroom-bulb.yaml").read_text("utf-8")
+    # Friendly rewrite lands on the substitution definition; the ssid
+    # follows the resolved label on both sides.
+    assert "  label: Bedroom Bulb\n" in new_yaml
+    assert "    ssid: Bedroom Bulb Fallback Hotspot\n" in new_yaml
 
 
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")

--- a/tests/controllers/devices/test_clone.py
+++ b/tests/controllers/devices/test_clone.py
@@ -123,7 +123,7 @@ async def test_clone_device_retargets_generated_fallback_ap_ssid(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """The generated fallback-AP ssid follows the clone's identity (#2245)."""
+    """The generated fallback-AP ssid follows the clone's identity."""
     ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
     (tmp_path / "kitchen.yaml").write_text(AP_SOURCE_YAML, "utf-8")
 

--- a/tests/controllers/devices/test_edit_friendly_name.py
+++ b/tests/controllers/devices/test_edit_friendly_name.py
@@ -132,7 +132,7 @@ async def test_edit_friendly_name_retargets_generated_fallback_ap_ssid(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """The generated fallback-AP ssid follows the friendly-name edit (#2245)."""
+    """The generated fallback-AP ssid follows the friendly-name edit."""
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     yaml_text = SOURCE_YAML + "\n" + wifi_ap_block("Kitchen Lamp Fallback Hotspot")
     (tmp_path / "kitchen.yaml").write_text(yaml_text, "utf-8")

--- a/tests/controllers/devices/test_edit_friendly_name.py
+++ b/tests/controllers/devices/test_edit_friendly_name.py
@@ -29,7 +29,7 @@ from esphome_device_builder.controllers._device_scanner import DeviceFileMetadat
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode
 
-from .conftest import MakeControllerFactory
+from .conftest import MakeControllerFactory, wifi_ap_block
 
 SOURCE_YAML = """\
 esphome:
@@ -126,6 +126,46 @@ async def test_edit_friendly_name_redirects_through_substitution(
     assert "  friendly_name: Pump Watcher\n" in new_yaml
     assert "  friendly_name: ${friendly_name}\n" in new_yaml
     assert "AC Float Monitor" not in new_yaml
+
+
+async def test_edit_friendly_name_retargets_generated_fallback_ap_ssid(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """The generated fallback-AP ssid follows the friendly-name edit (#2245)."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    yaml_text = SOURCE_YAML + "\n" + wifi_ap_block("Kitchen Lamp Fallback Hotspot")
+    (tmp_path / "kitchen.yaml").write_text(yaml_text, "utf-8")
+
+    await ctrl.edit_friendly_name(
+        configuration="kitchen.yaml",
+        new_friendly_name="Reading Lamp",
+    )
+
+    new_yaml = (tmp_path / "kitchen.yaml").read_text("utf-8")
+    assert "    ssid: Reading Lamp Fallback Hotspot\n" in new_yaml
+    assert "Kitchen Lamp Fallback Hotspot" not in new_yaml
+
+
+async def test_edit_friendly_name_retargets_name_labelled_ap_ssid_on_insert(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Inserting a first friendly name retargets an ssid derived from the device name."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    yaml_text = "esphome:\n  name: kitchen\n\nesp32:\n  variant: ESP32\n\n" + wifi_ap_block(
+        "kitchen Fallback Hotspot"
+    )
+    (tmp_path / "kitchen.yaml").write_text(yaml_text, "utf-8")
+
+    await ctrl.edit_friendly_name(
+        configuration="kitchen.yaml",
+        new_friendly_name="Reading Lamp",
+    )
+
+    new_yaml = (tmp_path / "kitchen.yaml").read_text("utf-8")
+    assert "  friendly_name: Reading Lamp\n" in new_yaml
+    assert "    ssid: Reading Lamp Fallback Hotspot\n" in new_yaml
 
 
 async def test_edit_friendly_name_safely_quotes_yaml_specials(

--- a/tests/controllers/devices/test_rename.py
+++ b/tests/controllers/devices/test_rename.py
@@ -240,7 +240,7 @@ async def test_rename_queues_firmware_job(
 async def test_rename_chain_content_retargets_name_labelled_ap_ssid(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """The OTA chain compiles content whose fallback-AP ssid tracks the rename (#2245)."""
+    """The OTA chain compiles content whose fallback-AP ssid tracks the rename."""
     controller = make_controller(tmp_path, esphome_cmd=["esphome"])
     yaml_text = "esphome:\n  name: kitchen\n\nesp32:\n  board: esp32dev\n\n" + wifi_ap_block(
         "kitchen Fallback Hotspot"

--- a/tests/controllers/devices/test_rename.py
+++ b/tests/controllers/devices/test_rename.py
@@ -27,7 +27,7 @@ from esphome_device_builder.models import (
     JobType,
 )
 
-from .conftest import MakeControllerFactory
+from .conftest import MakeControllerFactory, wifi_ap_block
 
 _YAML = """\
 esphome:
@@ -235,6 +235,38 @@ async def test_rename_queues_firmware_job(
     assert result["tail_job"]["job_type"] == JobType.RENAME
     # No file-level rename; the queued chain owns the rename + rollback.
     assert controller._scanner.calls == []
+
+
+async def test_rename_chain_content_retargets_name_labelled_ap_ssid(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """The OTA chain compiles content whose fallback-AP ssid tracks the rename (#2245)."""
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
+    yaml_text = "esphome:\n  name: kitchen\n\nesp32:\n  board: esp32dev\n\n" + wifi_ap_block(
+        "kitchen Fallback Hotspot"
+    )
+    (tmp_path / "kitchen.yaml").write_text(yaml_text, encoding="utf-8")
+    head = FirmwareJob(
+        job_id="abc123",
+        configuration="livingroom.yaml",
+        job_type=JobType.COMPILE,
+        status=JobStatus.QUEUED,
+    )
+    tail = FirmwareJob(
+        job_id="def456",
+        configuration="kitchen.yaml",
+        job_type=JobType.RENAME,
+        status=JobStatus.QUEUED,
+        new_name="livingroom",
+        depends_on="abc123",
+    )
+    controller._db.firmware = MagicMock()
+    controller._db.firmware.rename_chain = AsyncMock(return_value=(head, tail))
+
+    await controller.rename_device(configuration="kitchen.yaml", new_name="livingroom")
+
+    new_content = controller._db.firmware.rename_chain.await_args.kwargs["new_content"]
+    assert "    ssid: livingroom Fallback Hotspot\n" in new_content
 
 
 async def test_rename_missing_firmware_controller_raises(

--- a/tests/controllers/devices/test_rename_config_only.py
+++ b/tests/controllers/devices/test_rename_config_only.py
@@ -13,7 +13,7 @@ from esphome_device_builder.helpers.yaml import read_yaml_scalar
 from esphome_device_builder.models import ErrorCode
 from tests._storage_fixtures import write_storage_json
 
-from .conftest import MakeControllerFactory
+from .conftest import MakeControllerFactory, wifi_ap_block
 
 _YAML = """\
 esphome:
@@ -43,6 +43,40 @@ async def test_config_only_rename_rewrites_name_and_renames_file(
     # Untouched siblings survive the rewrite.
     assert read_yaml_scalar(new_content, ("esphome", "friendly_name")) == "Kitchen Light"
     assert controller._scanner.calls == [("reload", "livingroom.yaml"), ("scan",)]
+
+
+async def test_config_only_rename_retargets_name_labelled_ap_ssid(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """Without a friendly name the generated fallback-AP ssid tracks the rename (#2245)."""
+    controller = make_controller(tmp_path)
+    yaml_text = "esphome:\n  name: kitchen\n\nesp32:\n  board: esp32dev\n\n" + wifi_ap_block(
+        "kitchen Fallback Hotspot"
+    )
+    (tmp_path / "kitchen.yaml").write_text(yaml_text, encoding="utf-8")
+
+    await controller.rename_device(
+        configuration="kitchen.yaml", new_name="livingroom", config_only=True
+    )
+
+    new_content = (tmp_path / "livingroom.yaml").read_text(encoding="utf-8")
+    assert read_yaml_scalar(new_content, ("wifi", "ap", "ssid")) == "livingroom Fallback Hotspot"
+
+
+async def test_config_only_rename_leaves_friendly_labelled_ap_ssid(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """With a friendly name the ssid is friendly-derived; rename doesn't touch it."""
+    controller = make_controller(tmp_path)
+    yaml_text = _YAML + "\n" + wifi_ap_block("Kitchen Light Fallback Hotspot")
+    (tmp_path / "kitchen.yaml").write_text(yaml_text, encoding="utf-8")
+
+    await controller.rename_device(
+        configuration="kitchen.yaml", new_name="livingroom", config_only=True
+    )
+
+    new_content = (tmp_path / "livingroom.yaml").read_text(encoding="utf-8")
+    assert read_yaml_scalar(new_content, ("wifi", "ap", "ssid")) == "Kitchen Light Fallback Hotspot"
 
 
 async def test_config_only_rename_migrates_sidecar_metadata(

--- a/tests/controllers/devices/test_rename_config_only.py
+++ b/tests/controllers/devices/test_rename_config_only.py
@@ -48,7 +48,7 @@ async def test_config_only_rename_rewrites_name_and_renames_file(
 async def test_config_only_rename_retargets_name_labelled_ap_ssid(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """Without a friendly name the generated fallback-AP ssid tracks the rename (#2245)."""
+    """Without a friendly name the generated fallback-AP ssid tracks the rename."""
     controller = make_controller(tmp_path)
     yaml_text = "esphome:\n  name: kitchen\n\nesp32:\n  board: esp32dev\n\n" + wifi_ap_block(
         "kitchen Fallback Hotspot"

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -41,6 +41,7 @@ from esphome_device_builder.helpers.device_yaml import (
 )
 from esphome_device_builder.helpers.device_yaml._parsing import (
     _is_valid_esphome_name,
+    device_ap_label,
     extract_logger_baud_rate,
     extract_ota_partition_access,
 )
@@ -354,6 +355,28 @@ esphome:
     assert parse_esphome_meta(yaml_content, extra_substitutions=None) == parse_esphome_meta(
         yaml_content
     )
+
+
+@pytest.mark.parametrize(
+    ("yaml_content", "expected"),
+    [
+        pytest.param(
+            "esphome:\n  name: kitchen\n  friendly_name: Kitchen Lamp\n",
+            "Kitchen Lamp",
+            id="friendly_wins",
+        ),
+        pytest.param("esphome:\n  name: kitchen\n", "kitchen", id="name_fallback"),
+        pytest.param(
+            "substitutions:\n  room: Bedroom\nesphome:\n  name: kitchen\n"
+            "  friendly_name: ${room}\n",
+            "Bedroom",
+            id="substitution_resolves",
+        ),
+        pytest.param("wifi:\n  ssid: x\n", None, id="no_identity"),
+    ],
+)
+def test_device_ap_label(yaml_content: str, expected: str | None) -> None:
+    assert device_ap_label(yaml_content) == expected
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -42,6 +42,7 @@ from esphome_device_builder.helpers.yaml import (
     _splice_into_domain_block,
     _splice_into_multi_conf_block,
     _strip_yaml_quotes,
+    fallback_ap_ssid,
     generate_api_encryption_key,
     generate_component_yaml,
     is_plain_literal_scalar,
@@ -51,6 +52,7 @@ from esphome_device_builder.helpers.yaml import (
     parse_substitution_ref,
     read_yaml_scalar,
     rewrite_api_encryption_key,
+    rewrite_fallback_ap_ssid,
     rewrite_name_or_substitution,
     rewrite_rename_content,
     rewrite_yaml_scalar,
@@ -265,6 +267,79 @@ def test_rewrite_rename_content_refuses_non_retargetable(yaml: str) -> None:
         rewrite_rename_content(yaml, "bedroom-bulb", remedy="Do the thing.")
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
     assert excinfo.value.message.endswith("Do the thing.")
+
+
+# ---------------------------------------------------------------------------
+# rewrite_fallback_ap_ssid
+# ---------------------------------------------------------------------------
+
+_AP_YAML = """\
+esphome:
+  name: kitchen
+  friendly_name: Kitchen Lamp
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+  ap:
+    ssid: Kitchen Lamp Fallback Hotspot
+    password: "abc123def456"
+
+captive_portal:
+"""
+
+
+def test_rewrite_fallback_ap_ssid_retargets_generated_value() -> None:
+    out = rewrite_fallback_ap_ssid(_AP_YAML, "Kitchen Lamp", "Bedroom Bulb")
+    assert "    ssid: Bedroom Bulb Fallback Hotspot\n" in out
+    assert "Kitchen Lamp Fallback Hotspot" not in out
+    # Siblings untouched.
+    assert '    password: "abc123def456"\n' in out
+    assert "  ssid: !secret wifi_ssid\n" in out
+
+
+def test_rewrite_fallback_ap_ssid_matches_quoted_value_and_requotes() -> None:
+    yaml_text = _AP_YAML.replace(
+        "ssid: Kitchen Lamp Fallback Hotspot", 'ssid: "Kitchen #2 Fallback Hotspot"'
+    )
+    out = rewrite_fallback_ap_ssid(yaml_text, "Kitchen #2", "Bedroom #3")
+    assert '    ssid: "Bedroom #3 Fallback Hotspot"\n' in out
+
+
+def test_rewrite_fallback_ap_ssid_matches_truncated_long_label() -> None:
+    """A label trimmed to the 32-byte cap at generation time still matches."""
+    label = "Very Long Device Name That Overflows"
+    generated = fallback_ap_ssid(label)
+    assert label not in generated
+    yaml_text = _AP_YAML.replace("Kitchen Lamp Fallback Hotspot", generated)
+    out = rewrite_fallback_ap_ssid(yaml_text, label, "Short")
+    assert "    ssid: Short Fallback Hotspot\n" in out
+
+
+@pytest.mark.parametrize(
+    "current",
+    [
+        pytest.param("ssid: Kitchen Custom AP", id="customized"),
+        pytest.param("ssid: !secret ap_ssid", id="secret_tag"),
+        pytest.param("ssid: ${ap_ssid}", id="substitution"),
+        pytest.param("ssid: Kitchen Lamp ${suffix}", id="embedded_substitution"),
+    ],
+)
+def test_rewrite_fallback_ap_ssid_leaves_non_generated_values(current: str) -> None:
+    yaml_text = _AP_YAML.replace("ssid: Kitchen Lamp Fallback Hotspot", current)
+    assert rewrite_fallback_ap_ssid(yaml_text, "Kitchen Lamp", "Bedroom") == yaml_text
+
+
+def test_rewrite_fallback_ap_ssid_noop_without_ap_leaf() -> None:
+    yaml_text = "esphome:\n  name: kitchen\n\nwifi:\n  ssid: !secret wifi_ssid\n"
+    assert rewrite_fallback_ap_ssid(yaml_text, "kitchen", "bedroom") == yaml_text
+
+
+def test_rewrite_fallback_ap_ssid_noop_when_labels_missing_or_equal() -> None:
+    assert rewrite_fallback_ap_ssid(_AP_YAML, None, "Bedroom") == _AP_YAML
+    assert rewrite_fallback_ap_ssid(_AP_YAML, "Kitchen Lamp", None) == _AP_YAML
+    assert rewrite_fallback_ap_ssid(_AP_YAML, "Kitchen Lamp", "Kitchen Lamp") == _AP_YAML
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

The default generated config embeds the device identity in a literal fallback AP ssid (`wifi.ap.ssid: "Kitchen Lamp Fallback Hotspot"`), but clone, rename, and edit friendly name only rewrote the identity leaves, so the old identity survived in the hotspot name.

All three paths now retarget `wifi.ap.ssid` when it exactly matches the generated shape for the old label (friendly name, or the device name when there is none), recomputing it for the new label so the 32 byte cap still applies. A customized ssid, `!secret`, or `${...}` value is never touched. The derivation moved from the generator into a shared `fallback_ap_ssid` helper so the rewrite and the generator can't drift apart.

**Related issue or feature (if applicable):**

- fixes #2245

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
