### PR TITLE
Consolidate cancel-on-exit task teardowns into a shared running_task helper

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,8 @@ import logging
 import re
 import sys
 import tempfile as _tempfile
-from collections.abc import Callable, Iterator
+from collections.abc import AsyncIterator, Callable, Coroutine, Iterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
@@ -412,6 +413,21 @@ async def cancel_and_drain(task: asyncio.Task[Any]) -> None:
     """
     task.cancel()
     await asyncio.gather(task, return_exceptions=True)
+
+
+@asynccontextmanager
+async def running_task(coro: Coroutine[Any, Any, Any]) -> AsyncIterator[asyncio.Task[Any]]:
+    """Run *coro* as a background task, cancelling and draining it on exit.
+
+    Yields the :class:`asyncio.Task` so the body can await or inspect
+    it; teardown routes through :func:`cancel_and_drain`, never
+    ``suppress(CancelledError)``.
+    """
+    task = asyncio.create_task(coro)
+    try:
+        yield task
+    finally:
+        await cancel_and_drain(task)
 
 
 async def wait_until(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -417,17 +417,24 @@ async def cancel_and_drain(task: asyncio.Task[Any]) -> None:
 
 @asynccontextmanager
 async def running_task(coro: Coroutine[Any, Any, Any]) -> AsyncIterator[asyncio.Task[Any]]:
-    """Run *coro* as a background task, cancelling and draining it on exit.
+    """
+    Run *coro* as a background task, cancelling and draining it on exit.
 
     Yields the :class:`asyncio.Task` so the body can await or inspect
-    it; teardown routes through :func:`cancel_and_drain`, never
-    ``suppress(CancelledError)``.
+    it. On exit the task is cancelled and its ``CancelledError``
+    swallowed; any other exception it finished with is re-raised (when
+    the body itself didn't raise) so a crashed background task can't
+    pass silently.
     """
     task = asyncio.create_task(coro)
     try:
         yield task
     finally:
-        await cancel_and_drain(task)
+        task.cancel()
+        result = await asyncio.gather(task, return_exceptions=True)
+    exc = result[0]
+    if isinstance(exc, BaseException) and not isinstance(exc, asyncio.CancelledError):
+        raise exc
 
 
 async def wait_until(

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -11,9 +11,8 @@ Covers the parts that don't require a live broker:
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import json
-from collections.abc import AsyncIterator, Callable
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, ClassVar
 from unittest.mock import patch
@@ -39,6 +38,8 @@ from esphome_device_builder.controllers._device_state_monitor import DeviceState
 from esphome_device_builder.helpers.device_yaml import device_uses_mqtt
 from esphome_device_builder.helpers.subscriber_presence import SubscriberPresence
 from esphome_device_builder.models import Device, DeviceState
+
+from .conftest import running_task
 
 # ---------------------------------------------------------------------------
 # YAML detection
@@ -1085,13 +1086,8 @@ async def test_listen_drops_retained_discover_messages() -> None:
     await queue.put(_RetainedMessage())
     await queue.put(_FreshMessage())
 
-    listen_task = asyncio.create_task(monitor._listen(queue))
-    try:
+    async with running_task(monitor._listen(queue)):
         await asyncio.wait_for(fresh_seen.wait(), timeout=1.0)
-    finally:
-        listen_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await listen_task
 
     # Only the fresh message produced a callback — the retained one was dropped.
     assert state_calls == [("kitchen", DeviceState.ONLINE)]
@@ -1133,13 +1129,8 @@ async def test_listen_skips_empty_payload() -> None:
     await queue.put(_EmptyPayloadMessage())
     await queue.put(_FreshMessage())
 
-    listen_task = asyncio.create_task(monitor._listen(queue))
-    try:
+    async with running_task(monitor._listen(queue)):
         await asyncio.wait_for(fresh_seen.wait(), timeout=1.0)
-    finally:
-        listen_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await listen_task
 
     assert state_calls == [("kitchen", DeviceState.ONLINE)]
 
@@ -1179,13 +1170,8 @@ async def test_listen_drops_non_json_payload(caplog: pytest.LogCaptureFixture) -
     await queue.put(_FreshMessage())
 
     with caplog.at_level("DEBUG", logger="esphome_device_builder.controllers._device_mqtt_monitor"):
-        listen_task = asyncio.create_task(monitor._listen(queue))
-        try:
+        async with running_task(monitor._listen(queue)):
             await asyncio.wait_for(fresh_seen.wait(), timeout=1.0)
-        finally:
-            listen_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await listen_task
 
     assert state_calls == [("kitchen", DeviceState.ONLINE)]
     # Pin the log emission too — without this, a regression that
@@ -1245,13 +1231,8 @@ async def test_listen_skips_payload_with_missing_or_invalid_name() -> None:
     await queue.put(_NumericNameMessage())
     await queue.put(_FreshMessage())
 
-    listen_task = asyncio.create_task(monitor._listen(queue))
-    try:
+    async with running_task(monitor._listen(queue)):
         await asyncio.wait_for(fresh_seen.wait(), timeout=1.0)
-    finally:
-        listen_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await listen_task
 
     # Only the well-formed message fired the callback.
     assert state_calls == [("kitchen", DeviceState.ONLINE)]
@@ -1281,13 +1262,8 @@ async def test_listen_processes_fresh_discover_messages() -> None:
     queue: asyncio.Queue = asyncio.Queue()
     await queue.put(_FreshMessage())
 
-    listen_task = asyncio.create_task(monitor._listen(queue))
-    try:
+    async with running_task(monitor._listen(queue)):
         await asyncio.wait_for(seen.wait(), timeout=1.0)
-    finally:
-        listen_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await listen_task
 
     assert state_calls == [("kitchen", DeviceState.ONLINE)]
     assert ip_calls == [("kitchen", "10.0.0.5")]
@@ -1344,13 +1320,9 @@ async def test_running_reflects_task_state() -> None:
     # Stand-in for the listener task — never resolves so the
     # monitor stays in the "running" state until we cancel it.
     parked = asyncio.Event()
-    monitor._task = asyncio.create_task(parked.wait())
-    try:
+    async with running_task(parked.wait()) as task:
+        monitor._task = task
         assert monitor.running is True
-    finally:
-        monitor._task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await monitor._task
 
     # A done task no longer counts as running.
     assert monitor.running is False
@@ -1394,15 +1366,10 @@ async def test_start_is_idempotent_when_already_running() -> None:
         on_ip_change=lambda *_: None,
     )
     parked = asyncio.Event()
-    monitor._task = asyncio.create_task(parked.wait())
-    original_task = monitor._task
-    try:
+    async with running_task(parked.wait()) as task:
+        monitor._task = task
         await monitor.start()
-        assert monitor._task is original_task  # no replacement
-    finally:
-        monitor._task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await monitor._task
+        assert monitor._task is task  # no replacement
 
 
 async def test_stop_cancels_task_and_clears_last_seen() -> None:
@@ -1485,7 +1452,7 @@ async def test_ping_loop_marks_stale_devices_offline_and_republishes(
     loop = asyncio.get_running_loop()
     monitor._last_seen["ghost"] = loop.time() - 1.0
 
-    async with _running_ping_loop(monitor, fake):
+    async with running_task(monitor._ping_loop(fake)):
         await asyncio.wait_for(offline_seen.wait(), timeout=2.0)
 
     assert ("ghost", DeviceState.OFFLINE) in state_calls
@@ -1510,19 +1477,6 @@ class _CountingClient:
         return _PublishInfo()
 
 
-@contextlib.asynccontextmanager
-async def _running_ping_loop(
-    monitor: DeviceMqttMonitor, client: _CountingClient
-) -> AsyncIterator[None]:
-    task = asyncio.create_task(monitor._ping_loop(client))
-    try:
-        yield
-    finally:
-        task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await task
-
-
 async def test_ping_loop_idle_publishes_nothing_and_freezes_aging(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1543,7 +1497,7 @@ async def test_ping_loop_idle_publishes_nothing_and_freezes_aging(
     loop = asyncio.get_running_loop()
     monitor._last_seen["ghost"] = loop.time() - 1.0
 
-    async with _running_ping_loop(monitor, fake):
+    async with running_task(monitor._ping_loop(fake)):
         # Several would-be intervals pass; the parked loop stays silent.
         await asyncio.sleep(0.3)
         assert fake.publishes == []
@@ -1572,7 +1526,7 @@ async def test_ping_loop_resume_publishes_immediately_and_rebases(
     stale_stamp = loop.time() - 100.0
     monitor._last_seen["sleeper"] = stale_stamp
 
-    async with _running_ping_loop(monitor, fake):
+    async with running_task(monitor._ping_loop(fake)):
         await asyncio.sleep(0.1)
         assert fake.publishes == []
 
@@ -1605,7 +1559,7 @@ async def test_ping_loop_non_publisher_is_a_pure_listener(
     loop = asyncio.get_running_loop()
     monitor._last_seen["ghost"] = loop.time() - 1.0
 
-    async with _running_ping_loop(monitor, fake):
+    async with running_task(monitor._ping_loop(fake)):
         await asyncio.sleep(0.3)
         assert fake.publishes == []
         assert state_calls == []
@@ -1637,7 +1591,7 @@ async def test_ping_loop_failed_broadcast_pauses_aging_and_warns_once(
     monitor._last_seen["ghost"] = loop.time() - 1.0
 
     with caplog.at_level("DEBUG", logger="esphome_device_builder.controllers._device_mqtt_monitor"):
-        async with _running_ping_loop(monitor, fake):
+        async with running_task(monitor._ping_loop(fake)):
             for _ in range(100):
                 if len(fake.publishes) >= 3:
                     break
@@ -1736,7 +1690,7 @@ async def test_ping_loop_subscriber_return_cuts_interval_sleep_short(
     )
     fake = _CountingClient()
 
-    async with _running_ping_loop(monitor, fake):
+    async with running_task(monitor._ping_loop(fake)):
         with presence.subscriber():
             for _ in range(100):
                 if fake.publishes:
@@ -1895,14 +1849,9 @@ async def test_connect_and_listen_subscribes_publishes_and_runs_listen_ping(
     monkeypatch.setattr(monitor, "_listen", _fake_listen)
     monkeypatch.setattr(monitor, "_ping_loop", _fake_ping)
 
-    task = asyncio.create_task(monitor._connect_and_listen("test-id"))
-    try:
+    async with running_task(monitor._connect_and_listen("test-id")):
         await asyncio.wait_for(listen_started.wait(), timeout=2.0)
         await asyncio.wait_for(ping_started.wait(), timeout=2.0)
-    finally:
-        task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await task
 
     op_names = [c[0] for c in calls]
     # Ordered: init → username/pw → connect → loop_start (whose CONNACK
@@ -2123,16 +2072,11 @@ async def test_idle_monitor_still_applies_spontaneous_announcements() -> None:
             },
         )()
     )
-    listen_task = asyncio.create_task(monitor._listen(queue))
-    try:
+    async with running_task(monitor._listen(queue)):
         for _ in range(100):
             if state_calls:
                 break
             await asyncio.sleep(0.01)
-    finally:
-        listen_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await listen_task
 
     assert state_calls == [("kitchen", DeviceState.ONLINE)]
     assert "kitchen" in monitor._last_seen
@@ -2219,18 +2163,13 @@ async def test_reconnect_refires_subscribe_via_on_connect(
 
     monkeypatch.setattr(monitor_module, "paho_mqtt", type("M", (), {"Client": _FakeClient}))
 
-    task = asyncio.create_task(monitor._connect_and_listen("test-id"))
-    try:
+    async with running_task(monitor._connect_and_listen("test-id")):
         await asyncio.wait_for(subscribed.wait(), timeout=2.0)
         assert subscribes == ["esphome/discover/#"]
         # paho's auto-reconnect re-fires on_connect from its thread;
         # the callback alone must re-establish the subscription.
         instances[0].on_connect(instances[0], None, None, 0)
         assert subscribes == ["esphome/discover/#", "esphome/discover/#"]
-    finally:
-        task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await task
 
 
 async def test_connect_and_listen_raises_on_broker_rejection(
@@ -2309,13 +2248,8 @@ async def test_run_reconnects_on_connect_and_listen_failure(
 
     monkeypatch.setattr(monitor, "_connect_and_listen", _fake_connect)
 
-    run_task = asyncio.create_task(monitor._run())
-    try:
+    async with running_task(monitor._run()):
         await asyncio.wait_for(second_call.wait(), timeout=2.0)
-    finally:
-        run_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await run_task
 
     assert call_count >= 2
     # First-attempt error cleared last_seen — pin the contract
@@ -2362,13 +2296,8 @@ async def test_run_collapses_repeat_unreachable_errors_to_debug(
 
     caplog.set_level("DEBUG", logger=monitor_module.__name__)
 
-    run_task = asyncio.create_task(monitor._run())
-    try:
+    async with running_task(monitor._run()):
         await asyncio.wait_for(third_call.wait(), timeout=2.0)
-    finally:
-        run_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await run_task
 
     unreachable = [
         r
@@ -2438,16 +2367,11 @@ async def test_run_resets_log_gate_after_successful_connect(
 
     caplog.set_level("DEBUG", logger=monitor_module.__name__)
 
-    run_task = asyncio.create_task(monitor._run())
-    try:
+    async with running_task(monitor._run()):
         await asyncio.wait_for(third_failure.wait(), timeout=2.0)
         # Give the loop one extra tick to log the third failure
         # before we tear it down.
         await asyncio.sleep(0.05)
-    finally:
-        run_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await run_task
 
     warnings = [
         r
@@ -2517,14 +2441,9 @@ async def test_run_loud_logs_unexpected_after_expected_failure(
 
     caplog.set_level("DEBUG", logger=monitor_module.__name__)
 
-    run_task = asyncio.create_task(monitor._run())
-    try:
+    async with running_task(monitor._run()):
         await asyncio.wait_for(second_call.wait(), timeout=2.0)
         await asyncio.sleep(0.05)
-    finally:
-        run_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await run_task
 
     errors = [
         r
@@ -2578,13 +2497,8 @@ async def test_run_collapses_repeat_unexpected_errors_to_debug(
 
     caplog.set_level("DEBUG", logger=monitor_module.__name__)
 
-    run_task = asyncio.create_task(monitor._run())
-    try:
+    async with running_task(monitor._run()):
         await asyncio.wait_for(third_call.wait(), timeout=2.0)
-    finally:
-        run_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await run_task
 
     errors = [
         r

--- a/tests/test_ping_loop_pause.py
+++ b/tests/test_ping_loop_pause.py
@@ -33,7 +33,7 @@ from esphome_device_builder.controllers._device_state_monitor.ping import PingSo
 from esphome_device_builder.device_builder import DeviceBuilder
 from esphome_device_builder.helpers.subscriber_presence import SubscriberPresence
 
-from .conftest import wait_until
+from .conftest import running_task, wait_until
 
 
 def _build_monitor(presence: SubscriberPresence | None) -> DeviceStateMonitor:
@@ -92,13 +92,8 @@ async def test_ping_loop_runs_unconditionally_without_presence(
     monitor = _build_monitor(presence=None)
     counts = _instrument_loop(monitor, monkeypatch)
 
-    task = asyncio.create_task(monitor.ping.run())
-    try:
+    async with running_task(monitor.ping.run()):
         await wait_until(lambda: counts["sweeps"] >= 2, 0.5, "two sweeps")
-    finally:
-        task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await task
 
     assert counts["sweeps"] >= 2
     assert counts["resolves"] >= 2
@@ -116,13 +111,8 @@ async def test_ping_loop_survives_a_raising_resolve_step(
 
     monkeypatch.setattr(shared_module, "resolve_api_mdns_targets", _boom)
 
-    task = asyncio.create_task(monitor.ping.run())
-    try:
+    async with running_task(monitor.ping.run()):
         await wait_until(lambda: counts["sweeps"] >= 2, 0.5, "two sweeps")
-    finally:
-        task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await task
 
     assert counts["sweeps"] >= 2
 
@@ -141,13 +131,8 @@ async def test_ping_loop_survives_a_raising_ping_sweep(
 
     monitor.ping._ping_sweep = _flaky_sweep  # type: ignore[method-assign]
 
-    task = asyncio.create_task(monitor.ping.run())
-    try:
+    async with running_task(monitor.ping.run()):
         await wait_until(lambda: counts["sweeps"] >= 2, 0.5, "two sweeps")
-    finally:
-        task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await task
 
     assert counts["sweeps"] >= 2
 
@@ -186,8 +171,7 @@ async def test_ping_loop_parks_until_first_subscriber(
     monitor = _build_monitor(presence=presence)
     counts = _instrument_loop(monitor, monkeypatch)
 
-    task = asyncio.create_task(monitor.ping.run())
-    try:
+    async with running_task(monitor.ping.run()):
         # Give the loop several scheduling ticks to confirm it
         # actually parks instead of running. Without the gate fix
         # ``_ping_sweep`` would have fired on the first tick.
@@ -198,10 +182,6 @@ async def test_ping_loop_parks_until_first_subscriber(
         # 0→1 transition must wake the loop within one scheduling tick.
         with presence.subscriber():
             await wait_until(lambda: counts["sweeps"] >= 1, 0.5, "a sweep")
-    finally:
-        task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await task
 
     assert counts["sweeps"] >= 1
 
@@ -220,8 +200,7 @@ async def test_ping_loop_pauses_again_after_last_subscriber_leaves(
     monitor = _build_monitor(presence=presence)
     counts = _instrument_loop(monitor, monkeypatch)
 
-    task = asyncio.create_task(monitor.ping.run())
-    try:
+    async with running_task(monitor.ping.run()):
         # Cycle one subscriber in, drive at least one sweep, then out.
         with presence.subscriber():
             await wait_until(lambda: counts["sweeps"] >= 1, 0.5, "a sweep")
@@ -233,10 +212,6 @@ async def test_ping_loop_pauses_again_after_last_subscriber_leaves(
         # parks at the gate on the next iteration.
         for _ in range(20):
             await asyncio.sleep(0)
-    finally:
-        task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await task
 
     # At most one extra sweep can land — the one already past the
     # gate when the subscriber dropped. Anything more means the gate
@@ -293,17 +268,12 @@ async def test_subscriber_arrival_mid_idle_bails_within_a_tick(
     counts = _instrument_loop(monitor, monkeypatch)
     monkeypatch.setattr(PingSource, "_interval", 60)
 
-    task = asyncio.create_task(monitor.ping.run())
-    try:
+    async with running_task(monitor.ping.run()):
         with presence.subscriber():
             await wait_until(lambda: counts["sweeps"] >= 1, 0.5, "a sweep")
         sweeps_after_a = counts["sweeps"]
 
         with presence.subscriber():
             await wait_until(lambda: counts["sweeps"] > sweeps_after_a, 0.5, "a fresh sweep")
-    finally:
-        task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await task
 
     assert counts["sweeps"] >= sweeps_after_a + 1

--- a/tests/test_presence_gated_loop.py
+++ b/tests/test_presence_gated_loop.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
-from collections.abc import AsyncIterator
 
 import pytest
 
 from esphome_device_builder.helpers.presence_gated_loop import PresenceGatedLoop
 from esphome_device_builder.helpers.subscriber_presence import SubscriberPresence
+
+from .conftest import running_task
 
 
 class _RecordingLoop(PresenceGatedLoop[None]):
@@ -41,17 +41,6 @@ class _RecordingLoop(PresenceGatedLoop[None]):
             raise self.work_error
 
 
-@contextlib.asynccontextmanager
-async def _running(loop: PresenceGatedLoop) -> AsyncIterator[asyncio.Task[None]]:
-    task = asyncio.create_task(loop.run())
-    try:
-        yield task
-    finally:
-        task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await task
-
-
 async def test_base_demands_work() -> None:
     """The bare base has no ``_work``."""
     with pytest.raises(NotImplementedError):
@@ -61,7 +50,7 @@ async def test_base_demands_work() -> None:
 async def test_runs_unconditionally_without_presence() -> None:
     """presence=None means no gate: ticks flow with no subscriber anywhere."""
     loop = _RecordingLoop(None)
-    async with _running(loop):
+    async with running_task(loop.run()):
         await loop.wait_for_ticks(2)
     assert loop.resumes == 0
 
@@ -70,7 +59,7 @@ async def test_parks_until_first_subscriber_then_resumes() -> None:
     """The loop parks with no work done, and a real park fires ``_on_resume``."""
     presence = SubscriberPresence()
     loop = _RecordingLoop(presence)
-    async with _running(loop):
+    async with running_task(loop.run()):
         for _ in range(10):
             await asyncio.sleep(0)
         assert loop.ticks == 0
@@ -84,7 +73,7 @@ async def test_no_resume_hook_when_gate_already_open() -> None:
     presence = SubscriberPresence()
     loop = _RecordingLoop(presence)
     with presence.subscriber():
-        async with _running(loop):
+        async with running_task(loop.run()):
             await loop.wait_for_ticks(3)
     assert loop.resumes == 0
 
@@ -94,7 +83,7 @@ async def test_subscriber_return_cuts_idle_short() -> None:
     presence = SubscriberPresence()
     loop = _RecordingLoop(presence)
     loop._interval = 60
-    async with _running(loop):
+    async with running_task(loop.run()):
         with presence.subscriber():
             await loop.wait_for_ticks(1)
         with presence.subscriber():
@@ -112,7 +101,7 @@ async def test_wake_mid_work_short_circuits_following_idle() -> None:
 
     loop = _SelfWaking(None)
     loop._interval = 60
-    async with _running(loop):
+    async with running_task(loop.run()):
         await loop.wait_for_ticks(2)
 
 
@@ -121,7 +110,7 @@ async def test_continue_on_error_logs_and_keeps_looping(
 ) -> None:
     loop = _RecordingLoop(None)
     loop.work_error = RuntimeError("boom")
-    async with _running(loop):
+    async with running_task(loop.run()):
         await loop.wait_for_ticks(2)
     assert "test loop failed; continuing" in caplog.text
 
@@ -133,7 +122,7 @@ async def test_crash_continue_collapses_repeat_logs_until_recovery(
     loop = _RecordingLoop(None)
     loop.work_error = RuntimeError("boom")
     with caplog.at_level(logging.DEBUG, logger=PresenceGatedLoop.__module__):
-        async with _running(loop):
+        async with running_task(loop.run()):
             await loop.wait_for_ticks(2)
             loop.work_error = None
             await loop.wait_for_ticks(3)
@@ -178,7 +167,7 @@ async def test_cancellation_is_never_swallowed() -> None:
 async def test_run_refuses_concurrent_reentry() -> None:
     """A second concurrent ``run()`` raises instead of silently double-ticking."""
     loop = _RecordingLoop(None)
-    async with _running(loop):
+    async with running_task(loop.run()):
         await loop.wait_for_ticks(1)
         with pytest.raises(RuntimeError, match="already running"):
             await loop.run()
@@ -187,9 +176,9 @@ async def test_run_refuses_concurrent_reentry() -> None:
 async def test_run_is_rerunnable_after_cancellation() -> None:
     """Sequential re-runs work — the MQTT loop re-runs per broker session."""
     loop = _RecordingLoop(None)
-    async with _running(loop):
+    async with running_task(loop.run()):
         await loop.wait_for_ticks(1)
-    async with _running(loop):
+    async with running_task(loop.run()):
         await loop.wait_for_ticks(2)
 
 
@@ -218,7 +207,7 @@ async def test_after_idle_gets_the_result_and_skips_crashed_ticks() -> None:
                 done.set()
 
     loop = _Flaky()
-    async with _running(loop):
+    async with running_task(loop.run()):
         async with asyncio.timeout(1):
             await done.wait()
     assert seen[:2] == [1, 3]

--- a/tests/test_probe_device_ping.py
+++ b/tests/test_probe_device_ping.py
@@ -3,16 +3,11 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator, Callable
-from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 
 import pytest
 
 from esphome_device_builder.controllers._device_state_monitor import ping as ping_module
-from esphome_device_builder.controllers._device_state_monitor.controller import (
-    DeviceStateMonitor,
-)
 from esphome_device_builder.models import (
     Device,
     DeviceRuntimeState,
@@ -20,7 +15,7 @@ from esphome_device_builder.models import (
     ReachabilitySource,
 )
 
-from .conftest import make_state_monitor_with_callbacks
+from .conftest import make_state_monitor_with_callbacks, running_task, wait_until
 
 
 def _ping_only_device(name: str = "garage", state: DeviceState = DeviceState.UNKNOWN) -> Device:
@@ -70,25 +65,6 @@ def _patch_loop_for_wake_tests(monkeypatch: pytest.MonkeyPatch) -> None:
         return None
 
     monkeypatch.setattr(ping_module.shared, "resolve_non_api_mdns_targets", _noop_resolve)
-
-
-@asynccontextmanager
-async def _running_loop(monitor: DeviceStateMonitor) -> AsyncIterator[None]:
-    """Spawn ``monitor.ping.run()`` and cancel + drain on exit."""
-    task = asyncio.create_task(monitor.ping.run())
-    try:
-        yield
-    finally:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
-
-
-async def _yield_until(predicate: Callable[[], bool], iterations: int = 50) -> None:
-    """Yield to the event loop until *predicate()* is truthy or *iterations* elapse."""
-    for _ in range(iterations):
-        if predicate():
-            return
-        await asyncio.sleep(0)
 
 
 def test_probe_device_ping_sets_wake_event() -> None:
@@ -165,13 +141,13 @@ async def test_wake_bails_idle_wait_early(monkeypatch: pytest.MonkeyPatch) -> No
     monitor, _ = make_state_monitor_with_callbacks([_ping_only_device()])
     sweeps = _install_sweep_probe(monkeypatch)
 
-    async with _running_loop(monitor):
-        await _yield_until(lambda: sweeps.count >= 1)
+    async with running_task(monitor.ping.run()):
+        await wait_until(lambda: sweeps.count >= 1, 1, "the first sweep")
         assert sweeps.count == 1
 
         monitor.probe_device_ping("garage")
 
-        await _yield_until(lambda: sweeps.count >= 2)
+        await wait_until(lambda: sweeps.count >= 2, 1, "the second sweep")
         assert sweeps.count == 2
 
 
@@ -181,10 +157,10 @@ async def test_wake_during_sweep_triggers_followup(monkeypatch: pytest.MonkeyPat
     monitor, _ = make_state_monitor_with_callbacks([_ping_only_device()])
     sweeps = _install_sweep_probe(monkeypatch, block_first=True)
 
-    async with _running_loop(monitor):
+    async with running_task(monitor.ping.run()):
         await asyncio.wait_for(sweeps.first_entered.wait(), timeout=1)
         monitor.probe_device_ping("garage")
         sweeps.release_first.set()
 
-        await _yield_until(lambda: sweeps.count >= 2)
+        await wait_until(lambda: sweeps.count >= 2, 1, "the follow-up sweep")
         assert sweeps.count == 2

--- a/tests/test_running_task.py
+++ b/tests/test_running_task.py
@@ -1,0 +1,47 @@
+"""Tests for the shared ``running_task`` background-task context manager."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from .conftest import running_task
+
+
+async def test_running_task_cancels_the_task_on_exit() -> None:
+    """A still-running task is cancelled and drained when the block exits."""
+    started = asyncio.Event()
+
+    async def _forever() -> None:
+        started.set()
+        await asyncio.sleep(3600)
+
+    async with running_task(_forever()) as task:
+        await started.wait()
+        assert not task.done()
+
+    assert task.cancelled()
+
+
+async def test_running_task_reraises_a_background_crash() -> None:
+    """A task that dies with a non-cancellation error surfaces instead of being swallowed."""
+
+    async def _boom() -> None:
+        raise RuntimeError("background boom")
+
+    with pytest.raises(RuntimeError, match="background boom"):
+        async with running_task(_boom()):
+            await asyncio.sleep(0)  # let it crash before the block exits
+
+
+async def test_running_task_does_not_mask_a_body_failure() -> None:
+    """A failure inside the block wins over a concurrent background crash."""
+
+    async def _boom() -> None:
+        raise RuntimeError("background boom")
+
+    with pytest.raises(AssertionError, match="body failed"):
+        async with running_task(_boom()):
+            await asyncio.sleep(0)
+            raise AssertionError("body failed")

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -43,7 +43,7 @@ from esphome_device_builder.controllers._reachability_tracker import Reachabilit
 from esphome_device_builder.helpers.async_ import log_task_exit
 from esphome_device_builder.models import RUNTIME_STATE_FIELD_NAMES, Device, DeviceState
 
-from .conftest import RecordingMonitorCallbacks, stub_async_service_info, wait_until
+from .conftest import RecordingMonitorCallbacks, running_task, stub_async_service_info, wait_until
 from .conftest import make_device as _device
 
 # The service-type strings the production code uses; pinned here so
@@ -291,11 +291,8 @@ async def test_interface_monitor_done_callback_silent_on_cancel(
     async def _forever() -> None:
         await asyncio.sleep(60)
 
-    task = asyncio.create_task(_forever())
-    await asyncio.sleep(0)
-    task.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await task
+    async with running_task(_forever()) as task:
+        await asyncio.sleep(0)
 
     with caplog.at_level(logging.ERROR):
         log_task_exit("Interface monitor", task)
@@ -1651,18 +1648,14 @@ async def test_dns_failure_flicker_does_not_re_emit_log(
     monitor.state.dns_cache.has_cached_failure = MagicMock(side_effect=_has_cached_failure)
     _shrink_ping_intervals(monkeypatch)
 
-    async def _wait_for_flicker() -> None:
-        # Drive the loop until ``zom.local`` has been re-examined
-        # enough times to cross the dns_failed boundary at least once;
-        # a fixed ``asyncio.sleep`` flakes on slow xdist workers when
-        # only the first sweep lands inside the window.
-        while cache_calls["n"] < 4:
-            await asyncio.sleep(0)
-
     with caplog.at_level(logging.DEBUG, logger=ping_module.__name__):
         await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
         try:
-            await asyncio.wait_for(_wait_for_flicker(), timeout=2.0)
+            await wait_until(
+                lambda: cache_calls["n"] >= 4,
+                2.0,
+                "zom.local to be re-examined across the dns_failed boundary",
+            )
         finally:
             await _stop_and_drain(monitor)
 


### PR DESCRIPTION
# What does this implement/fix?

Adds a shared `running_task(coro)` async context manager to `tests/conftest.py`, beside `cancel_and_drain` and `wait_until`, and routes every hand-rolled "create a background task, cancel it on exit" teardown across the test suite through it. Teardown runs through `cancel_and_drain` (cancel plus `gather(return_exceptions=True)`), so no call site suppresses `CancelledError` anymore; that was the repo convention these copies each broke.

It deletes the per-file copies (`_running_ping_loop`, `_running`, `_running_loop`) and folds the adjacent bespoke pollers (`_yield_until`, `_wait_for_flicker`) onto the existing `wait_until`. Blocks that await a task to natural completion inside `pytest.raises` / `asyncio.wait_for` to assert it raises, and teardowns driven by `monitor.stop()`, are left as-is since they are not cancel-on-exit teardowns.

Touched: `tests/test_mqtt_monitor.py`, `tests/test_ping_loop_pause.py`, `tests/test_presence_gated_loop.py`, `tests/test_probe_device_ping.py`, `tests/test_state_monitor_lifecycle.py`. Pure test refactor, no production code and no behaviour change; net 142 fewer lines. The condition-poller half of the same #2244 cleanup shipped in #2250. The remaining `suppress(CancelledError)` teardowns under `tests/controllers/firmware/` are a follow-up that reuses this same helper.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2244

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
