### PR TITLE
Run the compile subprocess tree in UTF-8 mode

### DIFF
--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -117,11 +117,19 @@ _NO_ESPHOME_MODULE_MARKER = "No module named 'esphome'"
 # * ``PYTHONUNBUFFERED`` keeps Python subprocesses flushing progress
 #   lines (especially ``\r``-terminated ones) instead of buffering
 #   them until a ``\n`` arrives.
+# * ``PYTHONUTF8`` / ``PYTHONIOENCODING`` force every Python in the
+#   build tree (esphome, idf.py, the IDF penv tools) onto UTF-8 for
+#   stdio and locale-default codecs. Without them a layer of the
+#   Windows toolchain decodes esp_idf_size's UTF-8 box-drawing table
+#   with the OEM codepage and the job log shows ``Γöé`` mojibake;
+#   POSIX defaults to UTF-8 already, so there this only pins parity.
 ESPHOME_SUBPROCESS_ENV: dict[str, str] = {
     "PLATFORMIO_FORCE_ANSI": "true",
     "FORCE_COLOR": "1",
     "CLICOLOR_FORCE": "1",
     "PYTHONUNBUFFERED": "1",
+    "PYTHONUTF8": "1",
+    "PYTHONIOENCODING": "utf-8",
 }
 
 

--- a/tests/controllers/firmware/test_subprocess_env.py
+++ b/tests/controllers/firmware/test_subprocess_env.py
@@ -181,3 +181,9 @@ def test_malformed_remote_build_path_falls_through_to_local(
     env = controller._compose_subprocess_env(_make_job(configuration=configuration))
 
     assert env.get("ESPHOME_DATA_DIR") == os.environ.get("ESPHOME_DATA_DIR")
+
+
+def test_subprocess_env_forces_utf8() -> None:
+    """The build tree runs in UTF-8 mode, or Windows layers decode output with the OEM codepage."""
+    assert ESPHOME_SUBPROCESS_ENV["PYTHONUTF8"] == "1"
+    assert ESPHOME_SUBPROCESS_ENV["PYTHONIOENCODING"] == "utf-8"


### PR DESCRIPTION
# What does this implement/fix?

On a native-Windows build server, the `esp_idf_size` memory table in the compile log renders as mojibake:

```
Γöé Memory Type/Section Γöé Used [bytes] Γöé Used [%] Γöé ...
```

Byte-level analysis of a downloaded job log shows the stored text is valid UTF-8 of `Γöé`, and re-encoding it as CP437 recovers `│` (`e2 94 82`) — i.e. some layer of the Windows toolchain subprocess tree decoded UTF-8 box-drawing output with the OEM codepage and re-emitted it. The dashboard's own pipeline is faithful (it decodes UTF-8 with `errors="replace"`), as are the layers that could be audited from source: esphome's espidf runner, idf.py's stream reads, and `run_size_tool.cmake` (which doesn't capture output at all). The mangling layer is one that consults the platform-default/console encoding.

Fix at the environment level rather than chasing the individual layer: add `PYTHONUTF8=1` and `PYTHONIOENCODING=utf-8` to `ESPHOME_SUBPROCESS_ENV`, the shared constant both the local job runner (`compose_subprocess_env`) and the remote receiver runner already layer onto every `esphome` subprocess. This puts every Python in the build tree (esphome, the espidf runner, idf.py, the IDF penv tools including esp_idf_size) into UTF-8 mode for stdio and for locale-default codecs, so no layer can fall back to the OEM codepage in either direction. On POSIX the defaults are already UTF-8, so this only pins the existing behavior and keeps the local/remote parity contract.

**Related issue or feature (if applicable):**

- fixes the `Γöé` mojibake in the esp_idf_size table of Windows compile logs

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
