### PR TITLE
Drop inherited IDF_PATH overrides at daemon startup

### DIFF
--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -412,6 +412,7 @@ def main() -> None:
 
     from .device_builder import DeviceBuilder  # noqa: PLC0415
     from .helpers.single_instance import ensure_single_execution  # noqa: PLC0415
+    from .helpers.toolchain_env import drop_inherited_idf_env  # noqa: PLC0415
     from .helpers.windows_build_paths import windows_short_build_paths  # noqa: PLC0415
 
     startup_timer.mark("builder")
@@ -420,6 +421,8 @@ def main() -> None:
     settings.parse_args(args)
     _warn_if_unprotected(settings)
     startup_timer.mark("settings")
+
+    drop_inherited_idf_env()
 
     # Keyed on ``CORE.data_dir`` (not ``config_dir``) so the HA
     # addon's Prod/Beta/DEV flavors — each with its own per-instance

--- a/esphome_device_builder/helpers/toolchain_env.py
+++ b/esphome_device_builder/helpers/toolchain_env.py
@@ -1,0 +1,22 @@
+"""Drop inherited ESP-IDF env overrides so builds use the managed toolchain."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+_LOGGER = logging.getLogger(__name__)
+
+# esphome's native ESP-IDF toolchain uses IDF_PATH verbatim when present and skips its managed
+# install entirely, so a machine-level leftover (commonly pointing into ~/.platformio from an
+# old PlatformIO-era setup) fails every esp32 build before it starts.
+_INHERITED_IDF_VARS = ("IDF_PATH", "IDF_TOOLS_PATH")
+
+
+def drop_inherited_idf_env() -> None:
+    """Remove inherited ``IDF_PATH`` / ``IDF_TOOLS_PATH`` from the process environment."""
+    for var in _INHERITED_IDF_VARS:
+        if (value := os.environ.pop(var, None)) is not None:
+            _LOGGER.warning(
+                "Ignoring inherited %s=%s; ESP-IDF is managed by the device builder", var, value
+            )

--- a/tests/test_toolchain_env.py
+++ b/tests/test_toolchain_env.py
@@ -1,0 +1,44 @@
+"""Unit contract for dropping inherited ESP-IDF env overrides."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+
+from esphome_device_builder.helpers.toolchain_env import drop_inherited_idf_env
+
+
+def test_drops_inherited_vars_and_names_each(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Both vars are removed and each dropped var is named with its value in the log."""
+    monkeypatch.setenv("IDF_PATH", r"C:\Users\user\.platformio\packages\framework-espidf")
+    monkeypatch.setenv("IDF_TOOLS_PATH", r"C:\esp\tools")
+    with caplog.at_level(logging.WARNING):
+        drop_inherited_idf_env()
+    assert "IDF_PATH" not in os.environ
+    assert "IDF_TOOLS_PATH" not in os.environ
+    assert r"IDF_PATH=C:\Users\user\.platformio\packages\framework-espidf" in caplog.text
+    assert r"IDF_TOOLS_PATH=C:\esp\tools" in caplog.text
+
+
+def test_noop_and_silent_when_absent(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Nothing is logged when neither var is present."""
+    monkeypatch.delenv("IDF_PATH", raising=False)
+    monkeypatch.delenv("IDF_TOOLS_PATH", raising=False)
+    with caplog.at_level(logging.WARNING):
+        drop_inherited_idf_env()
+    assert caplog.text == ""
+
+
+def test_drops_only_the_var_that_is_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A var that is absent stays absent while the set one is removed."""
+    monkeypatch.delenv("IDF_TOOLS_PATH", raising=False)
+    monkeypatch.setenv("IDF_PATH", "/opt/esp-idf")
+    drop_inherited_idf_env()
+    assert "IDF_PATH" not in os.environ
+    assert "IDF_TOOLS_PATH" not in os.environ


### PR DESCRIPTION
# What does this implement/fix?

esphome's native ESP-IDF toolchain uses IDF_PATH verbatim when it is present and skips its managed install entirely, so a machine level leftover (commonly pointing into `~/.platformio` from an old PlatformIO era setup) fails every esp32 build before it starts; on the reporter's compile node component discovery died with FileNotFoundError on `idf.py`. The Windows build relocation also moves `~/.platformio` to the short root, so even a pointer that once resolved dangles afterwards. The daemon now drops inherited IDF_PATH and IDF_TOOLS_PATH at startup and logs each dropped value; the device builder owns its toolchain environment, so machine leftovers never reach a build.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/387

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
