### PR TITLE
Pin the deferred catalog gate expectations after the resync

### DIFF
--- a/script/check_catalog.py
+++ b/script/check_catalog.py
@@ -259,13 +259,20 @@ _OPTION_EXPECTATIONS: list[tuple[str, str, int]] = [
 # entity-level inheritances belong here. The derivation itself is
 # pinned against live manifests in
 # ``tests/test_sync_components_component_gates.py``.
-_GATING_EXPECTATIONS: list[tuple[str, str, str]] = [
+_GATING_EXPECTATIONS: list[tuple[str, str, str | None]] = [
     # Zigbee + web_server entity options are inherited onto every
     # sensor via ``_SENSOR_SCHEMA``; they must be gated.
     ("sensor.ct_clamp", "zigbee_sensor", "zigbee"),
     ("sensor.ct_clamp", "web_server", "web_server"),
-    # MQTT entity option inherited via ``MQTT_COMPONENT_SCHEMA``.
+    # MQTT entity options inherited via ``MQTT_COMPONENT_SCHEMA`` /
+    # ``MQTT_COMMAND_COMPONENT_SCHEMA`` (#2300).
     ("switch.gpio", "state_topic", "mqtt"),
+    ("switch.gpio", "command_retain", "mqtt"),
+    # ``None`` pins gate *absence*: mqtt's own page never self-gates,
+    # and singleton auto-loaded base ids stay ungated advanced pickers
+    # (#1441; restored in #2305).
+    ("mqtt", "discovery", None),
+    ("captive_portal", "web_server_base_id", None),
 ]
 
 # Catalog-wide floors on gated-entry counts. The per-field rules above


### PR DESCRIPTION
# What does this implement/fix?

Adds the three catalog-gate smoke pins that were deferred until the regenerated catalog (#2307) merged, closing out the #2300 arc:

- `switch.gpio.command_retain` = `mqtt` — the field the original issue was about, inherited via `MQTT_COMMAND_COMPONENT_SCHEMA`.
- `mqtt.discovery` = `None` — pins self-gate *absence* on mqtt's own page (follow-up agreed on #2302; the introspected gates never self-gate).
- `captive_portal.web_server_base_id` = `None` — pins that singleton auto-loaded base ids stay ungated advanced pickers (the #2304/#2305 regression shape).

The row type widens to `tuple[str, str, str | None]`; `_check_component_gating` already compares with `!=`, so `None` expectations work unchanged. Verified locally: `script/check_catalog.py` passes against the checked-in catalog with all 6 gating rules.

**Related issue or feature (if applicable):**

- Follow-up to #2300 (fixed by the #2301 + #2307 chain); pins agreed on the #2302 and #2305 review threads. No standalone issue.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
