### PR TITLE
Key the OTA address-cache lookup on the configuration filename

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -21,10 +21,7 @@ from ...constants import is_secrets_file
 from ...helpers.api import CommandError, api_command
 from ...helpers.async_ import run_in_executor
 from ...helpers.build_size import BuildSizeRefreshResult
-from ...helpers.device_yaml import (
-    board_requires_wifi,
-    configuration_stem,
-)
+from ...helpers.device_yaml import board_requires_wifi
 from ...helpers.event_bus import Event
 from ...helpers.secrets_state import (
     SecretsContentError,
@@ -337,8 +334,8 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         Empty list when the device is unknown, has no OTA-capable
         integration loaded, or has no cached IP available.
         """
-        target_name = configuration_stem(configuration)
-        device = next((d for d in self._scanner.devices if d.name == target_name), None)
+        # Keyed on the YAML filename; the esphome name can differ from the stem.
+        device = self.get_by_configuration(configuration)
         if device is None:
             return []
         # The CLI only consults the address cache from upload paths

--- a/tests/controllers/firmware/test_address_cache.py
+++ b/tests/controllers/firmware/test_address_cache.py
@@ -16,6 +16,7 @@ from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.controllers.devices.helpers import _build_address_cache_args
 from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.models import Device, FirmwareJob, JobType
+from tests._recording_scanner import RecordingScanner
 from tests.conftest import make_device
 from tests.controllers.devices.conftest import RecordingStateMonitor
 
@@ -154,13 +155,13 @@ def test_multiple_cached_addresses_sorted() -> None:
 def _devices_controller_with(*devices: Device) -> Any:
     """Build a thin DevicesController shell with a stubbed scanner + monitor.
 
-    ``get_address_cache_args`` only reads the scanner's device list,
-    the state monitor's cached-addresses lookup, and the device's
-    ``loaded_integrations`` field — keep the rest of the controller
-    out of the test surface.
+    ``get_address_cache_args`` only reads the scanner's
+    configuration-keyed lookup, the state monitor's cached-addresses
+    lookup, and the device's ``loaded_integrations`` field — keep the
+    rest of the controller out of the test surface.
     """
     controller = DevicesController.__new__(DevicesController)
-    scanner = MagicMock()
+    scanner = RecordingScanner()
     scanner.devices = list(devices)
     controller._scanner = scanner
     controller._state_monitor = _monitor(["192.168.1.50"])
@@ -219,6 +220,23 @@ def test_get_address_cache_args_unknown_configuration_returns_empty() -> None:
     args = controller.get_address_cache_args("ghost.yaml")
 
     assert args == []
+
+
+def test_get_address_cache_args_filename_differs_from_device_name() -> None:
+    """A renamed YAML whose stem differs from ``esphome.name`` still gets cache args."""
+    controller = _devices_controller_with(
+        _device(
+            name="esphome-web-0ea4a4",
+            configuration="uw15.yaml",
+            address="esphome-web-0ea4a4.local",
+            ip="10.15.2.199",
+        )
+    )
+
+    assert controller.get_address_cache_args("uw15.yaml") == [
+        "--mdns-address-cache",
+        "esphome-web-0ea4a4.local=10.15.2.199",
+    ]
 
 
 def test_get_ota_address_cache_args_returns_cache_for_ota_port() -> None:


### PR DESCRIPTION
# What does this implement/fix?

`get_address_cache_args` looked the device up by comparing the esphome name against the YAML filename stem. For a device whose file was renamed after adoption (the reporter's `UW15.yaml` with name `esphome-web-0ea4a4`) the lookup returned nothing, so upload and logs ran the esphome CLI with no `--mdns-address-cache` args and the CLI resolved the `.local` name itself; on the reporter's network that resolve answers `::` and `0.0.0.0`, so espota fails while the dashboard sits on the correct IP the whole time.

The lookup now uses the scanner's configuration-keyed index, so the persisted IP reaches the CLI regardless of what the file is called. Regression test covers a device whose filename stem differs from its name; the OTA delegation is already pinned by the existing `test_get_ota_address_cache_args_returns_cache_for_ota_port`.

Follow-ups filed for the resolver junk itself: #2264 (filter unspecified addresses dashboard side) and esphome/aioesphomeapi#1833 (skip unspecified addresses in resolver results).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2262

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
