### PR TITLE
Consolidate the test suite's condition-polling helpers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -414,6 +414,26 @@ async def cancel_and_drain(task: asyncio.Task[Any]) -> None:
     await asyncio.gather(task, return_exceptions=True)
 
 
+async def wait_until(
+    condition: Callable[[], object],
+    timeout: float,
+    what: str,
+    *,
+    interval: float = 0,
+) -> None:
+    """Poll *condition* until truthy; pytest.fail naming *what* after *timeout*.
+
+    ``interval`` defaults to a bare loop yield; pass a coarser one
+    when the condition tracks real-world time (e.g. a live broker).
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not condition():
+        if loop.time() >= deadline:
+            pytest.fail(f"timed out waiting for {what}")
+        await asyncio.sleep(interval)
+
+
 # ---------------------------------------------------------------------------
 # submit_job test helpers
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -421,7 +421,8 @@ async def wait_until(
     *,
     interval: float = 0,
 ) -> None:
-    """Poll *condition* until truthy; pytest.fail naming *what* after *timeout*.
+    """
+    Poll *condition* until truthy; pytest.fail naming *what* on timeout.
 
     ``interval`` defaults to a bare loop yield; pass a coarser one
     when the condition tracks real-world time (e.g. a live broker).

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -50,6 +50,7 @@ from esphome_device_builder.models import (
     JobType,
 )
 
+from ...conftest import wait_until
 from .conftest import REMOTE_PIN, capture_local_events, make_remote_job
 
 if TYPE_CHECKING:
@@ -244,13 +245,7 @@ async def _wait_until_dispatched(client: Any, *, timeout: float = 1.0) -> None:
     regression that never reaches the submit shows up as a
     clear test failure rather than a hung pytest run.
     """
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + timeout
-    while client.submit_job.await_count == 0:
-        if loop.time() >= deadline:
-            msg = f"submit_job not awaited within {timeout}s"
-            raise AssertionError(msg)
-        await asyncio.sleep(0)
+    await wait_until(lambda: client.submit_job.await_count > 0, timeout, "submit_job dispatch")
 
 
 async def _wait_for_wire_cancel(client: Any, *, timeout: float = 1.0) -> None:
@@ -265,21 +260,15 @@ async def _wait_for_wire_cancel(client: Any, *, timeout: float = 1.0) -> None:
     ``_request_remote_cancel`` mirror) signals the cancel
     event, the runner wakes and dispatches
     ``client.cancel_job``. Polling on
-    :attr:`AsyncMock.await_count` with a 50 ms granularity
-    returns the instant that wire send lands.
+    :attr:`AsyncMock.await_count` returns the instant that
+    wire send lands.
 
     Raises :class:`AssertionError` on timeout for the same
     reason :func:`_wait_until_dispatched` does — a regression
     that never sends the wire cancel should be a clean fail,
     not a hang.
     """
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + timeout
-    while client.cancel_job.await_count == 0:
-        if loop.time() >= deadline:
-            msg = f"cancel_job not awaited within {timeout}s"
-            raise AssertionError(msg)
-        await asyncio.sleep(0.05)
+    await wait_until(lambda: client.cancel_job.await_count > 0, timeout, "wire cancel_job")
 
 
 def _fire_session_closed(
@@ -1968,13 +1957,9 @@ def _make_reset_job(*, job_id: str = "reset-1") -> FirmwareJob:
 
 async def _wait_until_reset_dispatched(client: Any, *, timeout: float = 1.0) -> None:
     """Yield until the runner moved past ``await client.reset_build_env(...)``."""
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + timeout
-    while client.reset_build_env.await_count == 0:
-        if loop.time() >= deadline:
-            msg = f"reset_build_env not awaited within {timeout}s"
-            raise AssertionError(msg)
-        await asyncio.sleep(0)
+    await wait_until(
+        lambda: client.reset_build_env.await_count > 0, timeout, "reset_build_env dispatch"
+    )
 
 
 async def test_remote_reset_dispatches_frame_and_finalises_on_completed(

--- a/tests/e2e/slow/mqtt/test_mqtt_discovery_broker.py
+++ b/tests/e2e/slow/mqtt/test_mqtt_discovery_broker.py
@@ -15,7 +15,6 @@ import contextlib
 import json
 import shutil
 import socket
-from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +24,8 @@ from esphome_device_builder.controllers import _device_mqtt_monitor as monitor_m
 from esphome_device_builder.controllers._device_mqtt_coordinator import DeviceMqttCoordinator
 from esphome_device_builder.helpers.subscriber_presence import SubscriberPresence
 from esphome_device_builder.models import Device, DeviceState
+
+from ....conftest import wait_until
 
 paho = pytest.importorskip("paho.mqtt.client")
 
@@ -46,14 +47,6 @@ def _free_port() -> int:
     with socket.socket() as sock:
         sock.bind(("127.0.0.1", 0))
         return sock.getsockname()[1]
-
-
-async def _wait_for(condition: Callable[[], bool], timeout: float, what: str) -> None:
-    deadline = asyncio.get_running_loop().time() + timeout
-    while not condition():
-        if asyncio.get_running_loop().time() > deadline:
-            pytest.fail(f"timed out waiting for {what}")
-        await asyncio.sleep(0.05)
 
 
 async def _restart_mosquitto(tmp_path: Path, port: int) -> asyncio.subprocess.Process:
@@ -182,10 +175,11 @@ async def test_broker_restart_resubscribes_and_recovers(
     try:
         await coord.reconcile()
         with presence.subscriber():
-            await _wait_for(
+            await wait_until(
                 lambda: {n for n, s in events if s == DeviceState.ONLINE} == {"dev1", "dev2"},
                 10.0,
                 "both devices ONLINE",
+                interval=0.05,
             )
 
             broker.terminate()
@@ -197,10 +191,11 @@ async def test_broker_restart_resubscribes_and_recovers(
             broker = await _restart_mosquitto(tmp_path, port)
 
             events.clear()
-            await _wait_for(
+            await wait_until(
                 lambda: {n for n, s in events if s == DeviceState.ONLINE} == {"dev1", "dev2"},
                 20.0,
                 "devices rediscovered after broker restart",
+                interval=0.05,
             )
         assert not [e for e in events if e[1] == DeviceState.OFFLINE], (
             "broker outage must not flip devices OFFLINE"
@@ -256,7 +251,12 @@ async def test_six_devices_two_logins_single_broadcaster(
         await coord.reconcile()
         assert coord.active_brokers == 2
         monitors = list(coord._monitors.values())
-        await _wait_for(lambda: all(m.connected for m in monitors), 10.0, "both logins connected")
+        await wait_until(
+            lambda: all(m.connected for m in monitors),
+            10.0,
+            "both logins connected",
+            interval=0.05,
+        )
 
         # Idle: connected and subscribed, but not a single broadcast.
         await asyncio.sleep(1.0)
@@ -264,10 +264,11 @@ async def test_six_devices_two_logins_single_broadcaster(
         assert states == {}
 
         with presence.subscriber():
-            await _wait_for(
+            await wait_until(
                 lambda: all(states.get(f"dev{i}") == DeviceState.ONLINE for i in range(1, 7)),
                 10.0,
                 "all six devices ONLINE",
+                interval=0.05,
             )
             assert ips["dev1"] == "10.0.0.1"
             # One elected broadcaster per broker — two logins must not
@@ -276,7 +277,12 @@ async def test_six_devices_two_logins_single_broadcaster(
 
             # A device that stops answering ages out OFFLINE.
             fakes[0].answering = False
-            await _wait_for(lambda: states.get("dev1") == DeviceState.OFFLINE, 10.0, "dev1 OFFLINE")
+            await wait_until(
+                lambda: states.get("dev1") == DeviceState.OFFLINE,
+                10.0,
+                "dev1 OFFLINE",
+                interval=0.05,
+            )
 
         # Dashboard gone: broadcasts stop again (allow one in-flight tick).
         await asyncio.sleep(0.5)

--- a/tests/test_ping_loop_pause.py
+++ b/tests/test_ping_loop_pause.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from collections.abc import Callable
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -33,6 +32,8 @@ from esphome_device_builder.controllers._device_state_monitor._state import Moni
 from esphome_device_builder.controllers._device_state_monitor.ping import PingSource
 from esphome_device_builder.device_builder import DeviceBuilder
 from esphome_device_builder.helpers.subscriber_presence import SubscriberPresence
+
+from .conftest import wait_until
 
 
 def _build_monitor(presence: SubscriberPresence | None) -> DeviceStateMonitor:
@@ -78,16 +79,6 @@ def _instrument_loop(
     return counts
 
 
-async def _drive_until(condition: Callable[[], object], *, timeout: float = 0.5) -> None:
-    """Wait for *condition()* to become truthy or raise on timeout."""
-
-    async def _spin() -> None:
-        while not condition():
-            await asyncio.sleep(0)
-
-    await asyncio.wait_for(_spin(), timeout=timeout)
-
-
 async def test_ping_loop_runs_unconditionally_without_presence(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -103,7 +94,7 @@ async def test_ping_loop_runs_unconditionally_without_presence(
 
     task = asyncio.create_task(monitor.ping.run())
     try:
-        await _drive_until(lambda: counts["sweeps"] >= 2)
+        await wait_until(lambda: counts["sweeps"] >= 2, 0.5, "two sweeps")
     finally:
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
@@ -127,7 +118,7 @@ async def test_ping_loop_survives_a_raising_resolve_step(
 
     task = asyncio.create_task(monitor.ping.run())
     try:
-        await _drive_until(lambda: counts["sweeps"] >= 2)
+        await wait_until(lambda: counts["sweeps"] >= 2, 0.5, "two sweeps")
     finally:
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
@@ -152,7 +143,7 @@ async def test_ping_loop_survives_a_raising_ping_sweep(
 
     task = asyncio.create_task(monitor.ping.run())
     try:
-        await _drive_until(lambda: counts["sweeps"] >= 2)
+        await wait_until(lambda: counts["sweeps"] >= 2, 0.5, "two sweeps")
     finally:
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
@@ -206,7 +197,7 @@ async def test_ping_loop_parks_until_first_subscriber(
 
         # 0→1 transition must wake the loop within one scheduling tick.
         with presence.subscriber():
-            await _drive_until(lambda: counts["sweeps"] >= 1)
+            await wait_until(lambda: counts["sweeps"] >= 1, 0.5, "a sweep")
     finally:
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
@@ -233,7 +224,7 @@ async def test_ping_loop_pauses_again_after_last_subscriber_leaves(
     try:
         # Cycle one subscriber in, drive at least one sweep, then out.
         with presence.subscriber():
-            await _drive_until(lambda: counts["sweeps"] >= 1)
+            await wait_until(lambda: counts["sweeps"] >= 1, 0.5, "a sweep")
         sweeps_at_disconnect = counts["sweeps"]
 
         # After disconnect, give the loop several ticks. The count
@@ -305,11 +296,11 @@ async def test_subscriber_arrival_mid_idle_bails_within_a_tick(
     task = asyncio.create_task(monitor.ping.run())
     try:
         with presence.subscriber():
-            await _drive_until(lambda: counts["sweeps"] >= 1)
+            await wait_until(lambda: counts["sweeps"] >= 1, 0.5, "a sweep")
         sweeps_after_a = counts["sweeps"]
 
         with presence.subscriber():
-            await _drive_until(lambda: counts["sweeps"] > sweeps_after_a)
+            await wait_until(lambda: counts["sweeps"] > sweeps_after_a, 0.5, "a fresh sweep")
     finally:
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):

--- a/tests/test_remote_build_only.py
+++ b/tests/test_remote_build_only.py
@@ -36,7 +36,7 @@ from esphome_device_builder.helpers.event_bus import EventBus
 from esphome_device_builder.helpers.pin_emoji import pin_emoji, pin_emoji_names
 from esphome_device_builder.models import EventType, StoredPeer
 
-from .conftest import MakeSettingsFactory, make_remote_build_controller
+from .conftest import MakeSettingsFactory, make_remote_build_controller, wait_until
 from .conftest import RemoteBuildTestHandles as RemoteBuildController
 
 _RBO_LOGGER = "esphome_device_builder._remote_build_only"
@@ -74,14 +74,6 @@ async def _send_pair_request(
         peer_ip=peer_ip,
         pairing_key=pairing_key,
     )
-
-
-async def _wait_until(predicate: Any, timeout: float = 2.0) -> None:
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + timeout
-    while not predicate():
-        assert loop.time() < deadline, "condition not reached in time"
-        await asyncio.sleep(0.01)
 
 
 class _FakeDB:
@@ -341,7 +333,7 @@ async def test_bootstrap_first_pair_success(
 
     with caplog.at_level("INFO", logger=_RBO_LOGGER):
         bootstrap = asyncio.create_task(rbo._bootstrap_first_pair(db, receiver))
-        await _wait_until(receiver.is_pairing_window_open)
+        await wait_until(receiver.is_pairing_window_open, 2.0, "pairing window open")
         assert receiver.state.auto_approve_first_pair
         key = receiver.state.bootstrap_pairing_key
         assert key is not None
@@ -396,7 +388,7 @@ async def test_bootstrap_banner_key_survives_pair_during_identity_load(
 
     with patch.object(rbo, "_log_pairing_banner", _spy):
         bootstrap = asyncio.create_task(rbo._bootstrap_first_pair(db, receiver))
-        await _wait_until(receiver.is_pairing_window_open)
+        await wait_until(receiver.is_pairing_window_open, 2.0, "pairing window open")
         key = receiver.state.bootstrap_pairing_key
         response = await _send_pair_request(
             RemoteBuildController(MagicMock(), receiver), pairing_key=key
@@ -419,7 +411,7 @@ async def test_bootstrap_first_pair_with_source_allowlist(
 
     with caplog.at_level("INFO", logger=_RBO_LOGGER):
         bootstrap = asyncio.create_task(rbo._bootstrap_first_pair(db, receiver))
-        await _wait_until(receiver.is_pairing_window_open)
+        await wait_until(receiver.is_pairing_window_open, 2.0, "pairing window open")
         key = receiver.state.bootstrap_pairing_key
         assert key is not None
 
@@ -483,12 +475,12 @@ async def test_serve_parks_after_bootstrap_pair(tmp_path: Path) -> None:
     assert receiver is not None
     serve = asyncio.create_task(rbo._serve(db))  # type: ignore[arg-type]
 
-    await _wait_until(receiver.is_pairing_window_open)
+    await wait_until(receiver.is_pairing_window_open, 2.0, "pairing window open")
     await _send_pair_request(
         RemoteBuildController(MagicMock(), receiver),
         pairing_key=receiver.state.bootstrap_pairing_key,
     )
-    await _wait_until(lambda: not receiver.is_pairing_window_open())
+    await wait_until(lambda: not receiver.is_pairing_window_open(), 2.0, "pairing window closed")
     await asyncio.sleep(0.05)
 
     assert not serve.done()

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -21,7 +21,7 @@ import asyncio
 import hashlib
 import json
 import secrets
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -109,6 +109,7 @@ from .conftest import (
     make_submit_job_frames,
     make_tar_bundle,
     reset_offloader_firmware_stub,
+    wait_until,
 )
 
 
@@ -119,27 +120,6 @@ def _make_controller(*, config_dir: Any = None) -> RemoteBuildController:
 def _seed_peer(controller: RemoteBuildController, peer: StoredPeer) -> None:
     """Insert *peer* into the controller's RAM-canonical APPROVED dict."""
     controller.receiver.state.approved_peers[peer.dashboard_id] = peer
-
-
-async def _wait_until(condition: Callable[[], bool], *, timeout: float = 10.0) -> None:
-    """Yield to the loop until *condition()* returns truthy or *timeout* elapses.
-
-    Raises :exc:`TimeoutError` (via :func:`asyncio.wait_for`) when
-    the condition stays false past *timeout* — surfaces a
-    deterministic failure in place of a silent
-    ``for _ in range(N): sleep(0)`` loop that would otherwise
-    fall through and let the next assertion produce a misleading
-    error message. Use for waits whose synchronisation source is
-    a piece of mutated state (registry dict membership, attribute
-    flip) rather than a callback we can wire an
-    :class:`asyncio.Event` into.
-    """
-
-    async def _spin() -> None:
-        while not condition():
-            await asyncio.sleep(0)
-
-    await asyncio.wait_for(_spin(), timeout=timeout)
 
 
 # ---------------------------------------------------------------------------
@@ -1265,7 +1245,11 @@ async def test_e2e_peer_link_session_stays_open_after_intent_response(
         # registration happens just before. If the WS closed
         # instead, ``"alpha"`` would never land in the dict and
         # the wait would time out (deterministic failure).
-        await _wait_until(lambda: "alpha" in controller.receiver.state.peer_link_sessions)
+        await wait_until(
+            lambda: "alpha" in controller.receiver.state.peer_link_sessions,
+            10.0,
+            "alpha peer-link session registered",
+        )
         assert not ws.closed
     finally:
         await ws.close()
@@ -1364,13 +1348,21 @@ async def test_e2e_peer_link_session_unregistered_on_peer_close(
     _session, ws, _ = await _drive_peer_link_session_open(
         client, dashboard_id="alpha", initiator_priv=initiator_priv
     )
-    await _wait_until(lambda: "alpha" in controller.receiver.state.peer_link_sessions)
+    await wait_until(
+        lambda: "alpha" in controller.receiver.state.peer_link_sessions,
+        10.0,
+        "alpha peer-link session registered",
+    )
 
     await ws.close()
 
     # The receiver's session loop sees the close, exits, and
     # ``unregister_peer_link_session`` runs in its ``finally``.
-    await _wait_until(lambda: "alpha" not in controller.receiver.state.peer_link_sessions)
+    await wait_until(
+        lambda: "alpha" not in controller.receiver.state.peer_link_sessions,
+        10.0,
+        "alpha peer-link session unregistered",
+    )
 
 
 async def test_e2e_peer_link_session_drained_on_controller_stop(
@@ -1395,7 +1387,11 @@ async def test_e2e_peer_link_session_drained_on_controller_stop(
         client, dashboard_id="alpha", initiator_priv=initiator_priv
     )
     try:
-        await _wait_until(lambda: "alpha" in controller.receiver.state.peer_link_sessions)
+        await wait_until(
+            lambda: "alpha" in controller.receiver.state.peer_link_sessions,
+            10.0,
+            "alpha peer-link session registered",
+        )
 
         # ``stop()`` runs in the same loop; the test fixture
         # also calls ``stop()`` on teardown but we drive it

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -43,7 +43,7 @@ from esphome_device_builder.controllers._reachability_tracker import Reachabilit
 from esphome_device_builder.helpers.async_ import log_task_exit
 from esphome_device_builder.models import RUNTIME_STATE_FIELD_NAMES, Device, DeviceState
 
-from .conftest import RecordingMonitorCallbacks, stub_async_service_info
+from .conftest import RecordingMonitorCallbacks, stub_async_service_info, wait_until
 from .conftest import make_device as _device
 
 # The service-type strings the production code uses; pinned here so
@@ -182,13 +182,7 @@ async def _wait_for_ping_sweep(
     if until is None:
         await asyncio.sleep(0.05)
         return
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + 5.0
-    while not until():
-        if loop.time() >= deadline:
-            msg = "ping loop did not reach the expected state within 5s"
-            raise AssertionError(msg)
-        await asyncio.sleep(0.01)
+    await wait_until(until, 5.0, "the ping loop's expected state", interval=0.01)
 
 
 async def _stop_and_drain(monitor: DeviceStateMonitor) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Extracts one shared async `wait_until(condition, timeout, what, *, interval=0)` into `tests/conftest.py` and collapses the test tree's private condition polling copies onto it. Exploration found seven, not five: the issue's list plus `_drive_until` in `test_ping_loop_pause.py` and the polling core of `_wait_for_ping_sweep` in `test_state_monitor_lifecycle.py`.

Timeouts stay per call site (the old defaults spanned 0.5 to 10 seconds, so no shared default is safe). The poll interval defaults to a bare loop yield, the tightest existing flavor; the e2e mqtt callers pass `interval=0.05` explicitly since they wait on a real mosquitto broker and a bare yield spin would burn CPU for wall clock time. The three `test_remote_runner.py` variants keep their names and their 40 call sites; only their bodies collapse to one delegating line each.

Failure semantics unify on the descriptive `pytest.fail("timed out waiting for {what}")`. The helpers that raised `TimeoutError` or bare `AssertionError` now fail the same way; verified no caller asserts on the old exception types.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2240

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
