### PR TITLE
Pin the Docker bump PR author/committer to esphome[bot]

### DIFF
--- a/.github/workflows/bump-esphome-docker-pin.yml
+++ b/.github/workflows/bump-esphome-docker-pin.yml
@@ -109,6 +109,8 @@ jobs:
           base: dev
           branch: bump-device-builder-${{ github.event.release.tag_name }}
           delete-branch: true
+          author: "esphome[bot] <115708604+esphome[bot]@users.noreply.github.com>"
+          committer: "esphome[bot] <115708604+esphome[bot]@users.noreply.github.com>"
           commit-message: "Bump bundled esphome-device-builder to ${{ github.event.release.tag_name }}"
           title: "Bump bundled esphome-device-builder to ${{ github.event.release.tag_name }}"
           body: |


### PR DESCRIPTION
# What does this implement/fix?

The release workflow (`bump-esphome-docker-pin.yml`) opens the esphome Docker bump PR via `peter-evans/create-pull-request`, which by default leaves `github-actions[bot]` as the committer while the author resolves to `esphome[bot]`. That split shows up as two identities co-authoring the bump commit. This pins both `author` and `committer` to `esphome[bot]` so the bump commit carries a single identity.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [ ] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.