### PR TITLE
Pin the recurring docstring-review failure shape in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,13 @@ Home Assistant add-on.
   retelling the production story (name what the test pins, in one
   sentence); "same shape as X / mirrors Y" framing.
 
+  **The most-repeated review nit in this repo** is a fresh docstring
+  that states the contract and then keeps going: a second sentence or
+  paragraph of why the code exists, what breaks without it, or which
+  CI job catches the regression. Write the one-line contract and stop;
+  the justification goes in the PR body. Before committing, reread
+  every new docstring and delete everything after the contract.
+
 - **Comments**: same bar. Default to none. Add one only when the *why*
   is non-obvious: a hidden constraint, subtle invariant, bug workaround,
   surprising behaviour. **Don't remove existing comments** unless the


### PR DESCRIPTION
# What does this implement/fix?

The most-repeated automated-review nit in this repo is a fresh docstring that states the contract and then keeps going: a second sentence or paragraph of why the code exists, what breaks without it, or which CI job catches the regression. It was flagged three times in one day (#2293, #2301, #2302), always that same shape, despite the existing terse-docstring guidance.

This adds a short paragraph to the Code style section naming the failure shape explicitly and the pre-commit self-check that prevents it: write the one-line contract and stop; reread every new docstring before committing and delete everything after the contract.

**Related issue or feature (if applicable):**

- follow-up to review threads on #2302

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.