### PR TITLE
Migrate firmware test teardowns onto running_task

### DIFF
--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Iterator
-from contextlib import suppress
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
@@ -51,6 +50,8 @@ from esphome_device_builder.models import (
     PeerStatus,
     StoredPairing,
 )
+
+from ...conftest import running_task
 
 
 class EnqueueStep(StrEnum):
@@ -495,14 +496,9 @@ async def run_until_terminal(
             settled.set()
 
     bus.fire = _capture
-    runner_task = asyncio.create_task(controller._run_queue())
-    try:
+    async with running_task(controller._run_queue()):
         async with asyncio.timeout(timeout):
             await settled.wait()
-    finally:
-        runner_task.cancel()
-        with suppress(asyncio.CancelledError):
-            await runner_task
 
     return captured
 

--- a/tests/controllers/firmware/test_branches_coverage.py
+++ b/tests/controllers/firmware/test_branches_coverage.py
@@ -25,7 +25,6 @@ Surfaces touched here:
 from __future__ import annotations
 
 import asyncio
-import contextlib
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -46,6 +45,8 @@ from tests.controllers.firmware.conftest import (
     BareFirmwareControllerFactory,
     FirmwareControllerFactory,
 )
+
+from ...conftest import running_task
 
 
 def _job(
@@ -213,15 +214,12 @@ async def test_run_queue_skips_cancelled_jobs_without_spawning(
 
     controller._execute_job = _spy_execute  # type: ignore[method-assign]
 
-    runner = asyncio.create_task(controller._run_queue())
-    # Give the runner a chance to dequeue + skip + return for next get.
-    for _ in range(20):
-        await asyncio.sleep(0)
-        if controller.state.compile_lane.queue.empty():
-            break
-    runner.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await runner
+    async with running_task(controller._run_queue()):
+        # Give the runner a chance to dequeue + skip + return for next get.
+        for _ in range(20):
+            await asyncio.sleep(0)
+            if controller.state.compile_lane.queue.empty():
+                break
 
     assert spawned is False
 
@@ -425,18 +423,13 @@ async def test_upload_lane_holds_upload_until_build_gate_clears(
 
     controller._execute_job = _spy_execute  # type: ignore[method-assign]
 
-    runner_task = asyncio.create_task(runner.run_lane(controller, controller.state.upload_lane))
-    try:
+    async with running_task(runner.run_lane(controller, controller.state.upload_lane)):
         await asyncio.wait_for(held_at_gate.wait(), timeout=1.0)  # parked at the gate
         assert not executed.is_set()  # held by the active reset
 
         reset.status = JobStatus.COMPLETED
         controller.state.build_gate.set()
         await asyncio.wait_for(executed.wait(), timeout=1.0)  # released, now runs
-    finally:
-        runner_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await runner_task
 
 
 async def test_upload_lane_holds_upload_behind_same_config_clean(
@@ -462,18 +455,13 @@ async def test_upload_lane_holds_upload_behind_same_config_clean(
 
     controller._execute_job = _spy_execute  # type: ignore[method-assign]
 
-    runner_task = asyncio.create_task(runner.run_lane(controller, controller.state.upload_lane))
-    try:
+    async with running_task(runner.run_lane(controller, controller.state.upload_lane)):
         await asyncio.wait_for(held_at_gate.wait(), timeout=1.0)  # parked behind the clean
         assert not executed.is_set()
 
         clean.status = JobStatus.COMPLETED
         controller.state.build_gate.set()
         await asyncio.wait_for(executed.wait(), timeout=1.0)  # released, now runs
-    finally:
-        runner_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await runner_task
 
 
 async def test_upload_lane_skips_an_upload_cancelled_while_held(
@@ -498,8 +486,7 @@ async def test_upload_lane_skips_an_upload_cancelled_while_held(
 
     controller._execute_job = _spy_execute  # type: ignore[method-assign]
 
-    runner_task = asyncio.create_task(runner.run_lane(controller, controller.state.upload_lane))
-    try:
+    async with running_task(runner.run_lane(controller, controller.state.upload_lane)):
         await asyncio.wait_for(held_at_gate.wait(), timeout=1.0)  # parked at the gate
         assert executed == []  # held by the active reset
 
@@ -513,7 +500,3 @@ async def test_upload_lane_skips_an_upload_cancelled_while_held(
 
         await asyncio.wait_for(fresh_ran.wait(), timeout=1.0)
         assert "u1" not in executed  # the cancelled held upload was skipped
-    finally:
-        runner_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await runner_task

--- a/tests/controllers/firmware/test_execute_job_e2e.py
+++ b/tests/controllers/firmware/test_execute_job_e2e.py
@@ -57,6 +57,8 @@ from tests.controllers.firmware.conftest import (
     wire_real_queue as _wire_real_queue,
 )
 
+from ...conftest import running_task
+
 if TYPE_CHECKING:
     from .conftest import FirmwareControllerFactory
 
@@ -351,8 +353,7 @@ async def test_compile_mid_run_cancel_marks_cancelled(
 
     controller._db.bus.fire = _watch
 
-    runner_task = asyncio.create_task(controller._run_queue())
-    try:
+    async with running_task(controller._run_queue()):
         await asyncio.wait_for(proc_alive.wait(), timeout=10.0)
         # The subprocess is now blocking in ``sys.stdin.read()``.
         # Mark cancel + terminate the process — the runner picks
@@ -363,16 +364,12 @@ async def test_compile_mid_run_cancel_marks_cancelled(
         controller.state.processes[job.job_id].terminate()
 
         # Wait for the cancel event from the runner's natural
-        # post-``proc.wait()`` path, NOT from ``runner_task.cancel()``
-        # below. If we cancelled the task here without waiting,
+        # post-``proc.wait()`` path, NOT from the context exit's
+        # cancel. If we cancelled the task here without waiting,
         # ``_execute_job``'s ``except CancelledError`` branch would
         # fire JOB_CANCELLED too and the test couldn't distinguish
         # "user-cancel path worked" from "task-cancel path worked".
         await asyncio.wait_for(cancelled_fired.wait(), timeout=10.0)
-    finally:
-        runner_task.cancel()
-        with suppress(asyncio.CancelledError):
-            await runner_task
 
     assert job.status == JobStatus.CANCELLED
     # Subprocess actually exited (the user-cancel branch awaits
@@ -436,8 +433,7 @@ async def test_execute_job_runner_shutdown_terminates_and_marks_cancelled(
 
     controller._db.bus.fire = _watch
 
-    runner_task = asyncio.create_task(controller._run_queue())
-    try:
+    async with running_task(controller._run_queue()) as runner_task:
         await asyncio.wait_for(proc_alive.wait(), timeout=10.0)
         assert job.job_id in controller.state.processes
         proc = controller.state.processes[job.job_id]
@@ -445,16 +441,12 @@ async def test_execute_job_runner_shutdown_terminates_and_marks_cancelled(
         # Cancel the runner task itself — this is the shutdown shape,
         # not the user-cancel one. Nothing is added to
         # ``_cancel_requested`` so the post-``proc.wait()`` branch
-        # can't be the one that finalises the job.
+        # can't be the one that finalises the job. Awaited here (not
+        # left to the context exit) because the assertions below need
+        # the cancellation fully processed.
         runner_task.cancel()
         with suppress(asyncio.CancelledError):
             await runner_task
-    finally:
-        # Defensive cleanup if the assertion path above bailed early.
-        if not runner_task.done():
-            runner_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await runner_task
 
     assert job.status == JobStatus.CANCELLED
     assert any(c["type"] == EventType.JOB_CANCELLED for c in captured)
@@ -530,18 +522,12 @@ async def test_execute_job_runner_shutdown_kills_subprocess_group(
 
     controller._db.bus.fire = _watch
 
-    runner_task = asyncio.create_task(controller._run_queue())
-    try:
+    async with running_task(controller._run_queue()) as runner_task:
         await asyncio.wait_for(child_seen.wait(), timeout=10.0)
         assert child_pid, "test bug: never read CHILD_PID line"
         runner_task.cancel()
         with suppress(asyncio.CancelledError):
             await runner_task
-    finally:
-        if not runner_task.done():
-            runner_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await runner_task
 
     # Poll until the child is reaped — group SIGTERM has a brief
     # propagation window, then the kernel cleans up the zombie

--- a/tests/controllers/firmware/test_follow_jobs_race.py
+++ b/tests/controllers/firmware/test_follow_jobs_race.py
@@ -12,12 +12,11 @@ awaited.
 from __future__ import annotations
 
 import asyncio
-from contextlib import suppress
 from typing import Any
 
 from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType, StreamEvent
 
-from ...conftest import FakeWebSocketClient
+from ...conftest import FakeWebSocketClient, running_task
 from .conftest import FirmwareControllerFactory, make_follow_race_controller
 
 
@@ -50,32 +49,28 @@ async def test_follow_jobs_replays_snapshot_then_live_events_in_order(
     client = FakeWebSocketClient(yield_per_event=True)
     bus = controller._db.bus
 
-    follow_task = asyncio.create_task(controller.follow_jobs(client=client, message_id="m1"))
-    # Yield once so the helper finishes its synchronous setup
-    # (listeners attached) and starts awaiting in send_initial.
-    await asyncio.sleep(0)
-
-    # Fire a JOB_QUEUED while the snapshot replay is in flight. The
-    # listener queues it; the helper drains it after the snapshot
-    # finishes.
-    new_job = FirmwareJob(
-        job_id="c",
-        configuration="c.yaml",
-        job_type=JobType.COMPILE,
-        status=JobStatus.QUEUED,
-        output=[],
-    )
-    bus.fire(EventType.JOB_QUEUED, {"job": new_job})
-
-    # Yield enough that the snapshot + the live event get drained.
-    for _ in range(20):
+    async with running_task(controller.follow_jobs(client=client, message_id="m1")):
+        # Yield once so the helper finishes its synchronous setup
+        # (listeners attached) and starts awaiting in send_initial.
         await asyncio.sleep(0)
-        if any(e == EventType.JOB_QUEUED for (_mid, e, _d) in client.events):
-            break
 
-    follow_task.cancel()
-    with suppress(asyncio.CancelledError):
-        await follow_task
+        # Fire a JOB_QUEUED while the snapshot replay is in flight. The
+        # listener queues it; the helper drains it after the snapshot
+        # finishes.
+        new_job = FirmwareJob(
+            job_id="c",
+            configuration="c.yaml",
+            job_type=JobType.COMPILE,
+            status=JobStatus.QUEUED,
+            output=[],
+        )
+        bus.fire(EventType.JOB_QUEUED, {"job": new_job})
+
+        # Yield enough that the snapshot + the live event get drained.
+        for _ in range(20):
+            await asyncio.sleep(0)
+            if any(e == EventType.JOB_QUEUED for (_mid, e, _d) in client.events):
+                break
 
     snapshot_events = client.events_for(StreamEvent.SNAPSHOT)
     queued_events = client.events_for(EventType.JOB_QUEUED)
@@ -133,32 +128,28 @@ async def test_follow_jobs_snapshot_does_not_duplicate_with_concurrent_mutation(
             if event == StreamEvent.SNAPSHOT and data["job_id"] == "a":
                 await block.wait()
 
-    follow_task = asyncio.create_task(controller.follow_jobs(client=GatedClient(), message_id="m1"))
-    # Yield until the helper has delivered snapshot[a] and is
-    # parked on ``block.wait()``.
-    for _ in range(20):
-        await asyncio.sleep(0)
-        if received:
-            break
-    assert received[0][0] == StreamEvent.SNAPSHOT
-    assert received[0][1]["job_id"] == "a"
+    async with running_task(controller.follow_jobs(client=GatedClient(), message_id="m1")):
+        # Yield until the helper has delivered snapshot[a] and is
+        # parked on ``block.wait()``.
+        for _ in range(20):
+            await asyncio.sleep(0)
+            if received:
+                break
+        assert received[0][0] == StreamEvent.SNAPSHOT
+        assert received[0][1]["job_id"] == "a"
 
-    # Mutate job_b AND fire the matching JOB_OUTPUT — the same
-    # interleaving the runner produces between snapshot iterations.
-    job_b.output.append("b-mid-snapshot\n")
-    bus.fire(EventType.JOB_OUTPUT, {"job_id": "b", "line": "b-mid-snapshot\n"})
+        # Mutate job_b AND fire the matching JOB_OUTPUT — the same
+        # interleaving the runner produces between snapshot iterations.
+        job_b.output.append("b-mid-snapshot\n")
+        bus.fire(EventType.JOB_OUTPUT, {"job_id": "b", "line": "b-mid-snapshot\n"})
 
-    # Release the helper and let it iterate to snapshot[b] then
-    # drain the queued live event.
-    block.set()
-    for _ in range(20):
-        await asyncio.sleep(0)
-        if any(e == EventType.JOB_OUTPUT for (e, _d) in received):
-            break
-
-    follow_task.cancel()
-    with suppress(asyncio.CancelledError):
-        await follow_task
+        # Release the helper and let it iterate to snapshot[b] then
+        # drain the queued live event.
+        block.set()
+        for _ in range(20):
+            await asyncio.sleep(0)
+            if any(e == EventType.JOB_OUTPUT for (e, _d) in received):
+                break
 
     snapshots = {d["job_id"]: d for (e, d) in received if e == StreamEvent.SNAPSHOT}
     job_outputs = [d for (e, d) in received if e == EventType.JOB_OUTPUT]
@@ -184,15 +175,11 @@ async def test_follow_jobs_unsubscribes_on_cancellation(
     bus = controller._db.bus
     client = FakeWebSocketClient(yield_per_event=True)
 
-    follow_task = asyncio.create_task(controller.follow_jobs(client=client, message_id="m1"))
-    await asyncio.sleep(0)
+    async with running_task(controller.follow_jobs(client=client, message_id="m1")):
+        await asyncio.sleep(0)
 
-    listener_count_before = sum(len(bus._listeners.get(et, ())) for et in EventType)
-    assert listener_count_before > 0
-
-    follow_task.cancel()
-    with suppress(asyncio.CancelledError):
-        await follow_task
+        listener_count_before = sum(len(bus._listeners.get(et, ())) for et in EventType)
+        assert listener_count_before > 0
 
     listener_count_after = sum(len(bus._listeners.get(et, ())) for et in EventType)
     assert listener_count_after == 0
@@ -219,17 +206,13 @@ async def test_follow_jobs_forwards_job_progress_events(
     bus = controller._db.bus
     client = FakeWebSocketClient(yield_per_event=True)
 
-    follow_task = asyncio.create_task(controller.follow_jobs(client=client, message_id="m1"))
-    await asyncio.sleep(0)
+    async with running_task(controller.follow_jobs(client=client, message_id="m1")):
+        await asyncio.sleep(0)
 
-    progress = {"job_id": "a", "stage": "compile", "percent": 42}
-    bus.fire(EventType.JOB_PROGRESS, progress)
+        progress = {"job_id": "a", "stage": "compile", "percent": 42}
+        bus.fire(EventType.JOB_PROGRESS, progress)
 
-    await _drain_until(client, lambda c: any(e == "job_progress" for (_m, e, _d) in c.events))
-
-    follow_task.cancel()
-    with suppress(asyncio.CancelledError):
-        await follow_task
+        await _drain_until(client, lambda c: any(e == "job_progress" for (_m, e, _d) in c.events))
 
     progress_events = client.events_for("job_progress")
     assert progress_events == [progress]
@@ -248,22 +231,18 @@ async def test_follow_jobs_drops_lifecycle_event_with_no_job_payload(
     bus = controller._db.bus
     client = FakeWebSocketClient(yield_per_event=True)
 
-    follow_task = asyncio.create_task(controller.follow_jobs(client=client, message_id="m1"))
-    await asyncio.sleep(0)
+    async with running_task(controller.follow_jobs(client=client, message_id="m1")):
+        await asyncio.sleep(0)
 
-    # Bare payload — no ``job`` key. The handler must early-return
-    # without raising and without pushing anything.
-    bus.fire(EventType.JOB_QUEUED, {"unrelated": "noise"})
+        # Bare payload — no ``job`` key. The handler must early-return
+        # without raising and without pushing anything.
+        bus.fire(EventType.JOB_QUEUED, {"unrelated": "noise"})
 
-    # And then a normal event so we have a synchronisation point —
-    # if the handler had crashed, the listener would be torn down
-    # and this second event would never reach the client.
-    bus.fire(EventType.JOB_PROGRESS, {"job_id": "a"})
-    await _drain_until(client, lambda c: any(e == "job_progress" for (_m, e, _d) in c.events))
-
-    follow_task.cancel()
-    with suppress(asyncio.CancelledError):
-        await follow_task
+        # And then a normal event so we have a synchronisation point —
+        # if the handler had crashed, the listener would be torn down
+        # and this second event would never reach the client.
+        bus.fire(EventType.JOB_PROGRESS, {"job_id": "a"})
+        await _drain_until(client, lambda c: any(e == "job_progress" for (_m, e, _d) in c.events))
 
     assert client.events_for("job_queued") == []
     assert client.events_for("job_progress") == [{"job_id": "a"}]
@@ -283,16 +262,12 @@ async def test_follow_jobs_lifecycle_payload_passthrough_for_dict_job(
     bus = controller._db.bus
     client = FakeWebSocketClient(yield_per_event=True)
 
-    follow_task = asyncio.create_task(controller.follow_jobs(client=client, message_id="m1"))
-    await asyncio.sleep(0)
+    async with running_task(controller.follow_jobs(client=client, message_id="m1")):
+        await asyncio.sleep(0)
 
-    raw = {"job_id": "z", "status": "completed"}
-    bus.fire(EventType.JOB_COMPLETED, {"job": raw})
-    await _drain_until(client, lambda c: any(e == "job_completed" for (_m, e, _d) in c.events))
-
-    follow_task.cancel()
-    with suppress(asyncio.CancelledError):
-        await follow_task
+        raw = {"job_id": "z", "status": "completed"}
+        bus.fire(EventType.JOB_COMPLETED, {"job": raw})
+        await _drain_until(client, lambda c: any(e == "job_completed" for (_m, e, _d) in c.events))
 
     completed = client.events_for("job_completed")
     assert completed == [raw]

--- a/tests/controllers/firmware/test_lane_concurrency_e2e.py
+++ b/tests/controllers/firmware/test_lane_concurrency_e2e.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 from esphome_device_builder.models import EventType, JobStatus, JobType
@@ -24,6 +23,8 @@ from tests.controllers.firmware.conftest import (
 from tests.controllers.firmware.conftest import (
     wire_real_queue as _wire_real_queue,
 )
+
+from ...conftest import running_task
 
 if TYPE_CHECKING:
     from .conftest import FirmwareControllerFactory
@@ -83,8 +84,7 @@ async def test_parked_upload_does_not_block_a_compile(
     upload = await controller.upload(configuration="alpha.yaml", port="OTA")
     compile_job = await controller.compile(configuration="beta.yaml")
 
-    runner = asyncio.create_task(controller._run_queue())
-    try:
+    async with running_task(controller._run_queue()):
         async with asyncio.timeout(10):
             await asyncio.gather(upload_started.wait(), compile_completed.wait())
 
@@ -103,7 +103,3 @@ async def test_parked_upload_does_not_block_a_compile(
         async with asyncio.timeout(10):
             await upload_terminal.wait()
         assert upload.status == JobStatus.CANCELLED
-    finally:
-        runner.cancel()
-        with suppress(asyncio.CancelledError):
-            await runner

--- a/tests/controllers/firmware/test_parallel_uploads.py
+++ b/tests/controllers/firmware/test_parallel_uploads.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
@@ -23,6 +22,8 @@ from esphome_device_builder.controllers.firmware.constants import MAX_CONCURRENT
 from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType
 from tests.controllers.firmware.conftest import run_until_terminal, seed_yamls, wire_real_queue
 from tests.controllers.firmware.conftest import wire_devices as _wire_devices
+
+from ...conftest import running_task
 
 if TYPE_CHECKING:
     from .conftest import FirmwareControllerFactory
@@ -68,8 +69,7 @@ async def test_three_uploads_overlap_and_fourth_queues(
 
     jobs = [await controller.upload(configuration=name, port="OTA") for name in names]
 
-    runner = asyncio.create_task(controller._run_queue())
-    try:
+    async with running_task(controller._run_queue()):
         await _wait_started(started, *names[:MAX_CONCURRENT_UPLOADS])
 
         lane = controller.state.upload_lane
@@ -87,10 +87,6 @@ async def test_three_uploads_overlap_and_fourth_queues(
         await _wait_started(started, names[3])
         assert jobs[3].status is JobStatus.RUNNING
         assert jobs[0].status is JobStatus.CANCELLED
-    finally:
-        runner.cancel()
-        with suppress(asyncio.CancelledError):
-            await runner
 
 
 async def test_thread_uploads_serialize_beside_concurrent_normal_uploads(
@@ -109,8 +105,7 @@ async def test_thread_uploads_serialize_beside_concurrent_normal_uploads(
     mesh2 = await controller.upload(configuration="mesh2.yaml", port="OTA")
     alpha = await controller.upload(configuration="alpha.yaml", port="OTA")
 
-    runner = asyncio.create_task(controller._run_queue())
-    try:
+    async with running_task(controller._run_queue()):
         await _wait_started(started, "mesh1.yaml", "alpha.yaml")
 
         thread_lane = controller.state.thread_upload_lane
@@ -126,10 +121,6 @@ async def test_thread_uploads_serialize_beside_concurrent_normal_uploads(
         await controller._terminate_job_process(mesh1)
         await _wait_started(started, "mesh2.yaml")
         assert list(thread_lane.active) == [mesh2.job_id]
-    finally:
-        runner.cancel()
-        with suppress(asyncio.CancelledError):
-            await runner
 
 
 async def test_cancel_one_of_three_concurrent_uploads_spares_siblings(
@@ -146,8 +137,7 @@ async def test_cancel_one_of_three_concurrent_uploads_spares_siblings(
 
     jobs = [await controller.upload(configuration=name, port="OTA") for name in names]
 
-    runner = asyncio.create_task(controller._run_queue())
-    try:
+    async with running_task(controller._run_queue()):
         await _wait_started(started, *names)
         # JOB_STARTED fires before the spawn; wait for every registration.
         async with asyncio.timeout(10):
@@ -164,10 +154,6 @@ async def test_cancel_one_of_three_concurrent_uploads_spares_siblings(
         assert jobs[2].status is JobStatus.RUNNING
         assert controller.state.processes[jobs[0].job_id].returncode is None
         assert controller.state.processes[jobs[2].job_id].returncode is None
-    finally:
-        runner.cancel()
-        with suppress(asyncio.CancelledError):
-            await runner
 
 
 # Each upload sleeps a per-device staggered duration, then exits 0 —

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -61,7 +61,6 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, patch
@@ -88,6 +87,8 @@ from tests.controllers.firmware.conftest import (
 from tests.controllers.firmware.conftest import (
     wire_real_queue as _wire_real_queue,
 )
+
+from ...conftest import running_task
 
 if TYPE_CHECKING:
     from .conftest import FirmwareControllerFactory
@@ -565,13 +566,8 @@ async def test_cancel_during_hanging_verify_chip_terminates_subprocess(
             await asyncio.sleep(0.01)
         await controller.cancel(job_id=job.job_id)
 
-    canceller = asyncio.create_task(_cancel_when_verify_starts())
-    try:
+    async with running_task(_cancel_when_verify_starts()):
         captured = await _run_until_terminal(controller, timeout=5.0)
-    finally:
-        canceller.cancel()
-        with suppress(asyncio.CancelledError):
-            await canceller
 
     assert job.status == JobStatus.CANCELLED
     assert captured["job_cancelled"]
@@ -941,13 +937,8 @@ async def test_cancel_compile_mid_build_does_not_run_upload(
         await build_spawned.wait()
         await controller.cancel(job_id=compile_job.job_id)
 
-    canceller = asyncio.create_task(_cancel_when_build_starts())
-    try:
+    async with running_task(_cancel_when_build_starts()):
         await _run_until_terminal(controller, timeout=5.0)
-    finally:
-        canceller.cancel()
-        with suppress(asyncio.CancelledError):
-            await canceller
 
     assert compile_job.status == JobStatus.CANCELLED
     assert upload_job.status == JobStatus.CANCELLED


### PR DESCRIPTION
# What does this implement/fix?

Migrates the firmware controller test tree's hand rolled cancel on exit teardowns onto the shared `running_task` context manager from #2252. Twenty of the twenty two `suppress(CancelledError)` occurrences collapse; the try/finally scaffolding around each background runner disappears and the manager's drain also surfaces a crashed background task instead of letting it pass silently.

Two occurrences deliberately stay, both in `test_execute_job_e2e.py`: they are the test action itself (the shutdown shape under test cancels the runner mid body and must await the cancellation before asserting), not teardowns. Their previously separate defensive finally blocks are now covered by the surrounding `running_task` exit. The issue's other leave alone shapes (natural completion awaits, explicit stop() driven teardowns) had no occurrences in this tree.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2253

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
