### PR TITLE
Drop the stale mqtt self-gate pin; guard gate discovery with floors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,13 @@ Home Assistant add-on.
   retelling the production story (name what the test pins, in one
   sentence); "same shape as X / mirrors Y" framing.
 
+  **The most-repeated review nit in this repo** is a fresh docstring
+  that states the contract and then keeps going: a second sentence or
+  paragraph of why the code exists, what breaks without it, or which
+  CI job catches the regression. Write the one-line contract and stop;
+  the justification goes in the PR body. Before committing, reread
+  every new docstring and delete everything after the contract.
+
 - **Comments**: same bar. Default to none. Add one only when the *why*
   is non-obvious: a hidden constraint, subtle invariant, bug workaround,
   surprising behaviour. **Don't remove existing comments** unless the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,13 +60,6 @@ Home Assistant add-on.
   retelling the production story (name what the test pins, in one
   sentence); "same shape as X / mirrors Y" framing.
 
-  **The most-repeated review nit in this repo** is a fresh docstring
-  that states the contract and then keeps going: a second sentence or
-  paragraph of why the code exists, what breaks without it, or which
-  CI job catches the regression. Write the one-line contract and stop;
-  the justification goes in the PR body. Before committing, reread
-  every new docstring and delete everything after the contract.
-
 - **Comments**: same bar. Default to none. Add one only when the *why*
   is non-obvious: a hidden constraint, subtle invariant, bug workaround,
   surprising behaviour. **Don't remove existing comments** unless the

--- a/script/check_catalog.py
+++ b/script/check_catalog.py
@@ -208,9 +208,11 @@ def main() -> int:  # noqa: C901
 
     failures.extend(_check_option_lists(catalog))
     failures.extend(_check_component_gating(catalog))
-    failures.extend(_check_gating_floors(catalog))
+    # One shared body pass feeds the full-catalog checks below.
+    all_bodies = [(cid, _load_body_from_disk(cid)) for cid in catalog._by_id]
+    failures.extend(_check_gating_floors(all_bodies))
     failures.extend(_check_no_field_bullet_descriptions(catalog))
-    failures.extend(_check_boolean_options_exclusive(catalog))
+    failures.extend(_check_boolean_options_exclusive(all_bodies))
 
     if failures:
         print(f"FAIL: {len(failures)} catalog regression(s):")
@@ -262,6 +264,8 @@ _GATING_EXPECTATIONS: list[tuple[str, str, str]] = [
     # sensor via ``_SENSOR_SCHEMA``; they must be gated.
     ("sensor.ct_clamp", "zigbee_sensor", "zigbee"),
     ("sensor.ct_clamp", "web_server", "web_server"),
+    # MQTT entity option inherited via ``MQTT_COMPONENT_SCHEMA``.
+    ("switch.gpio", "state_topic", "mqtt"),
 ]
 
 # Catalog-wide floors on gated-entry counts. The per-field rules above
@@ -358,11 +362,10 @@ def _check_component_gating(catalog: ComponentCatalog) -> list[str]:
     return failures
 
 
-def _check_gating_floors(catalog: ComponentCatalog) -> list[str]:
+def _check_gating_floors(bodies: list[tuple[str, Any]]) -> list[str]:
     """Return a failure per gate whose catalog-wide entry count fell below its floor."""
     counts: dict[str, int] = {}
-    for cid in catalog._by_id:
-        component = _load_body_from_disk(cid)
+    for _cid, component in bodies:
         if component is None:
             continue
         stack = list(component.config_entries or [])
@@ -382,7 +385,7 @@ def _check_gating_floors(catalog: ComponentCatalog) -> list[str]:
     return failures
 
 
-def _check_boolean_options_exclusive(catalog: ComponentCatalog) -> list[str]:
+def _check_boolean_options_exclusive(bodies: list[tuple[str, Any]]) -> list[str]:
     """Fail on any entry typed ``boolean`` that also carries an option list.
 
     The frontend renders any entry with options as a dropdown, so a boolean
@@ -401,8 +404,7 @@ def _check_boolean_options_exclusive(catalog: ComponentCatalog) -> list[str]:
             if entry.config_entries:
                 walk(cid, entry.config_entries, f"{path}.")
 
-    for cid in catalog._by_id:
-        component = _load_body_from_disk(cid)
+    for cid, component in bodies:
         if component is None:
             failures.append(f"boolean/options check: missing body for {cid}")
         elif component.config_entries:

--- a/script/check_catalog.py
+++ b/script/check_catalog.py
@@ -208,6 +208,7 @@ def main() -> int:  # noqa: C901
 
     failures.extend(_check_option_lists(catalog))
     failures.extend(_check_component_gating(catalog))
+    failures.extend(_check_gating_floors(catalog))
     failures.extend(_check_no_field_bullet_descriptions(catalog))
     failures.extend(_check_boolean_options_exclusive(catalog))
 
@@ -222,6 +223,7 @@ def main() -> int:  # noqa: C901
         f"OK: {len(_EXPECTATIONS)} components, {field_count} fields, "
         f"{len(_OPTION_EXPECTATIONS)} option lists, "
         f"{len(_GATING_EXPECTATIONS)} gating rules, "
+        f"{len(_GATING_FLOORS)} gating floors, "
         "boolean/options exclusivity verified."
     )
     return 0
@@ -247,20 +249,34 @@ _OPTION_EXPECTATIONS: list[tuple[str, str, int]] = [
 
 
 # Cross-component gating assertions. Catches regressions where
-# infrastructure-dependent fields (zigbee_sensor, web_server, mqtt
-# discovery) lose their ``depends_on_component`` tag and start
-# showing up on the form even when the named component isn't
-# configured on the device.
+# infrastructure-dependent fields (zigbee_sensor, web_server) lose
+# their ``depends_on_component`` tag and start showing up on the
+# form even when the named component isn't configured on the device.
+# Gates are introspected from the live schema (requires_component /
+# OnlyWith), so a component's own fields carry no self-gate; only
+# entity-level inheritances belong here. The derivation itself is
+# pinned against live manifests in
+# ``tests/test_sync_components_component_gates.py``.
 _GATING_EXPECTATIONS: list[tuple[str, str, str]] = [
     # Zigbee + web_server entity options are inherited onto every
     # sensor via ``_SENSOR_SCHEMA``; they must be gated.
     ("sensor.ct_clamp", "zigbee_sensor", "zigbee"),
     ("sensor.ct_clamp", "web_server", "web_server"),
-    # MQTT-internal fields (inside the ``mqtt`` component itself).
-    # Gated even on the mqtt component because the field is only
-    # meaningful when the broker is configured downstream.
-    ("mqtt", "discovery", "mqtt"),
 ]
+
+# Catalog-wide floors on gated-entry counts. The per-field rules above
+# can't catch the wholesale failure mode: live-schema introspection
+# silently returning nothing (esphome upstream reshapes the
+# ``requires_component`` closures or ``OnlyWith`` markers, the walker
+# breaks) and a sync shipping a catalog with every gate stripped —
+# thousands of MQTT/zigbee/web_server fields un-hidden at once. Floors
+# sit at roughly half the current counts (mqtt 12719, web_server 4125,
+# zigbee 1792) so legitimate churn passes and wholesale loss fails.
+_GATING_FLOORS: dict[str, int] = {
+    "mqtt": 6000,
+    "web_server": 2000,
+    "zigbee": 800,
+}
 
 
 def _resolve_field(component: Any, path: str) -> Any:
@@ -338,6 +354,30 @@ def _check_component_gating(catalog: ComponentCatalog) -> list[str]:
             failures.append(
                 f"{cid}.{path}: depends_on_component expected {gate!r}, "
                 f"got {entry.depends_on_component!r}"
+            )
+    return failures
+
+
+def _check_gating_floors(catalog: ComponentCatalog) -> list[str]:
+    """Return a failure per gate whose catalog-wide entry count fell below its floor."""
+    counts: dict[str, int] = {}
+    for cid in catalog._by_id:
+        component = _load_body_from_disk(cid)
+        if component is None:
+            continue
+        stack = list(component.config_entries or [])
+        while stack:
+            entry = stack.pop()
+            if entry.depends_on_component:
+                counts[entry.depends_on_component] = counts.get(entry.depends_on_component, 0) + 1
+            stack.extend(entry.config_entries or [])
+    failures: list[str] = []
+    for gate, floor in _GATING_FLOORS.items():
+        if counts.get(gate, 0) < floor:
+            failures.append(
+                f"gating floor: {counts.get(gate, 0)} entries gated on {gate!r}, "
+                f"expected at least {floor} — introspection likely stopped "
+                "discovering gates"
             )
     return failures
 

--- a/tests/test_sync_components_component_gates.py
+++ b/tests/test_sync_components_component_gates.py
@@ -146,5 +146,6 @@ def test_live_switch_platform_derives_the_mqtt_gates(cv) -> None:
 
 def test_live_mqtt_component_has_no_self_gate(cv) -> None:
     """The mqtt component's own fields carry no gate on mqtt itself."""
-    gates = introspect_component("mqtt").get("component_gates") or {}
-    assert ("discovery",) not in gates
+    info = introspect_component("mqtt")
+    assert info, "mqtt manifest did not introspect"
+    assert ("discovery",) not in (info.get("component_gates") or {})

--- a/tests/test_sync_components_component_gates.py
+++ b/tests/test_sync_components_component_gates.py
@@ -9,6 +9,7 @@ import pytest
 from script.sync_components import (  # type: ignore[import-not-found]
     _apply_component_gates,
     _collect_component_gates,
+    introspect_component,
 )
 
 
@@ -131,3 +132,24 @@ def test_apply_never_overrides_an_explicit_gate() -> None:
     entries = [{"key": "command_retain", "depends_on_component": "custom"}]
     _apply_component_gates(entries, {("command_retain",): "mqtt"})
     assert entries[0]["depends_on_component"] == "custom"
+
+
+def test_live_switch_platform_derives_the_mqtt_gates(cv) -> None:
+    """The installed esphome's real gpio manifests yield the entity MQTT gates.
+
+    Runs against the esphome dev matrix too, so an upstream reshape of the
+    ``requires_component`` closures or ``OnlyWith`` markers fails here before
+    a nightly sync can ship a catalog with the gates stripped.
+    """
+    gates = introspect_component("gpio").get("component_gates") or {}
+    assert gates.get(("command_retain",)) == "mqtt"
+    assert gates.get(("state_topic",)) == "mqtt"
+    assert gates.get(("web_server",)) == "web_server"
+    assert gates.get(("web_server", "web_server_id")) == "web_server"
+    assert gates.get(("zigbee_switch",)) == "zigbee"
+
+
+def test_live_mqtt_component_has_no_self_gate(cv) -> None:
+    """The mqtt component's own fields carry no gate on mqtt itself."""
+    gates = introspect_component("mqtt").get("component_gates") or {}
+    assert ("discovery",) not in gates

--- a/tests/test_sync_components_component_gates.py
+++ b/tests/test_sync_components_component_gates.py
@@ -135,12 +135,7 @@ def test_apply_never_overrides_an_explicit_gate() -> None:
 
 
 def test_live_switch_platform_derives_the_mqtt_gates(cv) -> None:
-    """The installed esphome's real gpio manifests yield the entity MQTT gates.
-
-    Runs against the esphome dev matrix too, so an upstream reshape of the
-    ``requires_component`` closures or ``OnlyWith`` markers fails here before
-    a nightly sync can ship a catalog with the gates stripped.
-    """
+    """The installed esphome's real gpio manifests yield the entity gates."""
     gates = introspect_component("gpio").get("component_gates") or {}
     assert gates.get(("command_retain",)) == "mqtt"
     assert gates.get(("state_topic",)) == "mqtt"


### PR DESCRIPTION
# What does this implement/fix?

The catalog-sync run after #2301 failed its smoke test on one assertion: `mqtt.discovery: depends_on_component expected 'mqtt', got None` ([run](https://github.com/esphome/device-builder/actions/runs/30118318503)).

That pin was an artifact of the deleted hand map, which stamped gates by key name on every component including the mqtt component's own page. The self-gate was a no-op in the editor (an `mqtt:` block is by definition present while editing it), and the featured-add flow carries an explicit self-domain allowance for it (`test_drop_unconfigured_dependent_fields_keeps_self_domain`). Introspection correctly derives no self-gate, so the expectation is stale, not the sync. The zigbee / web_server entity expectations passed on the same run, confirming the derived gates landed.

Beyond dropping the stale row, this hardens the pipeline against the failure mode that actually matters: live-schema introspection silently returning nothing (an upstream esphome reshape of the `requires_component` closures or `OnlyWith` markers, a walker break) and a nightly shipping a catalog with every gate stripped — thousands of MQTT/zigbee/web_server fields un-hidden at once, reintroducing #2300 wholesale.

Two complementary guards:

- **Live-derivation pytest pins** (`tests/test_sync_components_component_gates.py`): `introspect_component` against the installed esphome's real `gpio` and `mqtt` manifests must derive `command_retain` / `state_topic` / nested `web_server.web_server_id` / `zigbee_switch` gates, and no self-gate on mqtt's own `discovery`. These run in the regular test matrix including the esphome **dev** job, so an upstream break fails PR CI before the nightly ever runs.
- **Catalog-wide gating floors** (`script/check_catalog.py::_check_gating_floors`): the generated catalog must carry at least 6000 mqtt-, 2000 web_server-, and 800 zigbee-gated entries (roughly half of today's 12719 / 4125 / 1792). Per-field pins can't catch wholesale loss; the floors fail the sync workflow before a degraded catalog reaches a PR. Transition-safe: they hold for both the current checked-in catalog and the regenerated one.

Per-field mqtt smoke coverage lands now via `("switch.gpio", "state_topic", "mqtt")`, which holds in both the checked-in and regenerated catalogs. Two more rows are blocked until the regenerated catalog merges (`check_catalog.py` also runs in `test.yml` against the checked-in catalog): `("switch.gpio", "command_retain", "mqtt")` and the self-gate absence pin `("mqtt", "discovery", None)` (with the tuple type widened to `str | None`); the live pytest pins cover both regression classes in the meantime.

After this merges, re-dispatching the sync workflow should go green and open the catalog PR with the new gates.

**Related issue or feature (if applicable):**

- fixes the failed catalog-sync run after #2301 (https://github.com/esphome/device-builder/actions/runs/30118318503)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
