### PR TITLE
Await real signals instead of polling in two test suites

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -243,23 +243,30 @@ class _CapturedEvents(list[dict]):
         super().append(item)
         self.received.set()
 
-    async def wait_for_status(self, status: str, *, timeout: float = 2.0) -> dict:
-        """Return the first captured event whose ``status`` matches *status*.
+    async def wait_for_match(
+        self, predicate: Callable[[dict], object], *, timeout: float = 2.0
+    ) -> dict:
+        """Return the first captured payload satisfying *predicate*, awaiting new ones.
 
-        The *timeout* bounds the total wait, not each loop iteration,
-        so a stream of non-matching events can't push the deadline
-        forward indefinitely.
+        Rescans the buffer on each wake, so a payload that already
+        landed is matched too. The *timeout* bounds the total wait, not
+        each loop iteration, so a stream of non-matching events can't
+        push the deadline forward indefinitely.
         """
 
         async def _poll() -> dict:
             while True:
                 for entry in self:
-                    if entry.get("status") == status:
+                    if predicate(entry):
                         return entry
                 self.received.clear()
                 await self.received.wait()
 
         return await asyncio.wait_for(_poll(), timeout=timeout)
+
+    async def wait_for_status(self, status: str, *, timeout: float = 2.0) -> dict:
+        """Return the first captured event whose ``status`` matches *status*."""
+        return await self.wait_for_match(lambda e: e.get("status") == status, timeout=timeout)
 
 
 def capture_events(bus: EventBus, event_type: EventType) -> _CapturedEvents:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,14 +244,19 @@ class _CapturedEvents(list[dict]):
         self.received.set()
 
     async def wait_for_match(
-        self, predicate: Callable[[dict], object], *, timeout: float = 2.0
+        self,
+        predicate: Callable[[dict], object],
+        *,
+        timeout: float = 2.0,
+        what: str = "a matching event",
     ) -> dict:
         """Return the first captured payload satisfying *predicate*, awaiting new ones.
 
         Rescans the buffer on each wake, so a payload that already
         landed is matched too. The *timeout* bounds the total wait, not
         each loop iteration, so a stream of non-matching events can't
-        push the deadline forward indefinitely.
+        push the deadline forward indefinitely; ``pytest.fail`` names
+        *what* on timeout, matching ``wait_until``.
         """
 
         async def _poll() -> dict:
@@ -262,11 +267,16 @@ class _CapturedEvents(list[dict]):
                 self.received.clear()
                 await self.received.wait()
 
-        return await asyncio.wait_for(_poll(), timeout=timeout)
+        try:
+            return await asyncio.wait_for(_poll(), timeout=timeout)
+        except TimeoutError:
+            pytest.fail(f"timed out waiting for {what}")
 
     async def wait_for_status(self, status: str, *, timeout: float = 2.0) -> dict:
         """Return the first captured event whose ``status`` matches *status*."""
-        return await self.wait_for_match(lambda e: e.get("status") == status, timeout=timeout)
+        return await self.wait_for_match(
+            lambda e: e.get("status") == status, timeout=timeout, what=f"status {status!r}"
+        )
 
 
 def capture_events(bus: EventBus, event_type: EventType) -> _CapturedEvents:

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -50,7 +50,6 @@ from esphome_device_builder.models import (
     JobType,
 )
 
-from ...conftest import wait_until
 from .conftest import REMOTE_PIN, capture_local_events, make_remote_job
 
 if TYPE_CHECKING:
@@ -68,10 +67,10 @@ def _wire_remote_build(
     Returns ``(remote_build, client)`` so the caller can both
     assert on the remote-build mock and reference the client
     for runner-state sync (``_wait_until_dispatched`` /
-    ``_wait_for_wire_cancel`` poll on the client's mock
-    counters). When *lookup_error* is passed the returned
-    client is ``None`` — there's nothing to dispatch to and
-    no submit-side sync to wait for.
+    ``_wait_for_wire_cancel`` await the client's ``*_dispatched``
+    events). When *lookup_error* is passed the returned client
+    is ``None`` — there's nothing to dispatch to and no
+    submit-side sync to wait for.
     """
     remote_build = MagicMock()
     if lookup_error is not None:
@@ -107,39 +106,45 @@ def _make_client(
     branches each lean on a different one of these.
     """
     client = MagicMock()
-    if submit_error is not None:
-        client.submit_job = AsyncMock(side_effect=submit_error)
-    else:
+    # Each verb sets its own event when awaited, giving the _wait_* helpers
+    # an awaitable dispatch signal instead of polling ``await_count``.
+    client.submit_job_dispatched = asyncio.Event()
+    client.cancel_job_dispatched = asyncio.Event()
+    client.reset_build_env_dispatched = asyncio.Event()
 
-        async def _echo_ack(**kwargs: Any) -> dict[str, Any]:
-            ack: dict[str, Any] = {"job_id": kwargs["job_id"], "accepted": accepted}
-            if reason is not None:
-                ack["reason"] = reason
-            return ack
+    def _ack(**kwargs: Any) -> dict[str, Any]:
+        ack: dict[str, Any] = {"job_id": kwargs["job_id"], "accepted": accepted}
+        if reason is not None:
+            ack["reason"] = reason
+        return ack
 
-        client.submit_job = AsyncMock(side_effect=_echo_ack)
-    if cancel_error is not None:
-        client.cancel_job = AsyncMock(side_effect=cancel_error)
-    else:
-        client.cancel_job = AsyncMock(return_value=cancel_return)
+    async def _submit_job(**kwargs: Any) -> dict[str, Any]:
+        client.submit_job_dispatched.set()
+        if submit_error is not None:
+            raise submit_error
+        return _ack(**kwargs)
+
+    async def _cancel_job(**kwargs: Any) -> bool:
+        client.cancel_job_dispatched.set()
+        if cancel_error is not None:
+            raise cancel_error
+        return cancel_return
+
+    async def _reset_build_env(**kwargs: Any) -> dict[str, Any]:
+        client.reset_build_env_dispatched.set()
+        if submit_error is not None:
+            raise submit_error
+        return _ack(**kwargs)
+
+    client.submit_job = AsyncMock(side_effect=_submit_job)
+    client.cancel_job = AsyncMock(side_effect=_cancel_job)
     # Default so COMPILE / UPLOAD / INSTALL tests don't have to
     # wire it per-test — the runner now goes through
     # ``_fetch_and_materialise`` for every non-CLEAN COMPLETED
     # job. Tests that want to inspect the call or simulate
     # failure override this assignment.
     client.download_artifacts = AsyncMock(return_value=_make_packed_artifacts())
-
-    async def _echo_reset_ack(**kwargs: Any) -> dict[str, Any]:
-        ack: dict[str, Any] = {"job_id": kwargs["job_id"], "accepted": accepted}
-        if reason is not None:
-            ack["reason"] = reason
-        return ack
-
-    client.reset_build_env = (
-        AsyncMock(side_effect=submit_error)
-        if submit_error is not None
-        else AsyncMock(side_effect=_echo_reset_ack)
-    )
+    client.reset_build_env = AsyncMock(side_effect=_reset_build_env)
     return client
 
 
@@ -225,50 +230,37 @@ def _request_remote_cancel(controller: Any, job: FirmwareJob) -> None:
         event.set()
 
 
+async def _await_dispatch(event: asyncio.Event, what: str, *, timeout: float = 1.0) -> None:
+    """Await *event*, failing with *what* if it doesn't fire within *timeout*."""
+    try:
+        await asyncio.wait_for(event.wait(), timeout)
+    except TimeoutError:
+        pytest.fail(f"timed out waiting for {what}")
+
+
 async def _wait_until_dispatched(client: Any, *, timeout: float = 1.0) -> None:
     """
     Yield until the runner has finished its dispatch phase.
 
-    Polls on :attr:`AsyncMock.await_count` for ``submit_job``
-    — the count increments only after the mock's awaited
-    coroutine has resolved, so this returns the instant the
-    runner moves past ``await client.submit_job(...)`` and
-    into ``_await_terminal``'s wait loop. Replaces fixed
-    ``for _ in range(N): await asyncio.sleep(0)`` constructs
-    that broke when residual coroutines from a prior test
-    left the loop in a different state than the runner
-    expected (the park-point depends on how many awaits the
-    runner has yielded through, and the number drifts across
-    refactors).
-
-    Raises :class:`AssertionError` on timeout so a runner
-    regression that never reaches the submit shows up as a
-    clear test failure rather than a hung pytest run.
+    The ``submit_job`` mock sets ``submit_job_dispatched`` when awaited,
+    so this returns the instant the runner moves past
+    ``await client.submit_job(...)`` into ``_await_terminal``'s wait.
+    Fails on timeout so a regression that never submits is a clean
+    failure, not a hung run.
     """
-    await wait_until(lambda: client.submit_job.await_count > 0, timeout, "submit_job dispatch")
+    await _await_dispatch(client.submit_job_dispatched, "submit_job dispatch", timeout=timeout)
 
 
 async def _wait_for_wire_cancel(client: Any, *, timeout: float = 1.0) -> None:
     """
     Yield until the runner has translated a local cancel into a wire ``cancel_job``.
 
-    The runner parks on
-    ``asyncio.wait({terminal, session_lost, cancel_wait},
-    return_when=FIRST_COMPLETED)`` — fully event-driven, no
-    poll cadence — so as soon as
-    ``FirmwareController.cancel`` (or the test's
-    ``_request_remote_cancel`` mirror) signals the cancel
-    event, the runner wakes and dispatches
-    ``client.cancel_job``. Polling on
-    :attr:`AsyncMock.await_count` returns the instant that
-    wire send lands.
-
-    Raises :class:`AssertionError` on timeout for the same
-    reason :func:`_wait_until_dispatched` does — a regression
-    that never sends the wire cancel should be a clean fail,
-    not a hang.
+    The runner parks on the terminal / session-lost / cancel wait; when
+    the cancel event signals, it wakes and dispatches ``client.cancel_job``,
+    whose mock sets ``cancel_job_dispatched``. Fails on timeout for the
+    same reason :func:`_wait_until_dispatched` does.
     """
-    await wait_until(lambda: client.cancel_job.await_count > 0, timeout, "wire cancel_job")
+    await _await_dispatch(client.cancel_job_dispatched, "wire cancel_job", timeout=timeout)
 
 
 def _fire_session_closed(
@@ -1957,8 +1949,8 @@ def _make_reset_job(*, job_id: str = "reset-1") -> FirmwareJob:
 
 async def _wait_until_reset_dispatched(client: Any, *, timeout: float = 1.0) -> None:
     """Yield until the runner moved past ``await client.reset_build_env(...)``."""
-    await wait_until(
-        lambda: client.reset_build_env.await_count > 0, timeout, "reset_build_env dispatch"
+    await _await_dispatch(
+        client.reset_build_env_dispatched, "reset_build_env dispatch", timeout=timeout
     )
 
 

--- a/tests/test_remote_build_only.py
+++ b/tests/test_remote_build_only.py
@@ -334,7 +334,7 @@ async def test_bootstrap_first_pair_success(
     with caplog.at_level("INFO", logger=_RBO_LOGGER):
         window = capture_events(db.bus, EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED)
         bootstrap = asyncio.create_task(rbo._bootstrap_first_pair(db, receiver))
-        await window.wait_for_match(lambda e: e["open"], timeout=2.0)
+        await window.wait_for_match(lambda e: e["open"], timeout=2.0, what="pairing window open")
         assert receiver.state.auto_approve_first_pair
         key = receiver.state.bootstrap_pairing_key
         assert key is not None
@@ -390,7 +390,7 @@ async def test_bootstrap_banner_key_survives_pair_during_identity_load(
     with patch.object(rbo, "_log_pairing_banner", _spy):
         window = capture_events(db.bus, EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED)
         bootstrap = asyncio.create_task(rbo._bootstrap_first_pair(db, receiver))
-        await window.wait_for_match(lambda e: e["open"], timeout=2.0)
+        await window.wait_for_match(lambda e: e["open"], timeout=2.0, what="pairing window open")
         key = receiver.state.bootstrap_pairing_key
         response = await _send_pair_request(
             RemoteBuildController(MagicMock(), receiver), pairing_key=key
@@ -414,7 +414,7 @@ async def test_bootstrap_first_pair_with_source_allowlist(
     with caplog.at_level("INFO", logger=_RBO_LOGGER):
         window = capture_events(db.bus, EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED)
         bootstrap = asyncio.create_task(rbo._bootstrap_first_pair(db, receiver))
-        await window.wait_for_match(lambda e: e["open"], timeout=2.0)
+        await window.wait_for_match(lambda e: e["open"], timeout=2.0, what="pairing window open")
         key = receiver.state.bootstrap_pairing_key
         assert key is not None
 
@@ -479,14 +479,14 @@ async def test_serve_parks_after_bootstrap_pair(tmp_path: Path) -> None:
     window = capture_events(db.bus, EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED)
     serve = asyncio.create_task(rbo._serve(db))  # type: ignore[arg-type]
 
-    await window.wait_for_match(lambda e: e["open"], timeout=2.0)
-    # Fresh capture so the close wait can't match the earlier open event.
+    await window.wait_for_match(lambda e: e["open"], timeout=2.0, what="pairing window open")
+    # Fresh capture so the close wait observes only events emitted after the pair request.
     closing = capture_events(db.bus, EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED)
     await _send_pair_request(
         RemoteBuildController(MagicMock(), receiver),
         pairing_key=receiver.state.bootstrap_pairing_key,
     )
-    await closing.wait_for_match(lambda e: not e["open"], timeout=2.0)
+    await closing.wait_for_match(lambda e: not e["open"], timeout=2.0, what="pairing window closed")
     await asyncio.sleep(0.05)
 
     assert not serve.done()

--- a/tests/test_remote_build_only.py
+++ b/tests/test_remote_build_only.py
@@ -36,7 +36,7 @@ from esphome_device_builder.helpers.event_bus import EventBus
 from esphome_device_builder.helpers.pin_emoji import pin_emoji, pin_emoji_names
 from esphome_device_builder.models import EventType, StoredPeer
 
-from .conftest import MakeSettingsFactory, make_remote_build_controller, wait_until
+from .conftest import MakeSettingsFactory, capture_events, make_remote_build_controller
 from .conftest import RemoteBuildTestHandles as RemoteBuildController
 
 _RBO_LOGGER = "esphome_device_builder._remote_build_only"
@@ -332,8 +332,9 @@ async def test_bootstrap_first_pair_success(
     assert receiver is not None
 
     with caplog.at_level("INFO", logger=_RBO_LOGGER):
+        window = capture_events(db.bus, EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED)
         bootstrap = asyncio.create_task(rbo._bootstrap_first_pair(db, receiver))
-        await wait_until(receiver.is_pairing_window_open, 2.0, "pairing window open")
+        await window.wait_for_match(lambda e: e["open"], timeout=2.0)
         assert receiver.state.auto_approve_first_pair
         key = receiver.state.bootstrap_pairing_key
         assert key is not None
@@ -387,8 +388,9 @@ async def test_bootstrap_banner_key_survives_pair_during_identity_load(
         orig_banner(identity, sources, key)
 
     with patch.object(rbo, "_log_pairing_banner", _spy):
+        window = capture_events(db.bus, EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED)
         bootstrap = asyncio.create_task(rbo._bootstrap_first_pair(db, receiver))
-        await wait_until(receiver.is_pairing_window_open, 2.0, "pairing window open")
+        await window.wait_for_match(lambda e: e["open"], timeout=2.0)
         key = receiver.state.bootstrap_pairing_key
         response = await _send_pair_request(
             RemoteBuildController(MagicMock(), receiver), pairing_key=key
@@ -410,8 +412,9 @@ async def test_bootstrap_first_pair_with_source_allowlist(
     assert receiver is not None
 
     with caplog.at_level("INFO", logger=_RBO_LOGGER):
+        window = capture_events(db.bus, EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED)
         bootstrap = asyncio.create_task(rbo._bootstrap_first_pair(db, receiver))
-        await wait_until(receiver.is_pairing_window_open, 2.0, "pairing window open")
+        await window.wait_for_match(lambda e: e["open"], timeout=2.0)
         key = receiver.state.bootstrap_pairing_key
         assert key is not None
 
@@ -473,14 +476,17 @@ async def test_serve_parks_after_bootstrap_pair(tmp_path: Path) -> None:
     db = _make_fake_db(tmp_path)
     receiver = db.remote_build_receiver
     assert receiver is not None
+    window = capture_events(db.bus, EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED)
     serve = asyncio.create_task(rbo._serve(db))  # type: ignore[arg-type]
 
-    await wait_until(receiver.is_pairing_window_open, 2.0, "pairing window open")
+    await window.wait_for_match(lambda e: e["open"], timeout=2.0)
+    # Fresh capture so the close wait can't match the earlier open event.
+    closing = capture_events(db.bus, EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED)
     await _send_pair_request(
         RemoteBuildController(MagicMock(), receiver),
         pairing_key=receiver.state.bootstrap_pairing_key,
     )
-    await wait_until(lambda: not receiver.is_pairing_window_open(), 2.0, "pairing window closed")
+    await closing.wait_for_match(lambda e: not e["open"], timeout=2.0)
     await asyncio.sleep(0.05)
 
     assert not serve.done()


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #2250. Two `wait_until` families poll only because nobody wired up the synchronization source that already exists; awaiting it removes the residual poll latency and makes the waits deterministic, per the anti-polling convention on `_CapturedEvents`.

Pairing-window waits in `tests/test_remote_build_only.py` now subscribe to the `REMOTE_BUILD_PAIRING_WINDOW_CHANGED` bus event the receiver already fires (`_fire_pairing_window_changed`) and await the transition, through a new generic `_CapturedEvents.wait_for_match(predicate)` in `tests/conftest.py`; the existing `wait_for_status` becomes a thin delegate, so its e2e callers are unchanged.

The remote-runner dispatch waits in `tests/controllers/firmware/test_remote_runner.py` gave each mocked verb (`submit_job` / `cancel_job` / `reset_build_env`) an `asyncio.Event` set from its `side_effect`, and the three wrapper helpers await that event instead of polling `AsyncMock.await_count`. All 41 call sites and every `assert_awaited_*` stay unchanged; the mock return/exception behaviour is preserved.

Deferred (noted in the issue): the `tests/test_ping_loop_pause.py` sweep counters. The `counts` dict must survive for post-wait assertions, the `>= N` and dynamic sequential waits don't map to a single event, and two sites are negative "prove no sweep fired" checks; an event conversion would be longer with no determinism gain over the already-fast poll. Also not touched: the e2e mqtt broker waits (wall-clock dominated) and `test_remote_build_peer_link.py` session-registry membership (no production hook; its fixture bus is a `MagicMock`).

Test-only, no production change.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2251

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
