### PR TITLE
Auto-discover cross-component gates from the live schema

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -298,7 +298,8 @@ _USE_ID_NAMESPACE_OVERRIDES: dict[str, str] = {
 _SECRET_KEY_FRAGMENTS = ("password", "passcode", "secret", "token", "api_key", "apikey")
 
 # Schema-time keys we don't expose to the user (build-system / preload).
-_SKIP_KEYS: frozenset[str] = frozenset({"mqtt_id", "zigbee_id", "then"})
+# ``*_id`` entries are auto-``GenerateID``'d internal references.
+_SKIP_KEYS: frozenset[str] = frozenset({"mqtt_id", "zigbee_id", "web_server_base_id", "then"})
 
 # Per-component fields we don't surface in the catalog because they're
 # deprecated and the dashboard handles the underlying concern itself.
@@ -328,45 +329,6 @@ _DEPRECATED_FIELDS: frozenset[tuple[str, str]] = frozenset(
 _BOARD_COMBOBOX_PLATFORMS: frozenset[str] = frozenset(
     {"esp8266", "nrf52", "bk72xx", "rtl87xx", "ln882x"}
 )
-
-# Cross-cutting fields that only make sense when a specific component
-# is configured on the same device — qos / retain need an ``mqtt:``
-# block, ``zigbee_sensor`` needs a ``zigbee:`` hub, and the
-# web_server entity overrides need a ``web_server:`` block. The
-# schema lists them on every entity (because they're valid options)
-# but most users never configure mqtt/zigbee/web_server, so without
-# gating the form is full of fields that quietly do nothing. The
-# frontend reads ``depends_on_component`` and hides each entry
-# unless the named component appears in the device's YAML.
-#
-# Fields upstream wraps in ``cv.requires_component(...)`` are gated
-# automatically from the live schema (``_collect_component_gates``) —
-# don't add those here; the hand entries below cover only gates the
-# walker can't see (``cv.OnlyWith`` keys and validator-less schema
-# refs) plus a name-keyed safety net for the core MQTT options.
-# Component-specific gates (e.g. "this LED option requires this LED
-# platform") belong in the per-component schema via ``depends_on`` /
-# ``depends_on_value_any`` instead.
-_COMPONENT_GATED_KEYS: dict[str, str] = {
-    # MQTT entity options (apply to every entity when ``mqtt:`` is set)
-    "qos": "mqtt",
-    "retain": "mqtt",
-    "discovery": "mqtt",
-    "subscribe_qos": "mqtt",
-    "state_topic": "mqtt",
-    "command_topic": "mqtt",
-    "availability": "mqtt",
-    # Zigbee entity options
-    "zigbee_sensor": "zigbee",
-    "zigbee_binary_sensor": "zigbee",
-    "zigbee_switch": "zigbee",
-    "zigbee_number": "zigbee",
-    # Web server entity overrides
-    "web_server": "web_server",
-    "web_server_id": "web_server",
-    "web_server_base_id": "web_server",
-}
-
 
 # UART ``DEBUG_SCHEMA`` shape — shared between ``uart.debug`` (the
 # original) and ``ble_nus.debug`` (which imports ``maybe_empty_debug``
@@ -2892,12 +2854,6 @@ def _convert_config_vars(
         override = _FIELD_OVERRIDES.get((component_id, key))
         if override is not None:
             entry = {**entry, **copy.deepcopy(override)}
-        # Cross-cutting infrastructure fields are only meaningful when
-        # the named component is configured. Tag them so the frontend
-        # can hide them by default.
-        gate = _COMPONENT_GATED_KEYS.get(key)
-        if gate and not entry.get("depends_on_component"):
-            entry["depends_on_component"] = gate
         out.append(entry)
     return _sort_entries(out)
 
@@ -5783,12 +5739,21 @@ def _collect_refined_types(  # noqa: C901
     return out
 
 
+@cache
+def _target_platform_names() -> frozenset[str]:
+    """Chip platform ids from esphome's ``Platform`` enum; empty if unimportable."""
+    try:
+        from esphome.const import Platform
+    except Exception:
+        return frozenset()
+    return frozenset(p.value for p in Platform)
+
+
 def _requires_component_gate(validator: Any) -> str | None:
     """
     Component name from a ``cv.requires_component`` validator chain, else None.
 
-    Peels ``vol.All`` wrappers; the first gate in chain order wins (zigbee's
-    ``report`` chains zigbee then esp32 — the entity gate, not the chip).
+    Peels ``vol.All`` wrappers; the first gate in chain order wins.
     """
     qualname = getattr(validator, "__qualname__", "") or ""
     if qualname.startswith("requires_component.") and (
@@ -5807,24 +5772,61 @@ def _requires_component_gate(validator: Any) -> str | None:
     return None
 
 
+def _only_with_gate(key: Any) -> str | None:
+    """
+    Component gating a ``cv.OnlyWith`` key marker, else None.
+
+    A list value requires every named component; the gate is the first
+    non-chip name (chip gating belongs to ``supported_platforms``).
+    """
+    if type(key).__name__ != "OnlyWith":
+        return None
+    if getattr(type(key), "__module__", "") != "esphome.config_validation":
+        return None
+    component = getattr(key, "_component", None)
+    names = component if isinstance(component, list) else [component]
+    chips = _target_platform_names()
+    for name in names:
+        if isinstance(name, str) and name and name not in chips:
+            return name
+    return None
+
+
 def _collect_component_gates(manifest: Any) -> dict[tuple[str, ...], str]:
     """
-    Walk the live ``CONFIG_SCHEMA`` for ``cv.requires_component`` gates.
+    Walk the live ``CONFIG_SCHEMA`` for cross-component gates.
 
-    The schema bundle drops the wrapper, so the gate is only recoverable
-    here; ``depends_on_component`` is stamped from the result (#2300).
+    Recovers what the schema bundle drops: ``cv.requires_component``
+    validator wrappers and ``cv.OnlyWith`` key markers. A container whose
+    every child carries one identical gate inherits it (the bare key has
+    nothing to introspect).
     """
     schema = getattr(manifest, "config_schema", None)
     if schema is None:
         return {}
     out: dict[tuple[str, ...], str] = {}
+    visited: list[tuple[str, ...]] = []
 
-    def visit(_key: Any, _key_name: str, val: Any, path: tuple[str, ...]) -> None:
-        gate = _requires_component_gate(val)
+    def visit(key: Any, _key_name: str, val: Any, path: tuple[str, ...]) -> None:
+        visited.append(path)
+        gate = _only_with_gate(key) or _requires_component_gate(val)
         if gate is not None:
             out[path] = gate
 
     _walk_schema_keys(schema, visit, descend_list_items=True)
+
+    visited_set = set(visited)
+    by_parent: dict[tuple[str, ...], list[tuple[str, ...]]] = {}
+    for path in visited:
+        if len(path) > 1:
+            by_parent.setdefault(path[:-1], []).append(path)
+    # Deepest parents first so an inherited gate can cascade upward.
+    for parent, kids in sorted(by_parent.items(), key=lambda kv: -len(kv[0])):
+        if parent in out or parent not in visited_set:
+            continue
+        gates = {out.get(kid) for kid in kids}
+        if len(gates) == 1 and (gate := next(iter(gates))) is not None:
+            out[parent] = gate
     return out
 
 
@@ -6331,10 +6333,10 @@ def _apply_component_gates(
     gates: dict[tuple[str, ...], str],
 ) -> None:
     """
-    Stamp introspected ``cv.requires_component`` gates onto matching entries.
+    Stamp introspected cross-component gates onto matching entries.
 
-    Explicit ``depends_on_component`` values (overrides, ``_COMPONENT_GATED_KEYS``,
-    ``default_with``) win; the introspected gate only fills the gap.
+    Explicit ``depends_on_component`` values (overrides, ``default_with``)
+    win; the introspected gate only fills the gap.
     """
     if not gates:
         return

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -339,9 +339,13 @@ _BOARD_COMBOBOX_PLATFORMS: frozenset[str] = frozenset(
 # frontend reads ``depends_on_component`` and hides each entry
 # unless the named component appears in the device's YAML.
 #
-# Keep this list focused on cross-cutting infrastructure. Component-
-# specific gates (e.g. "this LED option requires this LED platform")
-# belong in the per-component schema via ``depends_on`` /
+# Fields upstream wraps in ``cv.requires_component(...)`` are gated
+# automatically from the live schema (``_collect_component_gates``) —
+# don't add those here; the hand entries below cover only gates the
+# walker can't see (``cv.OnlyWith`` keys and validator-less schema
+# refs) plus a name-keyed safety net for the core MQTT options.
+# Component-specific gates (e.g. "this LED option requires this LED
+# platform") belong in the per-component schema via ``depends_on`` /
 # ``depends_on_value_any`` instead.
 _COMPONENT_GATED_KEYS: dict[str, str] = {
     # MQTT entity options (apply to every entity when ``mqtt:`` is set)
@@ -2621,6 +2625,7 @@ def build_component_entry(
         field_ranges = {k: v for k, v in field_ranges.items() if k not in bleed}
     _apply_field_ranges(config_entries, field_ranges)
     _apply_refined_types(config_entries, introspection.get("refined_types") or {})
+    _apply_component_gates(config_entries, introspection.get("component_gates") or {})
     _apply_typed_defaults(config_entries, introspection.get("typed_defaults") or {})
     _apply_inclusive_groups(config_entries, introspection.get("inclusive_groups") or {})
     _apply_list_fields(config_entries, introspection.get("list_fields") or {})
@@ -4716,6 +4721,7 @@ def introspect_component(component_id: str) -> dict[str, Any]:
         return merged
 
     refined_types = merge_from_platforms(_collect_refined_types)
+    component_gates = merge_from_platforms(_collect_component_gates)
     platform_constraints = merge_from_platforms(_collect_platform_constraints)
     field_ranges = _drop_machine_derived_ranges(
         component_id, merge_from_platforms(_collect_field_ranges)
@@ -4760,6 +4766,7 @@ def introspect_component(component_id: str) -> dict[str, Any]:
         "field_ranges": field_ranges,
         "field_range_bleed_keys": field_range_bleed_keys,
         "refined_types": refined_types,
+        "component_gates": component_gates,
         "inclusive_groups": inclusive_groups,
         "required_groups": required_groups,
         "list_fields": list_fields,
@@ -5776,6 +5783,51 @@ def _collect_refined_types(  # noqa: C901
     return out
 
 
+def _requires_component_gate(validator: Any) -> str | None:
+    """
+    Component name from a ``cv.requires_component`` validator chain, else None.
+
+    Peels ``vol.All`` wrappers; the first gate in chain order wins (zigbee's
+    ``report`` chains zigbee then esp32 — the entity gate, not the chip).
+    """
+    qualname = getattr(validator, "__qualname__", "") or ""
+    if qualname.startswith("requires_component.") and (
+        getattr(validator, "__module__", "") == "esphome.config_validation"
+    ):
+        try:
+            comp = _closure_nonlocals(validator).get("comp")
+        except ValueError:
+            comp = None
+        if isinstance(comp, str) and comp:
+            return comp
+    for inner in getattr(validator, "validators", None) or ():
+        gate = _requires_component_gate(inner)
+        if gate is not None:
+            return gate
+    return None
+
+
+def _collect_component_gates(manifest: Any) -> dict[tuple[str, ...], str]:
+    """
+    Walk the live ``CONFIG_SCHEMA`` for ``cv.requires_component`` gates.
+
+    The schema bundle drops the wrapper, so the gate is only recoverable
+    here; ``depends_on_component`` is stamped from the result (#2300).
+    """
+    schema = getattr(manifest, "config_schema", None)
+    if schema is None:
+        return {}
+    out: dict[tuple[str, ...], str] = {}
+
+    def visit(_key: Any, _key_name: str, val: Any, path: tuple[str, ...]) -> None:
+        gate = _requires_component_gate(val)
+        if gate is not None:
+            out[path] = gate
+
+    _walk_schema_keys(schema, visit, descend_list_items=True)
+    return out
+
+
 def _int_enum_refined_type(validator: Any) -> RefinedType | None:
     """Return an ``integer`` refinement iff *validator*'s live enum values are all real ints."""
     values = _extract_enum_values(validator)
@@ -6272,6 +6324,27 @@ def _normalize_bus_constraint_value(key: str, value: Any) -> Any:
     if key.endswith("timeout"):
         return cv.time_period(value).total_milliseconds
     return value
+
+
+def _apply_component_gates(
+    entries: list[dict],
+    gates: dict[tuple[str, ...], str],
+) -> None:
+    """
+    Stamp introspected ``cv.requires_component`` gates onto matching entries.
+
+    Explicit ``depends_on_component`` values (overrides, ``_COMPONENT_GATED_KEYS``,
+    ``default_with``) win; the introspected gate only fills the gap.
+    """
+    if not gates:
+        return
+
+    def visit(entry: dict, path: tuple[str, ...]) -> None:
+        gate = gates.get(path)
+        if gate and not entry.get("depends_on_component"):
+            entry["depends_on_component"] = gate
+
+    _walk_catalog_entries(entries, visit)
 
 
 def _apply_refined_types(

--- a/tests/test_sync_components_component_gates.py
+++ b/tests/test_sync_components_component_gates.py
@@ -1,4 +1,4 @@
-"""``cv.requires_component`` gates are auto-discovered from the live schema (#2300)."""
+"""Cross-component gates are auto-discovered from the live schema, not hand-listed."""
 
 from __future__ import annotations
 
@@ -26,8 +26,7 @@ def _manifest(schema) -> SimpleNamespace:
     return SimpleNamespace(config_schema=schema)
 
 
-def test_command_retain_gate_is_discovered(cv) -> None:
-    """The #2300 field: ``All(requires_component("mqtt"), boolean)`` yields the gate."""
+def test_requires_component_gate_is_discovered(cv) -> None:
     schema = cv.Schema(
         {cv.Optional("command_retain"): cv.All(cv.requires_component("mqtt"), cv.boolean)}
     )
@@ -59,6 +58,57 @@ def test_first_gate_in_a_multi_requires_chain_wins(cv) -> None:
         }
     )
     assert _collect_component_gates(_manifest(schema)) == {("report",): "zigbee"}
+
+
+def test_only_with_key_marker_is_discovered(cv) -> None:
+    schema = cv.Schema({cv.OnlyWith("web_server_id", "web_server"): cv.string})
+    assert _collect_component_gates(_manifest(schema)) == {("web_server_id",): "web_server"}
+
+
+def test_only_with_component_list_skips_chip_platforms(cv) -> None:
+    schema = cv.Schema({cv.OnlyWith("zigbee_switch", ["nrf52", "zigbee"]): cv.string})
+    assert _collect_component_gates(_manifest(schema)) == {("zigbee_switch",): "zigbee"}
+
+
+def test_only_without_is_not_a_gate(cv) -> None:
+    """``OnlyWithout`` keys on component absence; gating them would invert the meaning."""
+    schema = cv.Schema({cv.OnlyWithout("fallback", "wifi", default=True): cv.boolean})
+    assert _collect_component_gates(_manifest(schema)) == {}
+
+
+def test_container_with_unanimously_gated_children_inherits(cv) -> None:
+    schema = cv.Schema(
+        {
+            cv.Optional("web_server"): cv.Schema(
+                {
+                    cv.OnlyWith("web_server_id", "web_server"): cv.string,
+                    cv.Optional("sorting_weight"): cv.All(
+                        cv.requires_component("web_server"), cv.float_
+                    ),
+                }
+            )
+        }
+    )
+    gates = _collect_component_gates(_manifest(schema))
+    assert gates[("web_server",)] == "web_server"
+    assert gates[("web_server", "web_server_id")] == "web_server"
+    assert gates[("web_server", "sorting_weight")] == "web_server"
+
+
+def test_container_with_mixed_children_is_not_gated(cv) -> None:
+    schema = cv.Schema(
+        {
+            cv.Optional("box"): cv.Schema(
+                {
+                    cv.Optional("gated"): cv.All(cv.requires_component("mqtt"), cv.boolean),
+                    cv.Optional("plain"): cv.boolean,
+                }
+            )
+        }
+    )
+    gates = _collect_component_gates(_manifest(schema))
+    assert ("box",) not in gates
+    assert gates[("box", "gated")] == "mqtt"
 
 
 def test_ungated_fields_yield_nothing(cv) -> None:

--- a/tests/test_sync_components_default_extraction.py
+++ b/tests/test_sync_components_default_extraction.py
@@ -237,8 +237,8 @@ def test_convert_field_trigger_with_inner_config_vars_stays_nested(schema_dir: P
 def test_convert_field_unconditional_default_unchanged(schema_dir: Path) -> None:
     """Plain ``cv.Optional(K, default=True)`` flows through with no gate.
 
-    ``retain``'s ``_COMPONENT_GATED_KEYS`` membership applies in
-    ``_convert_config_vars``, not ``_convert_field``.
+    ``retain``'s mqtt gate is stamped from live introspection
+    (``_apply_component_gates``), not schema conversion.
     """
     raw = {"default": "true", "key": "Optional", "type": "boolean"}
     entry = _convert_field("retain", raw, schema_dir)

--- a/tests/test_sync_components_mqtt_gated_keys.py
+++ b/tests/test_sync_components_mqtt_gated_keys.py
@@ -1,0 +1,83 @@
+"""``cv.requires_component`` gates are auto-discovered from the live schema (#2300)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from script.sync_components import (  # type: ignore[import-not-found]
+    _apply_component_gates,
+    _collect_component_gates,
+)
+
+
+@pytest.fixture
+def cv():
+    """Lazy-import esphome's config_validation; skip if unavailable."""
+    try:
+        from esphome import config_validation as _cv  # noqa: PLC0415
+    except Exception:
+        pytest.skip("esphome.config_validation not importable")
+    return _cv
+
+
+def _manifest(schema) -> SimpleNamespace:
+    return SimpleNamespace(config_schema=schema)
+
+
+def test_command_retain_gate_is_discovered(cv) -> None:
+    """The #2300 field: ``All(requires_component("mqtt"), boolean)`` yields the gate."""
+    schema = cv.Schema(
+        {cv.Optional("command_retain"): cv.All(cv.requires_component("mqtt"), cv.boolean)}
+    )
+    assert _collect_component_gates(_manifest(schema)) == {("command_retain",): "mqtt"}
+
+
+def test_core_mqtt_command_schema_gates_every_field(cv) -> None:
+    """The real upstream schema yields the full MQTT entity-option inventory."""
+    gates = _collect_component_gates(_manifest(cv.MQTT_COMMAND_COMPONENT_SCHEMA))
+    expected = {
+        "qos",
+        "retain",
+        "discovery",
+        "subscribe_qos",
+        "state_topic",
+        "command_topic",
+        "command_retain",
+        "availability",
+    }
+    assert {path[0] for path, gate in gates.items() if gate == "mqtt"} >= expected
+
+
+def test_first_gate_in_a_multi_requires_chain_wins(cv) -> None:
+    schema = cv.Schema(
+        {
+            cv.Optional("report"): cv.All(
+                cv.requires_component("zigbee"), cv.requires_component("esp32"), cv.boolean
+            )
+        }
+    )
+    assert _collect_component_gates(_manifest(schema)) == {("report",): "zigbee"}
+
+
+def test_ungated_fields_yield_nothing(cv) -> None:
+    """Plain validators (sensor's ``force_update``) must not grow a gate."""
+    schema = cv.Schema({cv.Optional("force_update", default=False): cv.boolean})
+    assert _collect_component_gates(_manifest(schema)) == {}
+
+
+def test_apply_stamps_matching_paths() -> None:
+    entries = [
+        {"key": "command_retain", "depends_on_component": None},
+        {"key": "name", "depends_on_component": None},
+    ]
+    _apply_component_gates(entries, {("command_retain",): "mqtt"})
+    assert entries[0]["depends_on_component"] == "mqtt"
+    assert entries[1]["depends_on_component"] is None
+
+
+def test_apply_never_overrides_an_explicit_gate() -> None:
+    entries = [{"key": "command_retain", "depends_on_component": "custom"}]
+    _apply_component_gates(entries, {("command_retain",): "mqtt"})
+    assert entries[0]["depends_on_component"] == "custom"


### PR DESCRIPTION
# What does this implement/fix?

The Visual Editor shows a "Command Retain" toggle on a `switch` platform's Advanced settings even when no `mqtt:` block exists; toggling it writes `command_retain:` into the YAML, which esphome rejects (`This option requires component mqtt`), and the user has to hand-edit the YAML to recover (#2300).

**Root cause.** The frontend hides a field only when its catalog entry carries `depends_on_component` naming a component absent from the YAML. That marker came exclusively from the hand-maintained `_COMPONENT_GATED_KEYS` map — the schema bundle drops esphome's `cv.requires_component("mqtt")` wrappers, so nothing derived the gate. The map covered `qos` / `retain` / `discovery` / `subscribe_qos` / `state_topic` / `command_topic` / `availability` but missed `command_retain`, so every `command_retain` entry shipped ungated and rendered unconditionally. Auditing upstream showed the hand list had rotted well beyond the one field: 36 distinct MQTT-only keys were ungated (climate's 21 `*_state_topic` / `*_command_topic` keys, fan's 8, cover/valve's `position_*` / `tilt_*` topics and `mqtt_json_state_payload`, sensor's `expire_after`, and `command_retain` itself).

**Fix: derive the gates instead of hand-listing them; the hand map is deleted.** The sync already walks each component's live voluptuous `CONFIG_SCHEMA` for type refinement (`_collect_refined_types`), and every gate source is introspectable the same way:

- `cv.requires_component(comp)` validators: the closure's `__qualname__` identifies the factory and its `comp` freevar carries the component name. `vol.All` chains are peeled; in a multi-gate chain (zigbee's `report` chains `zigbee` then `esp32`) the first gate wins.
- `cv.OnlyWith` key markers (the zigbee entity ids, `web_server_id`): the marker object carries `_component`, a name or a list; from a list the first non-chip name wins, with the chip set derived from `esphome.const.Platform` (`OnlyWithout` is explicitly excluded since it keys on component absence).
- Containers with nothing to introspect on the bare key (the entity `web_server` sorting block): a container whose every child carries one identical gate inherits it.

A new `_collect_component_gates` walker (sharing `_walk_schema_keys` / `_closure_nonlocals`) records `{key_path: component}`, merged across platform manifests like every other introspection channel, and `_apply_component_gates` stamps `depends_on_component` onto the matching catalog entries (explicit values from overrides / `default_with` still win). `_COMPONENT_GATED_KEYS` is gone entirely; `web_server_base_id`, the one entry no walker can see, is an auto-`GenerateID`'d internal reference and moves to `_SKIP_KEYS` beside `mqtt_id` / `zigbee_id` (its three catalog entries drop).

This discovers all 36 missed MQTT keys, the nested entity sub-schema copies (e.g. haier's per-sensor `state_topic` at `('compressor_current', 'state_topic')`), and the `zigbee` / `web_server` / `psram` / `image` / `font` gates too — and any field esphome gates in a future release is picked up with no code change.

Verified end-to-end against the live esphome install: `introspect_component` on `gpio` / `haier` / `tuya` / `he60r` / `fs3000` discovers the full expected mqtt inventories (8 / 55 / 43 / 13 / 7 gated paths); on `gpio` / `xiaomi_mjyd02yla` the derived `web_server` and `zigbee` gates reproduce every gate the hand map used to stamp at the identical nested paths (all 560 catalog carriers nest `web_server_id` inside `web_server`, matching the live walk), plus the previously missing `sorting_weight` / `sorting_group_id` gates; and `force_update` (plain `cv.boolean` upstream, valid without MQTT) correctly gains no gate.

No catalog JSON is edited here (generated files are never hand-edited); the next nightly catalog sync stamps the gates across the affected definition files. The frontend needs no change — `isEntryVisible` already honors `depends_on_component`, exactly how the sibling MQTT fields (`qos`, `retain`, ...) behave today.

Note for anyone hitting this today: a YAML that already contains `command_retain` still can't be cleared from the UI (the boolean renderer has no "unset" state); that is a separate frontend limitation, tracked independently.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2300

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
