### PR TITLE
Cover the gating-floor failure branches and discovery boundary cases

### DIFF
--- a/script/check_catalog.py
+++ b/script/check_catalog.py
@@ -274,12 +274,14 @@ _GATING_EXPECTATIONS: list[tuple[str, str, str]] = [
 # ``requires_component`` closures or ``OnlyWith`` markers, the walker
 # breaks) and a sync shipping a catalog with every gate stripped —
 # thousands of MQTT/zigbee/web_server fields un-hidden at once. Floors
-# sit at roughly half the current counts (mqtt 12719, web_server 4125,
-# zigbee 1792) so legitimate churn passes and wholesale loss fails.
+# sit well below the live counts so legitimate churn passes and
+# wholesale loss fails; the band test in
+# ``tests/test_check_catalog_guards.py`` keeps them calibrated against
+# the checked-in catalog from both sides.
 _GATING_FLOORS: dict[str, int] = {
     "mqtt": 6000,
     "web_server": 2000,
-    "zigbee": 800,
+    "zigbee": 1600,
 }
 
 

--- a/tests/test_check_catalog_guards.py
+++ b/tests/test_check_catalog_guards.py
@@ -1,4 +1,4 @@
-"""Pins ``script/check_catalog.py``'s gating guards, including their failure branches."""
+"""Pins ``check_catalog``'s full-catalog body guards, including failure branches."""
 
 from __future__ import annotations
 
@@ -7,7 +7,10 @@ from typing import Any
 
 from script.check_catalog import (  # type: ignore[import-not-found]
     _GATING_FLOORS,
+    ComponentCatalog,
+    _check_boolean_options_exclusive,
     _check_gating_floors,
+    _load_body_from_disk,
 )
 
 
@@ -47,5 +50,62 @@ def test_floor_tally_counts_nested_entries() -> None:
 
 
 def test_floor_tally_skips_missing_bodies() -> None:
+    # The floors silently skip a None body; the sibling boolean/options
+    # guard reports it, so the miss is covered when both run on the same
+    # list (as main() feeds them).
     bodies = [("gone", None), *_bodies_with(dict(_GATING_FLOORS))]
     assert _check_gating_floors(bodies) == []
+
+
+def test_floors_sit_in_a_sane_band_of_the_live_catalog() -> None:
+    """A floor typo (6000 -> 60, or above the live count) fails here, not in the field."""
+    catalog = ComponentCatalog()
+    catalog.load()
+    counts: dict[str, int] = {}
+    for cid in catalog._by_id:
+        component = _load_body_from_disk(cid)
+        if component is None:
+            continue
+        stack = list(component.config_entries or [])
+        while stack:
+            entry = stack.pop()
+            if entry.depends_on_component:
+                counts[entry.depends_on_component] = counts.get(entry.depends_on_component, 0) + 1
+            stack.extend(entry.config_entries or [])
+    for gate, floor in _GATING_FLOORS.items():
+        live = counts.get(gate, 0)
+        assert floor <= live, f"{gate} floor {floor} above live count {live}: would fire spuriously"
+        assert floor >= live // 4, f"{gate} floor {floor} uselessly low vs live count {live}"
+
+
+def _bool_entry(type_: str, options: list | None, children: list | None = None) -> SimpleNamespace:
+    return SimpleNamespace(key="k", type=type_, options=options, config_entries=children)
+
+
+def test_boolean_options_exclusive_flags_the_union_regression() -> None:
+    nested = _bool_entry("string", None, children=[_bool_entry("boolean", [{"value": "once"}])])
+    bodies = [("comp", SimpleNamespace(config_entries=[nested]))]
+    failures = _check_boolean_options_exclusive(bodies)
+    assert len(failures) == 1
+    assert "boolean entry carries an options list" in failures[0]
+
+
+def test_boolean_options_exclusive_passes_clean_entries() -> None:
+    bodies = [
+        (
+            "comp",
+            SimpleNamespace(
+                config_entries=[
+                    _bool_entry("boolean", None),
+                    _bool_entry("string", [{"value": "x"}]),
+                ]
+            ),
+        )
+    ]
+    assert _check_boolean_options_exclusive(bodies) == []
+
+
+def test_boolean_options_exclusive_reports_a_missing_body() -> None:
+    assert _check_boolean_options_exclusive([("gone", None)]) == [
+        "boolean/options check: missing body for gone"
+    ]

--- a/tests/test_check_catalog_guards.py
+++ b/tests/test_check_catalog_guards.py
@@ -1,0 +1,51 @@
+"""Pins ``script/check_catalog.py``'s gating guards, including their failure branches."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from script.check_catalog import (  # type: ignore[import-not-found]
+    _GATING_FLOORS,
+    _check_gating_floors,
+)
+
+
+def _entry(gate: str | None, children: list[Any] | None = None) -> SimpleNamespace:
+    return SimpleNamespace(depends_on_component=gate, config_entries=children)
+
+
+def _bodies_with(counts: dict[str, int]) -> list[tuple[str, Any]]:
+    entries = [_entry(gate) for gate, n in counts.items() for _ in range(n)]
+    return [("synthetic", SimpleNamespace(config_entries=entries))]
+
+
+def test_floors_pass_at_the_floor() -> None:
+    assert _check_gating_floors(_bodies_with(dict(_GATING_FLOORS))) == []
+
+
+def test_floors_fail_one_below() -> None:
+    counts = dict(_GATING_FLOORS)
+    counts["mqtt"] -= 1
+    failures = _check_gating_floors(_bodies_with(counts))
+    assert len(failures) == 1
+    assert "mqtt" in failures[0]
+
+
+def test_floors_fail_loudly_on_an_empty_catalog() -> None:
+    """The wholesale-loss scenario: no gates anywhere trips every floor."""
+    failures = _check_gating_floors([("empty", SimpleNamespace(config_entries=[]))])
+    assert len(failures) == len(_GATING_FLOORS)
+
+
+def test_floor_tally_counts_nested_entries() -> None:
+    n = _GATING_FLOORS["mqtt"]
+    nested = _entry(None, children=[_entry("mqtt") for _ in range(n)])
+    others = _bodies_with({k: v for k, v in _GATING_FLOORS.items() if k != "mqtt"})
+    failures = _check_gating_floors([("nested", SimpleNamespace(config_entries=[nested])), *others])
+    assert failures == []
+
+
+def test_floor_tally_skips_missing_bodies() -> None:
+    bodies = [("gone", None), *_bodies_with(dict(_GATING_FLOORS))]
+    assert _check_gating_floors(bodies) == []

--- a/tests/test_check_catalog_guards.py
+++ b/tests/test_check_catalog_guards.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
+
+from esphome_device_builder.controllers.components import ComponentCatalog
 from script.check_catalog import (  # type: ignore[import-not-found]
     _GATING_FLOORS,
-    ComponentCatalog,
     _check_boolean_options_exclusive,
     _check_gating_floors,
     _load_body_from_disk,
 )
+
+pytestmark = pytest.mark.xdist_group("catalog")
 
 
 def _entry(gate: str | None, children: list[Any] | None = None) -> SimpleNamespace:
@@ -57,12 +61,12 @@ def test_floor_tally_skips_missing_bodies() -> None:
     assert _check_gating_floors(bodies) == []
 
 
-def test_floors_sit_in_a_sane_band_of_the_live_catalog() -> None:
+def test_floors_sit_in_a_sane_band_of_the_live_catalog(
+    session_component_catalog: ComponentCatalog,
+) -> None:
     """A floor typo (6000 -> 60, or above the live count) fails here, not in the field."""
-    catalog = ComponentCatalog()
-    catalog.load()
     counts: dict[str, int] = {}
-    for cid in catalog._by_id:
+    for cid in session_component_catalog._by_id:
         component = _load_body_from_disk(cid)
         if component is None:
             continue
@@ -74,8 +78,14 @@ def test_floors_sit_in_a_sane_band_of_the_live_catalog() -> None:
             stack.extend(entry.config_entries or [])
     for gate, floor in _GATING_FLOORS.items():
         live = counts.get(gate, 0)
-        assert floor <= live, f"{gate} floor {floor} above live count {live}: would fire spuriously"
-        assert floor >= live // 4, f"{gate} floor {floor} uselessly low vs live count {live}"
+        assert floor <= live, (
+            f"{gate} floor {floor} above live count {live}: the sync smoke would fire "
+            "spuriously — lower _GATING_FLOORS in script/check_catalog.py"
+        )
+        assert floor >= live // 4, (
+            f"{gate} floor {floor} drifted far below live count {live} — the catalog "
+            "grew; bump _GATING_FLOORS in script/check_catalog.py"
+        )
 
 
 def _bool_entry(type_: str, options: list | None, children: list | None = None) -> SimpleNamespace:

--- a/tests/test_sync_components_component_gates.py
+++ b/tests/test_sync_components_component_gates.py
@@ -173,13 +173,14 @@ def test_internal_id_keys_stay_skipped(tmp_path: Path) -> None:
     """``mqtt_id`` / ``zigbee_id`` never reach the catalog; other ids survive."""
     node = {
         "config_vars": {
-            "mqtt_id": {"key": "GeneratedID", "use_id_type": True},
-            "zigbee_id": {"key": "GeneratedID", "use_id_type": True},
-            "web_server_id": {"key": "Optional", "use_id_type": True},
+            "mqtt_id": {"key": "GeneratedID", "use_id_type": "mqtt::MQTTClientComponent"},
+            "zigbee_id": {"key": "GeneratedID", "use_id_type": "zigbee::ZigbeeComponent"},
+            "web_server_id": {"key": "OnlyWith", "use_id_type": "web_server::WebServer"},
         }
     }
-    keys = [e["key"] for e in _convert_config_vars(node, tmp_path)]
-    assert keys == ["web_server_id"]
+    entries = _convert_config_vars(node, tmp_path)
+    assert [e["key"] for e in entries] == ["web_server_id"]
+    assert entries[0]["references_component"] == "web_server"
 
 
 def test_live_switch_platform_derives_the_mqtt_gates(cv) -> None:

--- a/tests/test_sync_components_component_gates.py
+++ b/tests/test_sync_components_component_gates.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -9,6 +10,7 @@ import pytest
 from script.sync_components import (  # type: ignore[import-not-found]
     _apply_component_gates,
     _collect_component_gates,
+    _convert_config_vars,
     introspect_component,
 )
 
@@ -71,6 +73,12 @@ def test_only_with_component_list_skips_chip_platforms(cv) -> None:
     assert _collect_component_gates(_manifest(schema)) == {("zigbee_switch",): "zigbee"}
 
 
+def test_only_with_all_chip_list_yields_no_gate(cv) -> None:
+    """Chip-only gating belongs to ``supported_platforms``, not ``depends_on_component``."""
+    schema = cv.Schema({cv.OnlyWith("himem", ["esp32"]): cv.string})
+    assert _collect_component_gates(_manifest(schema)) == {}
+
+
 def test_only_without_is_not_a_gate(cv) -> None:
     """``OnlyWithout`` keys on component absence; gating them would invert the meaning."""
     schema = cv.Schema({cv.OnlyWithout("fallback", "wifi", default=True): cv.boolean})
@@ -94,6 +102,24 @@ def test_container_with_unanimously_gated_children_inherits(cv) -> None:
     assert gates[("web_server",)] == "web_server"
     assert gates[("web_server", "web_server_id")] == "web_server"
     assert gates[("web_server", "sorting_weight")] == "web_server"
+
+
+def test_nested_containers_cascade_the_inherited_gate(cv) -> None:
+    schema = cv.Schema(
+        {
+            cv.Optional("outer"): cv.Schema(
+                {
+                    cv.Optional("inner"): cv.Schema(
+                        {cv.Optional("leaf"): cv.All(cv.requires_component("mqtt"), cv.boolean)}
+                    )
+                }
+            )
+        }
+    )
+    gates = _collect_component_gates(_manifest(schema))
+    assert gates[("outer", "inner", "leaf")] == "mqtt"
+    assert gates[("outer", "inner")] == "mqtt"
+    assert gates[("outer",)] == "mqtt"
 
 
 def test_container_with_mixed_children_is_not_gated(cv) -> None:
@@ -132,6 +158,28 @@ def test_apply_never_overrides_an_explicit_gate() -> None:
     entries = [{"key": "command_retain", "depends_on_component": "custom"}]
     _apply_component_gates(entries, {("command_retain",): "mqtt"})
     assert entries[0]["depends_on_component"] == "custom"
+
+
+def test_apply_stamps_nested_paths() -> None:
+    leaf = {"key": "state_topic", "depends_on_component": None}
+    sibling = {"key": "name", "depends_on_component": None}
+    entries = [{"key": "compressor_current", "config_entries": [leaf, sibling]}]
+    _apply_component_gates(entries, {("compressor_current", "state_topic"): "mqtt"})
+    assert leaf["depends_on_component"] == "mqtt"
+    assert sibling["depends_on_component"] is None
+
+
+def test_internal_id_keys_stay_skipped(tmp_path: Path) -> None:
+    """``mqtt_id`` / ``zigbee_id`` never reach the catalog; other ids survive."""
+    node = {
+        "config_vars": {
+            "mqtt_id": {"key": "GeneratedID", "use_id_type": True},
+            "zigbee_id": {"key": "GeneratedID", "use_id_type": True},
+            "web_server_id": {"key": "Optional", "use_id_type": True},
+        }
+    }
+    keys = [e["key"] for e in _convert_config_vars(node, tmp_path)]
+    assert keys == ["web_server_id"]
 
 
 def test_live_switch_platform_derives_the_mqtt_gates(cv) -> None:

--- a/tests/test_sync_components_component_gates.py
+++ b/tests/test_sync_components_component_gates.py
@@ -1,4 +1,4 @@
-"""Cross-component gates are auto-discovered from the live schema, not hand-listed."""
+"""Cross-component gate discovery and catalog-key skipping, pinned at the generator."""
 
 from __future__ import annotations
 
@@ -175,7 +175,7 @@ def test_internal_id_keys_stay_skipped(tmp_path: Path) -> None:
         "config_vars": {
             "mqtt_id": {"key": "GeneratedID", "use_id_type": "mqtt::MQTTClientComponent"},
             "zigbee_id": {"key": "GeneratedID", "use_id_type": "zigbee::ZigbeeComponent"},
-            "web_server_id": {"key": "OnlyWith", "use_id_type": "web_server::WebServer"},
+            "web_server_id": {"key": "Optional", "use_id_type": "web_server::WebServer"},
         }
     }
     entries = _convert_config_vars(node, tmp_path)


### PR DESCRIPTION
# What does this implement/fix?

Test-coverage follow-up to the gate-discovery arc (#2301 / #2302 / #2305), closing the gaps a coverage audit found:

- **`script/check_catalog.py` had zero pytest coverage** — most importantly, the gating-floor guard's *failure branch* had never executed anywhere: a subtle tally bug (counting the wrong field, missing nested entries) would have turned the wholesale-loss tripwire into a guard that always passes. New `tests/test_check_catalog_guards.py` drives `_check_gating_floors` with synthetic bodies through pass-at-floor, fail-one-below, the empty-catalog wholesale-loss scenario (every floor trips), nested-entry tallying, and missing-body tolerance.
- **`_apply_component_gates` nested-path stamping was untested** while the real catalog's gates are nested-heavy (haier's per-sensor `('compressor_current', 'state_topic')`); now pinned, including the untouched sibling.
- **Discovery boundary cases**: an all-chip `OnlyWith` list (e.g. `["esp32"]`) must yield no gate (chip gating belongs to `supported_platforms`); nested containers cascade the inherited gate upward; and `mqtt_id` / `zigbee_id` staying in `_SKIP_KEYS` is pinned at the generator level — the mirror image of the `web_server_base_id` incident (#2305), so removals from the skip list are caught on the generator PR, not the next sync.

No production code changes; 755 sync/catalog tests pass locally.

**Related issue or feature (if applicable):**

- follow-up to #2302 / #2305

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
