### PR TITLE
Drop ambiguous MDX bare-stem aliases to stop title bleed

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1868,6 +1868,35 @@ def _iter_component_mdx() -> Iterator[tuple[str, str, Path]]:
             yield f"{parts[0]}.{parts[1]}", parts[1], mdx_path
 
 
+def _index_by_id_and_stem[V](triples: Iterable[tuple[str, str, V]]) -> dict[str, V]:
+    """
+    Index MDX values by catalog id and bare stem, dropping ambiguous stems.
+
+    The bare-stem alias lets a top-level component (``animation``) pick up the
+    value from its domain page (``image/animation``) it can't reach by exact id.
+    But when two pages share a stem with different values (``image/animation``
+    "Animation" vs ``lvgl/animation`` "LVGL Animations") the alias is ambiguous,
+    and ``rglob`` walk order would pick a winner nondeterministically — so the
+    stem key is dropped and the caller keeps the schema-derived value. Exact
+    catalog-id keys are always authoritative.
+    """
+    by_cid: dict[str, V] = {}
+    stem_value: dict[str, V] = {}
+    ambiguous: set[str] = set()
+    for cid, stem, value in triples:
+        by_cid[cid] = value
+        if stem in stem_value:
+            if stem_value[stem] != value:
+                ambiguous.add(stem)
+        else:
+            stem_value[stem] = value
+    out: dict[str, V] = dict(by_cid)
+    for stem, value in stem_value.items():
+        if stem not in ambiguous:
+            out.setdefault(stem, value)
+    return out
+
+
 def _load_mdx_descriptions() -> dict[str, str]:
     """Walk the cached docs repo, return ``{component_id: description}``.
 
@@ -1882,16 +1911,11 @@ def _load_mdx_descriptions() -> dict[str, str]:
     Caches the cloned docs repo in ``.cache/esphome.io/`` so re-runs
     don't refetch.
     """
-    out: dict[str, str] = {}
-    for component_id, stem, mdx_path in _iter_component_mdx():
-        text = _extract_mdx_description(mdx_path.read_text(encoding="utf-8"))
-        if text:
-            out[component_id] = text
-            # Also index under the bare stem if it's not already taken,
-            # so e.g. ``ota.esphome`` falls back to ``esphome.mdx`` if
-            # ever needed (rare, but cheap to support).
-            out.setdefault(stem, text)
-    return out
+    return _index_by_id_and_stem(
+        (component_id, stem, text)
+        for component_id, stem, mdx_path in _iter_component_mdx()
+        if (text := _extract_mdx_description(mdx_path.read_text(encoding="utf-8")))
+    )
 
 
 def _components_with_own_docs_page() -> frozenset[str]:
@@ -1917,13 +1941,11 @@ def _load_mdx_titles() -> dict[str, str]:
     "ESPHome OTA Updates"). Indexed by both the catalog id
     (``ota.esphome``) and the bare stem (``esphome``).
     """
-    out: dict[str, str] = {}
-    for component_id, stem, mdx_path in _iter_component_mdx():
-        title = _extract_mdx_title(mdx_path.read_text(encoding="utf-8"))
-        if title:
-            out[component_id] = title
-            out.setdefault(stem, title)
-    return out
+    return _index_by_id_and_stem(
+        (component_id, stem, title)
+        for component_id, stem, mdx_path in _iter_component_mdx()
+        if (title := _extract_mdx_title(mdx_path.read_text(encoding="utf-8")))
+    )
 
 
 # Frontmatter title matcher — same shape as the description matcher.
@@ -1953,13 +1975,11 @@ def _load_mdx_field_descriptions() -> dict[str, dict[str, str]]:
     Used to fill in per-field descriptions for components whose schema
     entries lack a ``docs`` field — most visibly the OTA platforms.
     """
-    out: dict[str, dict[str, str]] = {}
-    for component_id, stem, mdx_path in _iter_component_mdx():
-        fields = _extract_mdx_field_descriptions(mdx_path.read_text(encoding="utf-8"))
-        if fields:
-            out[component_id] = fields
-            out.setdefault(stem, fields)
-    return out
+    return _index_by_id_and_stem(
+        (component_id, stem, fields)
+        for component_id, stem, mdx_path in _iter_component_mdx()
+        if (fields := _extract_mdx_field_descriptions(mdx_path.read_text(encoding="utf-8")))
+    )
 
 
 # Top-level config-variable bullet line:
@@ -2130,13 +2150,11 @@ def _load_mdx_field_sections() -> dict[str, list[dict]]:
     Same id / stem keying as :func:`_load_mdx_field_descriptions`; feeds the
     nested field-description matcher.
     """
-    out: dict[str, list[dict]] = {}
-    for component_id, stem, mdx_path in _iter_component_mdx():
-        sections = _enumerate_mdx_field_sections(mdx_path.read_text(encoding="utf-8"))
-        if sections:
-            out[component_id] = sections
-            out.setdefault(stem, sections)
-    return out
+    return _index_by_id_and_stem(
+        (component_id, stem, sections)
+        for component_id, stem, mdx_path in _iter_component_mdx()
+        if (sections := _enumerate_mdx_field_sections(mdx_path.read_text(encoding="utf-8")))
+    )
 
 
 def _match_section_to_node(

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1870,14 +1870,10 @@ def _iter_component_mdx() -> Iterator[tuple[str, str, Path]]:
 
 def _index_by_id_and_stem[V](triples: Iterable[tuple[str, str, V]]) -> dict[str, V]:
     """
-    Index MDX values by catalog id and bare stem, dropping ambiguous stems.
+    Index by catalog id and bare stem; drop a stem whose pages disagree.
 
-    The bare-stem alias lets a top-level component (``animation``) pick up the
-    value from its domain page (``image/animation``) it can't reach by exact id.
-    But when two pages share a stem with different values (``image/animation``
-    "Animation" vs ``lvgl/animation`` "LVGL Animations") the alias is ambiguous,
-    and ``rglob`` walk order would pick a winner nondeterministically — so the
-    stem key is dropped and the caller keeps the schema-derived value. Exact
+    A bare stem shared by two pages with different values is dropped rather
+    than resolved by ``rglob`` walk order (non-deterministic). Exact
     catalog-id keys are always authoritative.
     """
     by_cid: dict[str, V] = {}

--- a/tests/test_sync_components_stem_alias.py
+++ b/tests/test_sync_components_stem_alias.py
@@ -1,0 +1,103 @@
+"""Tests for the MDX bare-stem aliasing in ``script/sync_components.py``.
+
+Pins ``_index_by_id_and_stem`` (the collision-aware id/stem index shared by the
+four ``_load_mdx_*`` loaders) and the name-backfill it feeds, so a stem claimed
+by two disagreeing docs pages (``image/animation`` vs ``lvgl/animation``) can't
+rename the top-level ``animation`` component to "LVGL Animations".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import script.sync_components as sc  # type: ignore[import-not-found]
+from script.sync_components import (  # type: ignore[import-not-found]
+    _backfill_descriptions_from_mdx,
+    _index_by_id_and_stem,
+)
+
+
+def test_exact_id_keys_are_authoritative() -> None:
+    """Each catalog id maps to its own value regardless of shared stems."""
+    out = _index_by_id_and_stem(
+        [
+            ("image.animation", "animation", "Animation"),
+            ("lvgl.animation", "animation", "LVGL Animations"),
+        ]
+    )
+    assert out["image.animation"] == "Animation"
+    assert out["lvgl.animation"] == "LVGL Animations"
+
+
+def test_ambiguous_stem_is_dropped() -> None:
+    """Two pages disagreeing on a stem drop the bare-stem alias entirely."""
+    out = _index_by_id_and_stem(
+        [
+            ("image.animation", "animation", "Animation"),
+            ("lvgl.animation", "animation", "LVGL Animations"),
+        ]
+    )
+    # The top-level ``animation`` id resolves only via this stem key; dropping
+    # it lets the name-backfill keep the schema-derived name.
+    assert "animation" not in out
+
+
+def test_unambiguous_stem_is_aliased() -> None:
+    """A stem owned by a single page still aliases so top-level ids find it."""
+    out = _index_by_id_and_stem([("ota.esphome", "esphome", "ESPHome OTA Updates")])
+    assert out["esphome"] == "ESPHome OTA Updates"
+
+
+def test_matching_values_on_a_shared_stem_are_not_ambiguous() -> None:
+    """Two pages agreeing on a stem keep the alias — no spurious drop."""
+    out = _index_by_id_and_stem([("a.thing", "thing", "V"), ("b.thing", "thing", "V")])
+    assert out["thing"] == "V"
+
+
+def test_id_equal_to_stem_stays_authoritative_through_a_collision() -> None:
+    """A top-level page's own id key survives a later same-stem collision."""
+    out = _index_by_id_and_stem([("thing", "thing", "Top"), ("b.thing", "thing", "Other")])
+    assert out["thing"] == "Top"
+
+
+def _entry(component_id: str, name: str) -> dict:
+    return {
+        "id": component_id,
+        "name": name,
+        "description": "Animated images on displays.",
+        "docs_url": "https://esphome.io/components/image/animation",
+        "config_entries": [],
+    }
+
+
+@pytest.fixture
+def _stub_mdx(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralise the docs-repo readers so backfill runs on injected dicts."""
+    monkeypatch.setattr(sc, "_load_mdx_descriptions", dict)
+    monkeypatch.setattr(sc, "_load_mdx_field_descriptions", dict)
+    monkeypatch.setattr(sc, "_load_mdx_field_sections", dict)
+    monkeypatch.setattr(sc, "_shared_docs_page_aliases", lambda _documented: {})
+
+
+@pytest.mark.usefixtures("_stub_mdx")
+def test_backfill_keeps_animation_name_when_stem_is_dropped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the ambiguous ``animation`` stem gone, the name is left untouched."""
+    # The fixed loader returns the image page under its exact id and no bare
+    # ``animation`` alias (the collision dropped it).
+    monkeypatch.setattr(sc, "_load_mdx_titles", lambda: {"image.animation": "Animation"})
+    entries = [_entry("animation", "Animation")]
+    _backfill_descriptions_from_mdx(entries)
+    assert entries[0]["name"] == "Animation"
+
+
+@pytest.mark.usefixtures("_stub_mdx")
+def test_backfill_would_rename_when_stem_bleeds_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Positive control: a polluted ``animation`` stem key is what renamed it."""
+    monkeypatch.setattr(sc, "_load_mdx_titles", lambda: {"animation": "LVGL Animations"})
+    entries = [_entry("animation", "Animation")]
+    _backfill_descriptions_from_mdx(entries)
+    assert entries[0]["name"] == "LVGL Animations"

--- a/tests/test_sync_components_stem_alias.py
+++ b/tests/test_sync_components_stem_alias.py
@@ -1,10 +1,4 @@
-"""Tests for the MDX bare-stem aliasing in ``script/sync_components.py``.
-
-Pins ``_index_by_id_and_stem`` (the collision-aware id/stem index shared by the
-four ``_load_mdx_*`` loaders) and the name-backfill it feeds, so a stem claimed
-by two disagreeing docs pages (``image/animation`` vs ``lvgl/animation``) can't
-rename the top-level ``animation`` component to "LVGL Animations".
-"""
+"""Pins ``_index_by_id_and_stem``: a bare stem two docs pages disagree on is dropped."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
# What does this implement/fix?

Nightly catalog-sync PR #2291 renamed the top-level `animation` component (category `misc`, `provides: ["image"]`, docs about animated GIFs on displays) from **"Animation" to "LVGL Animations"** — a name that bled from an unrelated LVGL docs page. That diff is the bug output and must not be merged; this fixes the generator so future syncs can't reintroduce it.

**Root cause.** The four `_load_mdx_*` loaders each index a docs page by catalog id *and* bare stem via `out.setdefault(stem, value)`. In the 2026.7.2 docs, two pages share the stem `animation`:

- `components/image/animation.mdx` → title "Animation"
- `components/lvgl/animation.mdx` → title "LVGL Animations"

`components_root.rglob("*.mdx")` has no ordering guarantee, so whichever page it walks first wins the bare `"animation"` key. The top-level `animation` component (cid == stem == `"animation"`, no cid-specific entry) resolves its name only through that ambiguous key, and the name-backfill *overwrites* a name that equals its stem-derived label — so the wrong title lands. `image.animation` is unaffected because its exact cid key wins. This also broke the sync's own "deterministic given a schema version" promise: a prior run produced "Animation", this one "LVGL Animations", purely from filesystem walk order. (Descriptions/fields carry the same latent alias but only backfill into empty slots, so they didn't visibly bleed.)

**Fix.** A shared `_index_by_id_and_stem` helper builds the `{id, stem}` index but drops any bare stem whose pages disagree — an ambiguous stem can't silently pick a walk-order winner, so the caller keeps the schema-derived value. Exact catalog-id keys stay authoritative. All four loaders route through it.

Verified against the live refreshed 2026.7.2 docs: `_load_mdx_titles()` now returns `image.animation` → "Animation", `lvgl.animation` → "LVGL Animations", bare `animation` → dropped; and the real name-backfill leaves a top-level `animation` entry named "Animation". No generated catalog JSON is edited (generator-only change); the next nightly regenerates a clean catalog, and #2291 should be closed.

**Related issue or feature (if applicable):**

- supersedes / blocks merging the bad diff in #2291 (nightly catalog sync)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
