### PR TITLE
Restore web_server_base_id to the catalog

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -298,8 +298,8 @@ _USE_ID_NAMESPACE_OVERRIDES: dict[str, str] = {
 _SECRET_KEY_FRAGMENTS = ("password", "passcode", "secret", "token", "api_key", "apikey")
 
 # Schema-time keys we don't expose to the user (build-system / preload).
-# ``web_server_base_id`` is deliberately absent: singleton auto-loaded
-# base ids stay in the catalog as advanced pickers (#1441).
+# Do not add ``web_server_base_id``: singleton auto-loaded base ids
+# stay in the catalog as advanced pickers (#1441).
 _SKIP_KEYS: frozenset[str] = frozenset({"mqtt_id", "zigbee_id", "then"})
 
 # Per-component fields we don't surface in the catalog because they're

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -298,6 +298,7 @@ _USE_ID_NAMESPACE_OVERRIDES: dict[str, str] = {
 _SECRET_KEY_FRAGMENTS = ("password", "passcode", "secret", "token", "api_key", "apikey")
 
 # Schema-time keys we don't expose to the user (build-system / preload).
+# ``mqtt_id`` / ``zigbee_id`` are auto-``GenerateID``'d internal refs.
 # Do not add ``web_server_base_id``: singleton auto-loaded base ids
 # stay in the catalog as advanced pickers (#1441).
 _SKIP_KEYS: frozenset[str] = frozenset({"mqtt_id", "zigbee_id", "then"})

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -298,8 +298,9 @@ _USE_ID_NAMESPACE_OVERRIDES: dict[str, str] = {
 _SECRET_KEY_FRAGMENTS = ("password", "passcode", "secret", "token", "api_key", "apikey")
 
 # Schema-time keys we don't expose to the user (build-system / preload).
-# ``*_id`` entries are auto-``GenerateID``'d internal references.
-_SKIP_KEYS: frozenset[str] = frozenset({"mqtt_id", "zigbee_id", "web_server_base_id", "then"})
+# ``web_server_base_id`` is deliberately absent: singleton auto-loaded
+# base ids stay in the catalog as advanced pickers (#1441).
+_SKIP_KEYS: frozenset[str] = frozenset({"mqtt_id", "zigbee_id", "then"})
 
 # Per-component fields we don't surface in the catalog because they're
 # deprecated and the dashboard handles the underlying concern itself.

--- a/tests/test_sync_components_sub_readings.py
+++ b/tests/test_sync_components_sub_readings.py
@@ -322,15 +322,23 @@ def test_resolve_auto_load_forces_and_restores_core_platform() -> None:
             core.pop(KEY_TARGET_PLATFORM, None)
 
 
-def test_web_server_base_id_converts_to_an_entry(tmp_path: Path) -> None:
-    """``web_server_base_id`` is not in ``_SKIP_KEYS``; it must survive conversion."""
+def test_web_server_base_id_converts_to_a_reference_entry(tmp_path: Path) -> None:
+    """A ``web_server_base_id`` config var survives conversion as a base-id picker."""
     from script.sync_components import _convert_config_vars  # noqa: PLC0415
 
     entries = _convert_config_vars(
-        {"config_vars": {"web_server_base_id": {"key": "GeneratedID", "use_id_type": True}}},
+        {
+            "config_vars": {
+                "web_server_base_id": {
+                    "key": "GeneratedID",
+                    "use_id_type": "web_server_base::WebServerBase",
+                }
+            }
+        },
         tmp_path,
     )
     assert [e["key"] for e in entries] == ["web_server_base_id"]
+    assert entries[0]["references_component"] == "web_server_base"
 
 
 def test_catalog_singleton_base_ids_advanced_multi_stay_shown() -> None:

--- a/tests/test_sync_components_sub_readings.py
+++ b/tests/test_sync_components_sub_readings.py
@@ -322,6 +322,17 @@ def test_resolve_auto_load_forces_and_restores_core_platform() -> None:
             core.pop(KEY_TARGET_PLATFORM, None)
 
 
+def test_web_server_base_id_converts_to_an_entry(tmp_path: Path) -> None:
+    """``web_server_base_id`` is not in ``_SKIP_KEYS``; it must survive conversion."""
+    from script.sync_components import _convert_config_vars  # noqa: PLC0415
+
+    entries = _convert_config_vars(
+        {"config_vars": {"web_server_base_id": {"key": "GeneratedID", "use_id_type": True}}},
+        tmp_path,
+    )
+    assert [e["key"] for e in entries] == ["web_server_base_id"]
+
+
 def test_catalog_singleton_base_ids_advanced_multi_stay_shown() -> None:
     """Singleton auto-loaded base ids hide; multi-instance pickers stay on the main form."""
     ws = {e["key"]: e for e in _load_body("web_server")["config_entries"]}


### PR DESCRIPTION
# What does this implement/fix?

The regenerated-catalog PR #2304 fails its Pytest matrix on `test_catalog_singleton_base_ids_advanced_multi_stay_shown`: `KeyError: 'web_server_base_id'`.

#2301 added `web_server_base_id` to `_SKIP_KEYS` on the reasoning that it is an auto-`GenerateID`'d internal reference like `mqtt_id` / `zigbee_id`. That overrode an intentional earlier design: #1441 / #1456 deliberately keep singleton auto-loaded base ids in the catalog as **advanced** id pickers (so a config with multiple `web_server_base` instances can still target one), while multi-instance ids (`modbus_id`, `spi_id`) stay on the main form. The test pinning that design reads the checked-in catalog, so the conflict stayed latent through #2301's green CI and only fired once the regenerated catalog (without the entries) landed on the sync branch.

This restores the entry: `web_server_base_id` is removed from `_SKIP_KEYS` with a comment recording the deliberate absence, and a new generator-level test pins that the key survives `_convert_config_vars` — that pin bites pre-regeneration (verified: the conversion yields the entry on this branch and `[]` with the key in `_SKIP_KEYS`), unlike the catalog-level test that let #2301 slip through.

One intentional delta versus the pre-#2301 catalog: the restored entries carry no `depends_on_component` (the deleted hand map stamped them `web_server`). That gate was wrong for this field — `captive_portal` / `prometheus` AUTO_LOAD `web_server_base`, so the picker is valid without any `web_server:` block; the entry stays hidden behind the Advanced disclosure either way. The catalog-level pin only asserts `references_component` + `advanced`, both preserved.

After this merges, re-dispatching the sync workflow refreshes the catalog branch; the three entries return and #2304's Pytest goes green.

**Related issue or feature (if applicable):**

- fixes the Pytest failures on #2304 (regression from #2301)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
