### PR TITLE
Parse esphome meta once per content string in the device mutation paths

### DIFF
--- a/esphome_device_builder/controllers/devices/mutations_clone.py
+++ b/esphome_device_builder/controllers/devices/mutations_clone.py
@@ -6,7 +6,11 @@ from typing import TYPE_CHECKING, Any, NoReturn
 
 from ...helpers.api import CommandError
 from ...helpers.async_ import run_in_executor
-from ...helpers.device_yaml import configuration_stem, retarget_fallback_ap_ssid
+from ...helpers.device_yaml import (
+    configuration_stem,
+    parse_esphome_meta,
+    retarget_fallback_ap_ssid,
+)
 from ...helpers.yaml import (
     ESPHOME_FRIENDLY_NAME_PATH,
     ESPHOME_NAME_PATH,
@@ -129,7 +133,9 @@ async def clone_device(  # noqa: C901
     new_content = rewrite_api_encryption_key(new_content, new_key)
     # Retarget the generated fallback-AP ssid, which the leaf
     # rewrites above don't reach.
-    new_content = retarget_fallback_ap_ssid(source_content, new_content)
+    new_content = retarget_fallback_ap_ssid(
+        new_content, parse_esphome_meta(source_content), parse_esphome_meta(new_content)
+    )
 
     # Carry forward only a *user-picked* ``board_id`` since that's
     # the catalog-key indirection the user chose at wizard time and

--- a/esphome_device_builder/controllers/devices/mutations_simple.py
+++ b/esphome_device_builder/controllers/devices/mutations_simple.py
@@ -212,6 +212,7 @@ async def rename_device(
     new_path = controller._db.settings.rel_path(new_filename)
 
     content = await _read_device_yaml_or_raise(controller, configuration)
+    old_meta = parse_esphome_meta(content)
 
     # Reject same-name renames up-front. Compare against the device's real
     # ``esphome.name``, not the filename stem: an uploaded config keeps its
@@ -219,7 +220,7 @@ async def rename_device(
     # a stem compare wrongly rejects the legitimate ``test_1`` -> ``test-1``
     # rename and wrongly accepts a real no-op whose filename differs from its
     # name.
-    if new_name == resolved_device_name(content, configuration):
+    if new_name == resolved_device_name(old_meta, configuration):
         raise CommandError(
             ErrorCode.INVALID_ARGS,
             "new_name must differ from the current device name",
@@ -239,7 +240,7 @@ async def rename_device(
     new_content = rewrite_rename_content(content, new_name, remedy=RENAME_REMEDY)
     # Retarget a name-labelled fallback-AP ssid; a friendly-labelled
     # one no-ops since its label is unchanged by a rename.
-    new_content = retarget_fallback_ap_ssid(content, new_content)
+    new_content = retarget_fallback_ap_ssid(new_content, old_meta, parse_esphome_meta(new_content))
 
     # An in-place rename can't go through the OTA chain (same filename), so
     # it rewrites the name with no flash even when the caller wanted the OTA
@@ -409,11 +410,7 @@ async def edit_friendly_name(
         # can't safely insert into either shape.
         raise CommandError(ErrorCode.INVALID_ARGS, str(exc)) from exc
 
-    # Retarget the generated fallback-AP ssid, which the leaf upsert
-    # doesn't reach.
-    new_content = retarget_fallback_ap_ssid(content, new_content)
-
-    # Round-trip check: parse the rewritten YAML through the
+    # Round-trip check: parse the upserted YAML through the
     # same reader the scanner uses. Defends against the
     # line-based upsert producing a YAML shape that serializes
     # fine but the reader misinterprets; a real bug shipped
@@ -423,8 +420,8 @@ async def edit_friendly_name(
     # ``# Board:`` at column 0, treated it as a fresh top-level
     # key, dropped the ``esphome:`` context, and silently lost
     # ``friendly_name`` on every load.
-    _, parsed_friendly, _, _ = parse_esphome_meta(new_content)
-    if parsed_friendly != new_friendly_name:
+    new_meta = parse_esphome_meta(new_content)
+    if new_meta.friendly_name != new_friendly_name:
         raise CommandError(
             ErrorCode.INTERNAL_ERROR,
             "Edited YAML doesn't round-trip through the reader — "
@@ -435,6 +432,9 @@ async def edit_friendly_name(
             "credentials, API keys, and static IPs) so we can "
             "extend the rewriter's coverage.",
         )
+    # Retarget the generated fallback-AP ssid, which the leaf upsert
+    # doesn't reach.
+    new_content = retarget_fallback_ap_ssid(new_content, parse_esphome_meta(content), new_meta)
     if new_content == content:
         # Idempotent: same value submitted (or the leaf already
         # was that value). Skip the write and signal no install

--- a/esphome_device_builder/controllers/firmware/rename_flow.py
+++ b/esphome_device_builder/controllers/firmware/rename_flow.py
@@ -11,7 +11,11 @@ from esphome.storage_json import StorageJSON
 from ...helpers.api import CommandError
 from ...helpers.async_ import run_in_executor
 from ...helpers.build_artifacts import remove_device_files
-from ...helpers.device_yaml import configuration_filename, resolved_device_name
+from ...helpers.device_yaml import (
+    configuration_filename,
+    parse_esphome_meta,
+    resolved_device_name,
+)
 from ...helpers.hostname import default_mdns_address
 from ...helpers.storage_path import resolve_storage_path
 from ...helpers.yaml import rewrite_rename_content
@@ -69,7 +73,7 @@ async def begin_rename(
     if new_content is None:
         new_content = rewrite_rename_content(content, new_name, remedy=RENAME_REMEDY)
     port = await resolve_old_device_address(
-        controller, configuration, resolved_device_name(content, configuration)
+        controller, configuration, resolved_device_name(parse_esphome_meta(content), configuration)
     )
     build_source = controller._resolve_install_source()
 

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -368,32 +368,30 @@ def parse_esphome_meta(
     return EsphomeMeta(meta["name"], meta["friendly_name"], meta["comment"], meta["area"])
 
 
-def resolved_device_name(yaml_content: str, configuration: str) -> str:
-    """Return the device's ``esphome.name`` when known, else the filename stem.
+def resolved_device_name(meta: EsphomeMeta, configuration: str) -> str:
+    """Return *meta*'s ``name`` when known, else the filename stem.
 
     A nonlocal ``${var}`` name stays an unresolved token in the parsed
     meta, so fall back to the stem rather than using the literal ref.
     """
-    parsed = parse_esphome_meta(yaml_content).name
-    if parsed and parse_substitution_ref(parsed) is None:
-        return parsed
+    if meta.name and parse_substitution_ref(meta.name) is None:
+        return meta.name
     return configuration_stem(configuration)
 
 
-def retarget_fallback_ap_ssid(old_yaml: str, new_yaml: str) -> str:
+def retarget_fallback_ap_ssid(new_yaml: str, old_meta: EsphomeMeta, new_meta: EsphomeMeta) -> str:
     """
     Follow the device identity into *new_yaml*'s generated fallback-AP ssid.
 
-    Both labels resolve through :func:`parse_esphome_meta` (friendly name
+    Both labels come off :func:`parse_esphome_meta` results (friendly name
     first, then name) so substitution-driven identities compare correctly;
     a customized ssid or an indirection is left untouched.
     """
-    return rewrite_fallback_ap_ssid(new_yaml, device_ap_label(old_yaml), device_ap_label(new_yaml))
+    return rewrite_fallback_ap_ssid(new_yaml, device_ap_label(old_meta), device_ap_label(new_meta))
 
 
-def device_ap_label(yaml_content: str) -> str | None:
+def device_ap_label(meta: EsphomeMeta) -> str | None:
     """Return the label the generator derives the fallback-AP SSID from."""
-    meta = parse_esphome_meta(yaml_content)
     return meta.friendly_name or meta.name
 
 

--- a/tests/controllers/devices/test_edit_friendly_name.py
+++ b/tests/controllers/devices/test_edit_friendly_name.py
@@ -27,6 +27,7 @@ import pytest
 
 from esphome_device_builder.controllers._device_scanner import DeviceFileMetadata, DeviceScanner
 from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.helpers.device_yaml import EsphomeMeta
 from esphome_device_builder.models import ErrorCode
 
 from .conftest import MakeControllerFactory, wifi_ap_block
@@ -678,7 +679,7 @@ async def test_edit_friendly_name_raises_internal_error_on_round_trip_mismatch(
 
     monkeypatch.setattr(
         "esphome_device_builder.controllers.devices.mutations_simple.parse_esphome_meta",
-        lambda _content: (None, None, None, None),
+        lambda _content: EsphomeMeta(None, None, None, None),
     )
 
     with pytest.raises(CommandError) as excinfo:

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -376,7 +376,7 @@ esphome:
     ],
 )
 def test_device_ap_label(yaml_content: str, expected: str | None) -> None:
-    assert device_ap_label(yaml_content) == expected
+    assert device_ap_label(parse_esphome_meta(yaml_content)) == expected
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

The device mutation paths parsed the same YAML string repeatedly: a rename parsed the old content in `resolved_device_name` and again inside `retarget_fallback_ap_ssid`; a friendly name edit parsed the new content for the fallback AP retarget and again for the round trip check.

`device_ap_label`, `retarget_fallback_ap_ssid`, and `resolved_device_name` now take the already parsed `EsphomeMeta`, so each call site parses a content string once and threads the result. The friendly name edit also reorders so the round trip check guards the upsert output directly. No behavior change; the parse count is the only delta.

**Related issue or feature (if applicable):**

- fixes #2248

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
