### PR TITLE
Retire the Esp32Variant enum in favor of the live variant snapshot

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -220,7 +220,7 @@ The subscription stays open for the connection's lifetime; closing the WebSocket
 
 > Controller: [`BoardCatalog`](../esphome_device_builder/controllers/boards.py)
 >
-> Enums: [`Platform`](../esphome_device_builder/models/boards.py), [`Esp32Variant`](../esphome_device_builder/models/boards.py), [`BoardTag`](../esphome_device_builder/models/boards.py)
+> Enums: [`Platform`](../esphome_device_builder/models/boards.py), [`BoardTag`](../esphome_device_builder/models/boards.py). A board's `variant` is a lowercase chip-variant string (`esp32c3`); its vocabulary is the `esp32_variants` snapshot in `platform_capabilities.index.json`.
 
 | Command | Args | Response | Description |
 |---------|------|----------|-------------|

--- a/esphome_device_builder/controllers/boards.py
+++ b/esphome_device_builder/controllers/boards.py
@@ -16,7 +16,6 @@ from ..models import (
     BoardCatalogEntry,
     BoardCatalogIndex,
     BoardTag,
-    Esp32Variant,
     PagedBoardsResponse,
     Platform,
 )
@@ -44,7 +43,7 @@ def _board_sort_key(board: BoardCatalogIndex) -> tuple[bool, bool, bool, str]:
 def _filter_by_variant(boards: list[BoardCatalogIndex], variant: str) -> list[BoardCatalogIndex]:
     """Boards whose variant equals *variant*, case-insensitively (empty if none)."""
     target = variant.lower()
-    return [b for b in boards if b.esphome.variant and b.esphome.variant.value.lower() == target]
+    return [b for b in boards if b.esphome.variant and b.esphome.variant.lower() == target]
 
 
 class BoardCatalog:
@@ -86,7 +85,7 @@ class BoardCatalog:
         *,
         query: str | None = None,
         platform: Platform | str | None = None,
-        variant: Esp32Variant | str | None = None,
+        variant: str | None = None,
         mcu: str | None = None,
         tag: BoardTag | str | None = None,
         offset: int = 0,

--- a/esphome_device_builder/controllers/components/controller.py
+++ b/esphome_device_builder/controllers/components/controller.py
@@ -59,7 +59,7 @@ def _summarize_description(text: str) -> str:
 
 
 def variant_to_key(variant: str) -> str:
-    """Normalise an ``Esp32Variant`` value (``esp32c3``) to a catalog key (``esp32_c3``).
+    """Normalise a chip-variant value (``esp32c3``) to a catalog key (``esp32_c3``).
 
     Matches the ``platform_defaults`` / ``platform_options`` key form; the
     base ``esp32`` and non-ESP32 platforms pass through unchanged. Shared with
@@ -832,7 +832,7 @@ class ComponentCatalog:
         board = self._db.boards.get_by_id(board_id)
         if board is None or board.esphome.variant is None:
             return None
-        return variant_to_key(board.esphome.variant.value)
+        return variant_to_key(board.esphome.variant)
 
 
 def _query_rank(entry: ComponentCatalogIndexEntry, query_lower: str) -> int:

--- a/esphome_device_builder/controllers/config/chip_detect.py
+++ b/esphome_device_builder/controllers/config/chip_detect.py
@@ -42,6 +42,9 @@ def _esp32_chip_family_map() -> dict[str, tuple[str, str, str]]:
 # ``_chip_family_to_descriptor`` to return ``None``, which the WS
 # handler surfaces as ``_DETECT_UNKNOWN_CHIP``.
 _CHIP_FAMILY_MAP: dict[str, tuple[str, str, str]] = {
+    # Seeded unconditionally: a degraded capabilities index empties the
+    # variant walk, and the common classic probe must keep working.
+    "esp32": ("ESP32", "esp32", "esp32"),
     **_esp32_chip_family_map(),
     "esp8266": ("ESP8266", "", "esp8266"),
 }

--- a/esphome_device_builder/controllers/config/chip_detect.py
+++ b/esphome_device_builder/controllers/config/chip_detect.py
@@ -11,8 +11,8 @@ from contextlib import suppress
 from pathlib import Path
 
 from ...definitions import load_platform_capabilities_index
+from ...helpers.chips import normalize_chip_variant
 from ...helpers.subprocess import run_subprocess_capture
-from ...models.boards import normalize_chip_variant
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/esphome_device_builder/controllers/config/chip_detect.py
+++ b/esphome_device_builder/controllers/config/chip_detect.py
@@ -10,8 +10,9 @@ import tempfile
 from contextlib import suppress
 from pathlib import Path
 
+from ...definitions import load_platform_capabilities_index
 from ...helpers.subprocess import run_subprocess_capture
-from ...models.boards import Esp32Variant
+from ...models.boards import normalize_chip_variant
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,16 +21,18 @@ def _esp32_chip_family_map() -> dict[str, tuple[str, str, str]]:
     """
     Build the esptool-family → ``(chip_family, variant, platform)`` table.
 
-    Sourced from :class:`Esp32Variant` so a new ESP32 variant is
-    recognised by adding one enum member; keys mirror esptool's dashed
-    family string and ``chip_family`` the frontend filter label.
+    Sourced from the live ``esp32_variants`` snapshot so a new ESP32 variant
+    is recognised after a catalog sync with no code change; keys mirror
+    esptool's dashed family string and ``chip_family`` the frontend filter
+    label.
     """
     table: dict[str, tuple[str, str, str]] = {}
-    for v in Esp32Variant:
-        suffix = v.value[len("esp32") :]  # "" for classic, "s3"/"c61"/… otherwise
+    for raw in sorted(load_platform_capabilities_index().esp32_variants):
+        variant = normalize_chip_variant(raw)
+        suffix = variant[len("esp32") :]  # "" for classic, "s3"/"c61"/… otherwise
         key = "esp32" if not suffix else f"esp32-{suffix}"
         label = "ESP32" if not suffix else f"ESP32-{suffix.upper()}"
-        table[key] = (label, v.value, "esp32")
+        table[key] = (label, variant, "esp32")
     return table
 
 

--- a/esphome_device_builder/controllers/devices/metadata.py
+++ b/esphome_device_builder/controllers/devices/metadata.py
@@ -56,7 +56,7 @@ def _migrate_board_id_user_set_sync(config_dir: Path, boards: BoardCatalog) -> i
             picked = boards.get_by_id(board_id)
             if picked is None or picked.is_generic or _is_devices_esphome_io_import(picked):
                 continue
-            variant = picked.esphome.variant.value if picked.esphome.variant else ""
+            variant = picked.esphome.variant or ""
             winner = boards.find_by_pio_board(
                 picked.esphome.board, variant, picked.esphome.platform.value
             )

--- a/esphome_device_builder/definitions/__init__.py
+++ b/esphome_device_builder/definitions/__init__.py
@@ -46,13 +46,13 @@ from ..models import (
     BoardTag,
     Connectivity,
     DefaultComponent,
-    Esp32Variant,
     FeaturedBundle,
     FeaturedComponent,
     FieldPreset,
     PinFeature,
     Platform,
 )
+from ..models.boards import normalize_chip_variant
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -290,7 +290,13 @@ def _load_esphome_config(data: dict, board_id: str) -> BoardEsphomeConfig:
     """Load a BoardEsphomeConfig from a dict."""
     platform = Platform(data["platform"])
     variant_raw = data.get("variant")
-    variant = Esp32Variant(variant_raw) if variant_raw else None
+    variant = normalize_chip_variant(str(variant_raw)) if variant_raw else None
+    if variant is not None:
+        known = load_platform_capabilities_index().esp32_variants
+        # Fail open on an empty snapshot; warn (not drop) on an unknown value
+        # so the sync-time gate is where a typo actually fails.
+        if known and variant not in {normalize_chip_variant(v) for v in known}:
+            _LOGGER.warning("Board %s: unknown esp32 variant %r", board_id, variant)
     return BoardEsphomeConfig(
         platform=platform,
         board=data["board"],
@@ -363,7 +369,7 @@ def build_board_catalog_from_manifests(*, strict: bool = False) -> BoardCatalogR
             if not images:
                 generic = _generic_image_url(
                     esphome_cfg.platform.value,
-                    esphome_cfg.variant.value if esphome_cfg.variant else None,
+                    esphome_cfg.variant or None,
                 )
                 if generic:
                     images = [generic]

--- a/esphome_device_builder/definitions/__init__.py
+++ b/esphome_device_builder/definitions/__init__.py
@@ -290,8 +290,9 @@ def _load_esphome_config(data: dict, board_id: str) -> BoardEsphomeConfig:
     """Load a BoardEsphomeConfig from a dict."""
     platform = Platform(data["platform"])
     variant_raw = data.get("variant")
-    variant = normalize_chip_variant(str(variant_raw)) if variant_raw else None
-    if variant is not None:
+    variant: str | None = None
+    if platform is Platform.ESP32 and isinstance(variant_raw, str) and variant_raw:
+        variant = normalize_chip_variant(variant_raw)
         known = load_platform_capabilities_index().esp32_variants
         # Fail open on an empty snapshot; warn (not drop) on an unknown value
         # so the sync-time gate is where a typo actually fails.

--- a/esphome_device_builder/definitions/__init__.py
+++ b/esphome_device_builder/definitions/__init__.py
@@ -286,6 +286,14 @@ def _load_default_component(entry: object) -> DefaultComponent:
     raise TypeError(msg)
 
 
+@cache
+def _known_esp32_variants() -> frozenset[str]:
+    """Return the normalized snapshot vocabulary; empty when the index is degraded."""
+    return frozenset(
+        normalize_chip_variant(v) for v in load_platform_capabilities_index().esp32_variants
+    )
+
+
 def _load_esphome_config(data: dict, board_id: str) -> BoardEsphomeConfig:
     """Load a BoardEsphomeConfig from a dict."""
     platform = Platform(data["platform"])
@@ -293,11 +301,12 @@ def _load_esphome_config(data: dict, board_id: str) -> BoardEsphomeConfig:
     variant: str | None = None
     if platform is Platform.ESP32 and isinstance(variant_raw, str) and variant_raw:
         variant = normalize_chip_variant(variant_raw)
-        known = load_platform_capabilities_index().esp32_variants
-        # Fail open on an empty snapshot; warn (not drop) on an unknown value
-        # so the sync-time gate is where a typo actually fails.
-        if known and variant not in {normalize_chip_variant(v) for v in known}:
-            _LOGGER.warning("Board %s: unknown esp32 variant %r", board_id, variant)
+        known = _known_esp32_variants()
+        # Fail open on an empty snapshot; a populated one is the loud gate
+        # (the manifest walk skips or aborts per its ``strict`` mode).
+        if known and variant not in known:
+            msg = f"Board {board_id}: unknown esp32 variant {variant!r}"
+            raise ValueError(msg)
     return BoardEsphomeConfig(
         platform=platform,
         board=data["board"],

--- a/esphome_device_builder/definitions/__init__.py
+++ b/esphome_device_builder/definitions/__init__.py
@@ -30,6 +30,7 @@ import orjson
 import yaml
 
 from ..constants import IMPORT_SOURCE_TYPES
+from ..helpers.chips import normalize_chip_variant
 from ..helpers.lazy_catalog import (
     is_external_image_url,
     is_unsafe_catalog_id,
@@ -52,7 +53,6 @@ from ..models import (
     PinFeature,
     Platform,
 )
-from ..models.boards import normalize_chip_variant
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/esphome_device_builder/helpers/chips.py
+++ b/esphome_device_builder/helpers/chips.py
@@ -1,0 +1,12 @@
+"""Chip-vocabulary helpers importable without the models package.
+
+The validate-definitions pre-commit hook runs without the package's
+dependencies installed, so this module must stay import-light (stdlib only).
+"""
+
+from __future__ import annotations
+
+
+def normalize_chip_variant(name: str) -> str:
+    """Fold a chip-variant spelling (``ESP32-C3`` / ``esp32_c3``) onto the catalog form."""
+    return name.strip().replace("-", "").replace("_", "").lower()

--- a/esphome_device_builder/helpers/device_yaml/_generation.py
+++ b/esphome_device_builder/helpers/device_yaml/_generation.py
@@ -381,11 +381,10 @@ def _infer_native_wifi(board: BoardCatalogEntry) -> bool:
     snapshotted platform_capabilities index.
     """
     esphome_cfg = board.esphome
-    # ``str(...)`` handles both the production ``Platform`` StrEnum
-    # and bare-string inputs from
-    # tests that mock the catalog entry without going through the
-    # enum constructors. ``_has_native_wifi`` lowercases the variant
-    # itself, so no case normalisation is needed here.
+    # ``str(...)`` handles both the production ``Platform`` StrEnum and
+    # bare-string inputs from tests that mock the catalog entry.
+    # ``_has_native_wifi`` lowercases the variant itself, so no case
+    # normalisation is needed here.
     return _has_native_wifi(
         platform=str(esphome_cfg.platform) if esphome_cfg.platform else "",
         board=esphome_cfg.board,

--- a/esphome_device_builder/helpers/device_yaml/_generation.py
+++ b/esphome_device_builder/helpers/device_yaml/_generation.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 # (fail-open), matching the prior unknown-board behaviour.
 _caps = load_platform_capabilities_index()
 # ESPHome stores variant tags uppercase (``"ESP32H2"``); normalise to the
-# lowercase ``Esp32Variant`` form the wizard compares against.
+# lowercase catalog form the wizard compares against.
 _ESP32_NO_WIFI_VARIANTS: frozenset[str] = frozenset(v.lower() for v in _caps.esp32_no_wifi_variants)
 _RP2040_NO_WIFI_BOARDS: frozenset[str] = frozenset(_caps.rp2040_no_wifi_boards)
 
@@ -381,8 +381,8 @@ def _infer_native_wifi(board: BoardCatalogEntry) -> bool:
     snapshotted platform_capabilities index.
     """
     esphome_cfg = board.esphome
-    # ``str(...)`` handles both the production enum (``Platform`` /
-    # ``Esp32Variant`` are ``StrEnum``) and bare-string inputs from
+    # ``str(...)`` handles both the production ``Platform`` StrEnum
+    # and bare-string inputs from
     # tests that mock the catalog entry without going through the
     # enum constructors. ``_has_native_wifi`` lowercases the variant
     # itself, so no case normalisation is needed here.

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -10,7 +10,8 @@ from esphome import const
 from esphome.const import CONF_PACKAGES
 
 from ...definitions import load_platform_capabilities_index
-from ...models.boards import RP2_PLATFORM_ALIASES, normalize_chip_variant, normalize_platform
+from ...models.boards import RP2_PLATFORM_ALIASES, normalize_platform
+from ..chips import normalize_chip_variant
 from ..yaml import (
     _split_value_and_comment,
     _strip_yaml_quotes,

--- a/esphome_device_builder/models/boards.py
+++ b/esphome_device_builder/models/boards.py
@@ -135,9 +135,8 @@ class BoardEsphomeConfig(DashboardModel):
 
     platform: Platform
     board: str  # PlatformIO board ID
-    # Lowercase esp32 chip variant ("esp32c3"). The vocabulary is the live
-    # ``esp32_variants`` snapshot in platform_capabilities.index.json — never
-    # a local enum, which would lag upstream.
+    # Lowercase esp32 chip variant ("esp32c3"); vocabulary is the
+    # ``esp32_variants`` snapshot in platform_capabilities.index.json.
     variant: str | None = None
     framework: str | None = None  # "arduino" or "esp-idf"
     # Chip series within an ESPHome platform that lumps several under one

--- a/esphome_device_builder/models/boards.py
+++ b/esphome_device_builder/models/boards.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
 
-from ..helpers.chips import normalize_chip_variant
 from .common import (
     DashboardModel,
     FieldPreset,
@@ -20,7 +19,6 @@ from .common import (
 # `from .boards import PinFeature` paths.
 
 _ = PinFeature  # suppress "imported but unused" — this is a re-export
-__ = normalize_chip_variant  # re-export: dep-free home is helpers.chips
 
 
 class Connectivity(StrEnum):

--- a/esphome_device_builder/models/boards.py
+++ b/esphome_device_builder/models/boards.py
@@ -77,24 +77,6 @@ def normalize_chip_variant(name: str) -> str:
     return name.strip().replace("-", "").replace("_", "").lower()
 
 
-class Esp32Variant(StrEnum):
-    """ESP32 chip variants."""
-
-    ESP32 = "esp32"
-    ESP32S2 = "esp32s2"
-    ESP32S3 = "esp32s3"
-    ESP32S31 = "esp32s31"
-    ESP32C2 = "esp32c2"
-    ESP32C3 = "esp32c3"
-    ESP32C5 = "esp32c5"
-    ESP32C6 = "esp32c6"
-    ESP32C61 = "esp32c61"
-    ESP32H2 = "esp32h2"
-    ESP32H4 = "esp32h4"
-    ESP32H21 = "esp32h21"
-    ESP32P4 = "esp32p4"
-
-
 class BoardTag(StrEnum):
     """Board tags for unique features not captured by other fields."""
 
@@ -153,7 +135,10 @@ class BoardEsphomeConfig(DashboardModel):
 
     platform: Platform
     board: str  # PlatformIO board ID
-    variant: Esp32Variant | None = None
+    # Lowercase esp32 chip variant ("esp32c3"). The vocabulary is the live
+    # ``esp32_variants`` snapshot in platform_capabilities.index.json — never
+    # a local enum, which would lag upstream.
+    variant: str | None = None
     framework: str | None = None  # "arduino" or "esp-idf"
     # Chip series within an ESPHome platform that lumps several under one
     # key: currently rp2040 ("rp2040" / "rp2350"). Reusable to split the

--- a/esphome_device_builder/models/boards.py
+++ b/esphome_device_builder/models/boards.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
 
+from ..helpers.chips import normalize_chip_variant
 from .common import (
     DashboardModel,
     FieldPreset,
@@ -19,6 +20,7 @@ from .common import (
 # `from .boards import PinFeature` paths.
 
 _ = PinFeature  # suppress "imported but unused" — this is a re-export
+__ = normalize_chip_variant  # re-export: dep-free home is helpers.chips
 
 
 class Connectivity(StrEnum):
@@ -70,11 +72,6 @@ RP2_PLATFORM_ALIASES: frozenset[str] = frozenset({RP2_ALIAS_PLATFORM, RP2_CANONI
 def normalize_platform(name: str) -> str:
     """Fold the non-canonical RP2 platform spelling onto the canonical one."""
     return RP2_CANONICAL_PLATFORM if name.lower() == RP2_ALIAS_PLATFORM else name
-
-
-def normalize_chip_variant(name: str) -> str:
-    """Fold a chip-variant spelling (``ESP32-C3`` / ``esp32_c3``) onto the catalog form."""
-    return name.strip().replace("-", "").replace("_", "").lower()
 
 
 class BoardTag(StrEnum):

--- a/script/sync_boards.py
+++ b/script/sync_boards.py
@@ -83,12 +83,12 @@ from esphome_device_builder.models import (  # noqa: E402
     BoardEsphomeConfig,
     BoardPin,
     BoardTag,
-    Esp32Variant,
     FeaturedBundle,
     FeaturedComponent,
     PinFeature,
     Platform,
 )
+from esphome_device_builder.models.boards import normalize_chip_variant  # noqa: E402
 
 _LOGGER = logging.getLogger("sync_boards")
 
@@ -276,7 +276,7 @@ def _generated_board(
     name: str,
     display_name: str,
     pins: list[BoardPin],
-    variant: Esp32Variant | None = None,
+    variant: str | None = None,
 ) -> BoardCatalogEntry:
     """Build a minimal catalog entry (identity + derived pins) for an unmanifested board."""
     return BoardCatalogEntry(
@@ -571,7 +571,7 @@ def _augment_rp2040_onboard_ethernet_pins(boards: list[BoardCatalogEntry]) -> No
 
 def _esp32_generic_pins_by_variant(
     boards: list[BoardCatalogEntry],
-) -> dict[tuple[Esp32Variant, bool], list[BoardPin]]:
+) -> dict[tuple[str, bool], list[BoardPin]]:
     """
     Index the loaded ``generic-<variant>`` manifests' pins by (variant, ES-ness).
 
@@ -652,7 +652,7 @@ def _backfill_esp32_variants(boards: list[BoardCatalogEntry]) -> None:
             continue
         variant = esp32_variant_for_board(cfg.board)
         if variant is not None:
-            cfg.variant = Esp32Variant(variant)
+            cfg.variant = normalize_chip_variant(variant)
 
 
 def _backfill_donor_pins(
@@ -678,7 +678,7 @@ def _backfill_donor_pins(
             board.pins = list(donor.pins)
 
     def _chip(cfg: BoardEsphomeConfig) -> tuple[str, str, str | None]:
-        return (cfg.platform.value, cfg.board, cfg.variant.value if cfg.variant else None)
+        return (cfg.platform.value, cfg.board, cfg.variant or None)
 
     donors: dict[tuple[str, str, str | None], list[BoardCatalogEntry]] = {}
     for board in boards:
@@ -732,7 +732,7 @@ def _augment_esp32_boards(boards: list[BoardCatalogEntry]) -> None:
         display = _meta_name(meta, name)
         if name in ids or _name_already_listed(Platform("esp32"), name, display, names):
             continue
-        variant = Esp32Variant(meta["variant"].lower())
+        variant = normalize_chip_variant(meta["variant"])
         pins = _resolve_board_pins(pin_map, name)
         es = bool(meta.get("engineering_sample"))
         # Fall back to the other revision's generic for variants with one manifest.
@@ -930,14 +930,14 @@ def _augment_rmii_data_pins(boards: list[BoardCatalogEntry]) -> None:
     """
     module = importlib.import_module("esphome.components.ethernet")
     # No getattr default: an upstream rename should fail the sync loudly.
-    by_variant: dict[Esp32Variant, dict[int, str]] = {
-        Esp32Variant.ESP32: module.ESP32_RMII_FIXED_PINS,
-        Esp32Variant.ESP32P4: module.ESP32P4_RMII_DEFAULT_PINS,
+    by_variant: dict[str, dict[int, str]] = {
+        "esp32": module.ESP32_RMII_FIXED_PINS,
+        "esp32p4": module.ESP32P4_RMII_DEFAULT_PINS,
     }
     for board in boards:
         if board.esphome.platform is not Platform.ESP32 or not _has_rmii_ethernet(board):
             continue
-        fixed = by_variant.get(board.esphome.variant or Esp32Variant.ESP32)
+        fixed = by_variant.get(board.esphome.variant or "esp32")
         if not fixed:
             continue
         roles = {gpio: f"Ethernet {emac.removeprefix('EMAC_')}" for gpio, emac in fixed.items()}

--- a/script/sync_boards.py
+++ b/script/sync_boards.py
@@ -75,6 +75,7 @@ from esphome_device_builder.constants import BOARD_PIN_KEYS  # noqa: E402
 from esphome_device_builder.definitions import (  # noqa: E402
     build_board_catalog_from_manifests,
 )
+from esphome_device_builder.helpers.chips import normalize_chip_variant  # noqa: E402
 from esphome_device_builder.helpers.pin_gpio import parse_board_gpio  # noqa: E402
 from esphome_device_builder.models import (  # noqa: E402
     BoardCatalogEntry,
@@ -88,7 +89,6 @@ from esphome_device_builder.models import (  # noqa: E402
     PinFeature,
     Platform,
 )
-from esphome_device_builder.models.boards import normalize_chip_variant  # noqa: E402
 
 _LOGGER = logging.getLogger("sync_boards")
 

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -3682,9 +3682,9 @@ def _logger_interface_snapshot() -> tuple[dict[str, str], list[str]]:
     raw = _collect_platform_defaults(loader.get_component("logger")).get(("hardware_uart",), {})
     if not raw:
         raise RuntimeError("logger hardware_uart SplitDefault table not found")
-    # The key set the runtime can look up: platform keys plus the LIVE esp32
+    # The key set the runtime can look up: platform keys plus the live esp32
     # variants, spelled through the same normalizers the runtime uses. Live
-    # (not the local Esp32Variant enum) so a brand-new chip syncs the day it
+    # so a brand-new chip syncs the day it
     # lands; only a genuinely unknown platform key fails the sync loudly.
     known_keys = {p.value for p in Platform} | {normalize_chip_variant(v) for v in VARIANTS}
     defaults: dict[str, str] = {}

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -3682,10 +3682,10 @@ def _logger_interface_snapshot() -> tuple[dict[str, str], list[str]]:
     raw = _collect_platform_defaults(loader.get_component("logger")).get(("hardware_uart",), {})
     if not raw:
         raise RuntimeError("logger hardware_uart SplitDefault table not found")
-    # The key set the runtime can look up: platform keys plus the live esp32
-    # variants, spelled through the same normalizers the runtime uses. Live
-    # so a brand-new chip syncs the day it
-    # lands; only a genuinely unknown platform key fails the sync loudly.
+    # The key set the runtime can look up: platform keys plus the live
+    # esp32 variants, spelled through the same normalizers the runtime
+    # uses, so a brand-new chip syncs the day it lands; only a genuinely
+    # unknown platform key fails the sync loudly.
     known_keys = {p.value for p in Platform} | {normalize_chip_variant(v) for v in VARIANTS}
     defaults: dict[str, str] = {}
     for key, value in sorted(raw.items()):

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -125,6 +125,7 @@ from esphome_device_builder.controllers.components import (  # noqa: E402
 )
 from esphome_device_builder.controllers.components import variant_to_key  # noqa: E402
 from esphome_device_builder.helpers.automation_keys import is_trigger_key  # noqa: E402
+from esphome_device_builder.helpers.chips import normalize_chip_variant  # noqa: E402
 from esphome_device_builder.models import (  # noqa: E402
     RP2_ALIAS_PLATFORM,
     RP2_CANONICAL_PLATFORM,
@@ -143,7 +144,6 @@ from esphome_device_builder.models import (  # noqa: E402
     PinFeature,
     PinMode,
     Platform,
-    normalize_chip_variant,
     normalize_platform,
 )
 from script._light_schemas import (  # noqa: E402

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -46,6 +46,7 @@ sys.path.insert(0, str(_REPO_ROOT))
 
 # Up here so a missing esphome fails at startup, not mid-run on the
 # first page with a ``substitutions:`` block.
+from esphome.components.esp32.const import VARIANTS  # noqa: E402
 from esphome.components.substitutions import do_substitution_pass  # noqa: E402
 
 from esphome_device_builder.constants import (  # noqa: E402
@@ -54,7 +55,7 @@ from esphome_device_builder.constants import (  # noqa: E402
     DEVICE_IMPORT_SOURCE_TYPE,
     FEATURED_EXCLUDED_CATEGORIES,
 )
-from esphome_device_builder.models.boards import normalize_chip_variant  # noqa: E402
+from esphome_device_builder.helpers.chips import normalize_chip_variant  # noqa: E402
 from script._board_import import (  # noqa: E402
     ESP32_VARIANT_DEFAULT_BOARD,
     build_esphome_block,
@@ -118,17 +119,11 @@ _VALID_SOC_FAMILIES: frozenset[str] = frozenset({"esp32", "esp8266", "bk72xx", "
 # ``wifi:`` block that fails validation (P4 wifi needs ``esp32_hosted``). Built
 # from the live variant list longest-first so e.g. ``esp32s31`` isn't
 # swallowed by ``esp32s3`` (nor ``esp32c61`` by ``esp32c6``).
-def _esp32_variant_suffixes() -> list[str]:
-    from esphome.components.esp32.const import VARIANTS
-
-    return sorted(
-        (suffix for v in VARIANTS if (suffix := normalize_chip_variant(v).removeprefix("esp32"))),
-        key=len,
-        reverse=True,
-    )
-
-
-_ESP32_VARIANT_SUFFIXES = _esp32_variant_suffixes()
+_ESP32_VARIANT_SUFFIXES = sorted(
+    (suffix for v in VARIANTS if (suffix := normalize_chip_variant(v).removeprefix("esp32"))),
+    key=len,
+    reverse=True,
+)
 # Suffix must end the token (next char is ``-``, ``_``, or end) — a bare ``\b``
 # wouldn't fire before ``_`` (underscore is a word char) so ``esp32_s3_zero`` would
 # miss, and it keeps ``s3`` from matching inside ``s31``.

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -54,7 +54,7 @@ from esphome_device_builder.constants import (  # noqa: E402
     DEVICE_IMPORT_SOURCE_TYPE,
     FEATURED_EXCLUDED_CATEGORIES,
 )
-from esphome_device_builder.models.boards import Esp32Variant  # noqa: E402
+from esphome_device_builder.models.boards import normalize_chip_variant  # noqa: E402
 from script._board_import import (  # noqa: E402
     ESP32_VARIANT_DEFAULT_BOARD,
     build_esphome_block,
@@ -110,18 +110,25 @@ _DEVICES_REPO_RAW_BASE = "https://raw.githubusercontent.com/esphome/devices.esph
 # devices.esphome.io/src/utils/validFrontmatter.ts).
 _VALID_SOC_FAMILIES: frozenset[str] = frozenset({"esp32", "esp8266", "bk72xx", "rp2040", "rtl87xx"})
 
+
 # ESPHome esp32 board ids encode the chip variant (``esp32-p4-evboard``,
 # ``esp32-c6-devkitc-1``); infer it when a page gives ``board:`` but no
 # ``variant:``. Load-bearing for esp32p4 — it has no built-in radio, so the
 # wrong (classic-esp32) variant would mislabel it wifi-capable and emit a
 # ``wifi:`` block that fails validation (P4 wifi needs ``esp32_hosted``). Built
-# from ``Esp32Variant`` longest-first so e.g. ``esp32s31`` isn't swallowed by
-# ``esp32s3`` (nor ``esp32c61`` by ``esp32c6``).
-_ESP32_VARIANT_SUFFIXES = sorted(
-    (v.value.removeprefix("esp32") for v in Esp32Variant if v is not Esp32Variant.ESP32),
-    key=len,
-    reverse=True,
-)
+# from the live variant list longest-first so e.g. ``esp32s31`` isn't
+# swallowed by ``esp32s3`` (nor ``esp32c61`` by ``esp32c6``).
+def _esp32_variant_suffixes() -> list[str]:
+    from esphome.components.esp32.const import VARIANTS
+
+    return sorted(
+        (suffix for v in VARIANTS if (suffix := normalize_chip_variant(v).removeprefix("esp32"))),
+        key=len,
+        reverse=True,
+    )
+
+
+_ESP32_VARIANT_SUFFIXES = _esp32_variant_suffixes()
 # Suffix must end the token (next char is ``-``, ``_``, or end) — a bare ``\b``
 # wouldn't fire before ``_`` (underscore is a word char) so ``esp32_s3_zero`` would
 # miss, and it keeps ``s3`` from matching inside ``s31``.

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -40,6 +40,7 @@ from esphome_device_builder.helpers.lazy_catalog import (  # noqa: E402
     is_external_image_url,
     is_unsafe_manifest_path,
 )
+from esphome_device_builder.models.boards import normalize_chip_variant  # noqa: E402
 from script._component_catalog import load_component_catalog  # noqa: E402
 from script._manifest import ManifestError, load_manifest_dict  # noqa: E402
 
@@ -262,9 +263,14 @@ def _validate_pins_from(
         errors.append(f"{board_id}: pins_from '{donor_id}' has no pin table")
     ours = data.get("esphome") or {}
     theirs = donor.get("esphome") or {}
-    if (ours.get("platform"), ours.get("variant")) != (
+
+    def _variant_key(cfg: dict) -> str:
+        raw = cfg.get("variant")
+        return normalize_chip_variant(raw) if isinstance(raw, str) else ""
+
+    if (ours.get("platform"), _variant_key(ours)) != (
         theirs.get("platform"),
-        theirs.get("variant"),
+        _variant_key(theirs),
     ):
         errors.append(f"{board_id}: pins_from '{donor_id}' is a different chip")
     return errors
@@ -307,7 +313,7 @@ def _variant_warning(board_id: str, esphome_cfg: dict) -> str | None:
     if (
         isinstance(declared, str)
         and table_variant is not None
-        and declared.lower() != table_variant
+        and normalize_chip_variant(declared) != normalize_chip_variant(table_variant)
     ):
         return (
             f"{board_id}: esphome.variant '{declared}' does not match "
@@ -323,7 +329,7 @@ def _resolve_chip(esphome_cfg: dict) -> str | None:
     if platform == "esp32":
         declared = esphome_cfg.get("variant")
         if isinstance(declared, str):
-            return declared.lower()
+            return normalize_chip_variant(declared)
         return _esp32_table_variant(esphome_cfg)
     if platform == "esp8266":
         return "esp8266"

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -36,11 +36,11 @@ from esphome_device_builder.constants import (  # noqa: E402
     BUS_CATEGORIES,
     FEATURED_EXCLUDED_CATEGORIES,
 )
+from esphome_device_builder.helpers.chips import normalize_chip_variant  # noqa: E402
 from esphome_device_builder.helpers.lazy_catalog import (  # noqa: E402
     is_external_image_url,
     is_unsafe_manifest_path,
 )
-from esphome_device_builder.models.boards import normalize_chip_variant  # noqa: E402
 from script._component_catalog import load_component_catalog  # noqa: E402
 from script._manifest import ManifestError, load_manifest_dict  # noqa: E402
 

--- a/tests/controllers/test_board_catalog_invariants.py
+++ b/tests/controllers/test_board_catalog_invariants.py
@@ -81,7 +81,7 @@ def test_featured_boards_never_lose_to_a_non_canonical_entry(real_catalog: Board
     for board in real_catalog._boards:
         if not board.featured:
             continue
-        variant = board.esphome.variant.value if board.esphome.variant else ""
+        variant = board.esphome.variant or ""
         winner = real_catalog.find_by_pio_board(
             board.esphome.board, variant, board.esphome.platform.value
         )

--- a/tests/controllers/test_boards.py
+++ b/tests/controllers/test_boards.py
@@ -28,7 +28,6 @@ from esphome_device_builder.models import (
     BoardCatalogEntry,
     BoardCatalogIndex,
     BoardTag,
-    Esp32Variant,
     Platform,
 )
 from esphome_device_builder.models.boards import BoardEsphomeConfig
@@ -41,7 +40,7 @@ def _board(
     description: str = "",
     manufacturer: str = "Acme",
     platform: Platform = Platform.ESP32,
-    variant: Esp32Variant | None = None,
+    variant: str | None = None,
     pio_board: str = "esp32dev",
     tags: list[BoardTag] | None = None,
     featured: bool = False,
@@ -107,7 +106,7 @@ def catalog() -> BoardCatalog:
                 description="Compact dev board",
                 manufacturer="Seeed",
                 platform=Platform.ESP32,
-                variant=Esp32Variant.ESP32C3,
+                variant="esp32c3",
                 pio_board="esp32-c3-devkitm-1",
                 tags=[BoardTag.COMPACT, BoardTag.USB_C],
                 featured=True,
@@ -118,7 +117,7 @@ def catalog() -> BoardCatalog:
                 description="Display-equipped ESP32-S3",
                 manufacturer="M5Stack",
                 platform=Platform.ESP32,
-                variant=Esp32Variant.ESP32S3,
+                variant="esp32s3",
                 pio_board="m5stack-cores3",
                 tags=[BoardTag.DISPLAY],
             ),
@@ -127,7 +126,7 @@ def catalog() -> BoardCatalog:
                 name="Generic ESP32-C3",
                 manufacturer="Generic",
                 platform=Platform.ESP32,
-                variant=Esp32Variant.ESP32C3,
+                variant="esp32c3",
                 pio_board="esp32-c3-devkitm-1",
                 is_generic=True,
             ),
@@ -136,7 +135,7 @@ def catalog() -> BoardCatalog:
                 name="Generic ESP32-S3",
                 manufacturer="Generic",
                 platform=Platform.ESP32,
-                variant=Esp32Variant.ESP32S3,
+                variant="esp32s3",
                 pio_board="esp32-s3-devkitc-1",
                 is_generic=True,
             ),
@@ -173,7 +172,7 @@ async def test_get_board_returns_match_by_id(catalog: BoardCatalog) -> None:
     board = await catalog.get_board(board_id="m5stack-cores3")
     assert board is not None
     assert board.id == "m5stack-cores3"
-    assert board.esphome.variant == Esp32Variant.ESP32S3
+    assert board.esphome.variant == "esp32s3"
 
 
 async def test_get_board_returns_none_for_unknown_id(catalog: BoardCatalog) -> None:
@@ -325,7 +324,7 @@ async def test_get_boards_filters_compose(catalog: BoardCatalog) -> None:
     """
     resp = await catalog.get_boards(
         platform=Platform.ESP32,
-        variant=Esp32Variant.ESP32C3,
+        variant="esp32c3",
         tag=BoardTag.COMPACT,
     )
 
@@ -466,7 +465,7 @@ def test_find_by_pio_board_prefer_exact_id_beats_generic(catalog: BoardCatalog) 
             board_id="esp32-c3-devkitm-1",
             name="Espressif ESP32-C3-DevKitM-1",
             platform=Platform.ESP32,
-            variant=Esp32Variant.ESP32C3,
+            variant="esp32c3",
             pio_board="esp32-c3-devkitm-1",
         )
     )
@@ -498,7 +497,7 @@ def test_find_by_pio_board_returns_first_when_no_generic(
             board_id="zzz-second-vendor-c3",
             name="ZZZ Second Vendor C3",
             platform=Platform.ESP32,
-            variant=Esp32Variant.ESP32C3,
+            variant="esp32c3",
             pio_board="esp32-c3-devkitm-1",
         )
     )
@@ -582,7 +581,7 @@ def test_find_by_pio_board_prefers_matching_variant(catalog: BoardCatalog) -> No
         _board(
             board_id="alt-c3-board",
             platform=Platform.ESP32,
-            variant=Esp32Variant.ESP32C3,
+            variant="esp32c3",
             pio_board="some-shared-pio",
         )
     )
@@ -590,7 +589,7 @@ def test_find_by_pio_board_prefers_matching_variant(catalog: BoardCatalog) -> No
         _board(
             board_id="alt-s3-board",
             platform=Platform.ESP32,
-            variant=Esp32Variant.ESP32S3,
+            variant="esp32s3",
             pio_board="some-shared-pio",
         )
     )
@@ -607,7 +606,7 @@ def test_find_by_pio_board_matches_uppercase_variant(catalog: BoardCatalog) -> N
         _board(
             board_id="alt-c3-board",
             platform=Platform.ESP32,
-            variant=Esp32Variant.ESP32C3,
+            variant="esp32c3",
             pio_board="shared-pio-upper",
         )
     )
@@ -615,7 +614,7 @@ def test_find_by_pio_board_matches_uppercase_variant(catalog: BoardCatalog) -> N
         _board(
             board_id="alt-s3-board",
             platform=Platform.ESP32,
-            variant=Esp32Variant.ESP32S3,
+            variant="esp32s3",
             pio_board="shared-pio-upper",
         )
     )

--- a/tests/test_boards_json.py
+++ b/tests/test_boards_json.py
@@ -44,7 +44,6 @@ from esphome_device_builder.models.boards import (
     BoardTag,
     Connectivity,
     DefaultComponent,
-    Esp32Variant,
     FeaturedBundle,
     FeaturedComponent,
     Platform,
@@ -568,7 +567,7 @@ def test_round_trip_all_populated_entry_preserves_everything() -> None:
         esphome=BoardEsphomeConfig(
             platform=Platform.ESP32,
             board="esp32dev",
-            variant=Esp32Variant.ESP32S3,
+            variant="esp32s3",
             framework="arduino",
         ),
         hardware=BoardHardware(

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -75,6 +75,7 @@ from esphome_device_builder.controllers.config import (
     set_device_metadata,
 )
 from esphome_device_builder.controllers.config._preferences_store import PreferencesStore
+from esphome_device_builder.controllers.config.chip_detect import _CHIP_FAMILY_MAP
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.helpers.secrets_state import read_secrets_yaml
 from esphome_device_builder.models import (
@@ -1440,6 +1441,14 @@ def test_parse_chip_family_line_returns_none_when_unparseable() -> None:
 
 def test_parse_chip_family_line_returns_none_for_unknown_family() -> None:
     assert _parse_chip_family_line("Chip type: ESP32-Z99 (revision v9.9)") is None
+
+
+def test_chip_family_map_carries_snapshot_variants_and_seeded_rows() -> None:
+    """The table derives from the variant snapshot, with classic esp32 seeded."""
+    assert _CHIP_FAMILY_MAP["esp32"] == ("ESP32", "esp32", "esp32")
+    assert _CHIP_FAMILY_MAP["esp32-c3"] == ("ESP32-C3", "esp32c3", "esp32")
+    assert _CHIP_FAMILY_MAP["esp32-s3"] == ("ESP32-S3", "esp32s3", "esp32")
+    assert _CHIP_FAMILY_MAP["esp8266"] == ("ESP8266", "", "esp8266")
 
 
 def test_chip_family_to_descriptor_maps_esp8266() -> None:

--- a/tests/test_definitions_loader.py
+++ b/tests/test_definitions_loader.py
@@ -443,6 +443,18 @@ def test_load_board_catalog_skips_when_body_missing(
     assert any("Board body missing" in rec.getMessage() for rec in caplog.records)
 
 
+def test_load_esphome_config_warns_on_unknown_variant(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An out-of-snapshot variant loads (fail-open) with a warning, not a drop."""
+    with caplog.at_level(logging.WARNING):
+        cfg = defs._load_esphome_config(
+            {"platform": "esp32", "board": "custom", "variant": "ESP32-Z9"}, "custom-board"
+        )
+    assert cfg.variant == "esp32z9"
+    assert "unknown esp32 variant" in caplog.text
+
+
 def test_load_default_component_rejects_non_string_non_dict_entry() -> None:
     """A malformed default_components entry (not str / dict) raises ``TypeError``.
 

--- a/tests/test_definitions_loader.py
+++ b/tests/test_definitions_loader.py
@@ -443,16 +443,31 @@ def test_load_board_catalog_skips_when_body_missing(
     assert any("Board body missing" in rec.getMessage() for rec in caplog.records)
 
 
-def test_load_esphome_config_warns_on_unknown_variant(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """An out-of-snapshot variant loads (fail-open) with a warning, not a drop."""
-    with caplog.at_level(logging.WARNING):
-        cfg = defs._load_esphome_config(
+def test_load_esphome_config_rejects_unknown_variant() -> None:
+    """An out-of-snapshot variant raises, feeding the manifest walk's strict mode."""
+    with pytest.raises(ValueError, match="unknown esp32 variant"):
+        defs._load_esphome_config(
             {"platform": "esp32", "board": "custom", "variant": "ESP32-Z9"}, "custom-board"
         )
+
+
+def test_load_esphome_config_fails_open_on_empty_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A degraded capabilities index accepts any variant instead of raising."""
+    monkeypatch.setattr(defs, "_known_esp32_variants", frozenset)
+    cfg = defs._load_esphome_config(
+        {"platform": "esp32", "board": "custom", "variant": "ESP32-Z9"}, "custom-board"
+    )
     assert cfg.variant == "esp32z9"
-    assert "unknown esp32 variant" in caplog.text
+
+
+def test_load_esphome_config_ignores_variant_off_esp32() -> None:
+    """A non-esp32 manifest never grows a normalized variant."""
+    cfg = defs._load_esphome_config(
+        {"platform": "rp2040", "board": "rpipicow", "variant": "ESP32C3"}, "pico-board"
+    )
+    assert cfg.variant is None
 
 
 def test_load_default_component_rejects_non_string_non_dict_entry() -> None:

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -1605,7 +1605,7 @@ def _make_board(
 @pytest.mark.parametrize(
     ("board", "expect_fallback"),
     [
-        pytest.param(_make_board(platform=Platform.ESP32, variant="esp32c3"), True, id="esp32"),
+        pytest.param(_make_board(platform=Platform.ESP32, variant="esp32c3"), True, id="esp32c3"),
         pytest.param(
             _make_board(platform=Platform.RP2040, pio_board="rpipicow"), True, id="rp2040_picow"
         ),

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -58,7 +58,6 @@ from esphome_device_builder.models import (
     Device,
     DeviceRuntimeState,
     DeviceState,
-    Esp32Variant,
     Platform,
     ReachabilitySource,
 )
@@ -67,7 +66,7 @@ from tests._storage_fixtures import write_storage_json
 
 def _make_esp32_board(
     *,
-    variant: Esp32Variant | None = None,
+    variant: str | None = None,
     flash_size: str | None = None,
     framework: str | None = None,
     engineering_sample: bool = False,
@@ -1262,7 +1261,7 @@ def test_generate_yaml_emits_esp32_variant_when_set() -> None:
     refactor that consolidated the three ``if``s into one block
     can't silently drop a field.
     """
-    board = _make_esp32_board(variant=Esp32Variant.ESP32S3)
+    board = _make_esp32_board(variant="esp32s3")
     yaml = generate_device_yaml("kitchen", "Kitchen", board, ssid="", psk="")
 
     assert "esp32:\n  variant: esp32s3\n" in yaml
@@ -1325,7 +1324,7 @@ def test_generate_yaml_emits_engineering_sample_for_prerev3_p4() -> None:
     that faults at the bootloader on pre-rev3 silicon.
     """
     board = _make_esp32_board(
-        variant=Esp32Variant.ESP32P4,
+        variant="esp32p4",
         flash_size="32MB",
         framework="esp-idf",
         engineering_sample=True,
@@ -1337,7 +1336,7 @@ def test_generate_yaml_emits_engineering_sample_for_prerev3_p4() -> None:
 
 def test_generate_yaml_omits_engineering_sample_by_default() -> None:
     """Non-ES board → no ``engineering_sample`` line (rev3 P4s must not get it)."""
-    board = _make_esp32_board(variant=Esp32Variant.ESP32P4, framework="esp-idf")
+    board = _make_esp32_board(variant="esp32p4", framework="esp-idf")
     yaml = generate_device_yaml("kitchen", "Kitchen", board, ssid="", psk="")
 
     assert "engineering_sample" not in yaml
@@ -1350,7 +1349,7 @@ def test_generate_yaml_pins_logger_hardware_uart_when_set() -> None:
     output but no app logs on the chip-default console.
     """
     board = _make_esp32_board(
-        variant=Esp32Variant.ESP32P4,
+        variant="esp32p4",
         framework="esp-idf",
         logger_hardware_uart="UART0",
     )
@@ -1361,7 +1360,7 @@ def test_generate_yaml_pins_logger_hardware_uart_when_set() -> None:
 
 def test_generate_yaml_leaves_logger_bare_by_default() -> None:
     """No ``logger_hardware_uart`` → bare ``logger:`` (ESPHome's default console)."""
-    board = _make_esp32_board(variant=Esp32Variant.ESP32P4, framework="esp-idf")
+    board = _make_esp32_board(variant="esp32p4", framework="esp-idf")
     yaml = generate_device_yaml("kitchen", "Kitchen", board, ssid="", psk="")
 
     assert "logger:\n\n" in yaml
@@ -1376,7 +1375,7 @@ def test_generate_yaml_emits_all_three_esp32_fields_together() -> None:
     configs) expect the same shape ESPHome's docs use.
     """
     board = _make_esp32_board(
-        variant=Esp32Variant.ESP32S3,
+        variant="esp32s3",
         flash_size="16MB",
         framework="arduino",
     )
@@ -1398,7 +1397,7 @@ def test_generate_yaml_emits_explicit_wifi_credentials_when_provided() -> None:
     that always emitted ``!secret`` would silently break the
     "works without secrets.yaml" path.
     """
-    board = _make_esp32_board(variant=Esp32Variant.ESP32)
+    board = _make_esp32_board(variant="esp32")
 
     # Explicit credentials.
     explicit = generate_device_yaml("kitchen", "Kitchen", board, ssid="MyNetwork", psk="hunter2")
@@ -1414,7 +1413,7 @@ def test_generate_yaml_emits_explicit_wifi_credentials_when_provided() -> None:
 
 def test_generate_yaml_omits_wifi_when_board_has_wifi_but_no_secrets() -> None:
     """No literal ssid and no wifi secrets → no ``!secret`` block, network TODO instead."""
-    board = _make_esp32_board(variant=Esp32Variant.ESP32)
+    board = _make_esp32_board(variant="esp32")
 
     out = generate_device_yaml(
         "kitchen", "Kitchen", board, ssid="", psk="", wifi_secrets_available=False
@@ -1430,7 +1429,7 @@ def test_generate_yaml_omits_wifi_when_board_has_wifi_but_no_secrets() -> None:
 
 def test_generate_yaml_literal_ssid_inlines_regardless_of_secrets() -> None:
     """A literal ssid still inlines even when wifi secrets are absent."""
-    board = _make_esp32_board(variant=Esp32Variant.ESP32)
+    board = _make_esp32_board(variant="esp32")
 
     out = generate_device_yaml(
         "kitchen", "Kitchen", board, ssid="MyNet", psk="pw", wifi_secrets_available=False
@@ -1462,7 +1461,7 @@ def test_generate_yaml_secret_refs_resolve_through_esphome_loader(tmp_path: Path
     would load as the literal string "!secret wifi_ssid" and silently
     break wifi.
     """
-    board = _make_esp32_board(variant=Esp32Variant.ESP32)
+    board = _make_esp32_board(variant="esp32")
     (tmp_path / "secrets.yaml").write_text(
         "wifi_ssid: RealNetwork-7f3a\nwifi_password: RealPass-9b21\n", encoding="utf-8"
     )
@@ -1483,7 +1482,7 @@ def test_generate_yaml_literal_secret_string_stays_a_literal(tmp_path: Path) -> 
     magic secret string yields a literal, not a resolved secret, so
     the wizard must send empty rather than the string itself.
     """
-    board = _make_esp32_board(variant=Esp32Variant.ESP32)
+    board = _make_esp32_board(variant="esp32")
     (tmp_path / "secrets.yaml").write_text(
         "wifi_ssid: RealNetwork\nwifi_password: RealPass\n", encoding="utf-8"
     )
@@ -1513,7 +1512,7 @@ def test_generate_yaml_literal_secret_string_stays_a_literal(tmp_path: Path) -> 
 )
 def test_generate_device_yaml_quotes_wifi_credentials(ssid: str, psk: str) -> None:
     """ssid/psk round-trip through safe-scalar quoting intact."""
-    board = _make_esp32_board(variant=Esp32Variant.ESP32)
+    board = _make_esp32_board(variant="esp32")
     text = generate_device_yaml("kitchen", "Kitchen", board, ssid=ssid, psk=psk)
 
     parsed = yaml.safe_load(text)
@@ -1523,7 +1522,7 @@ def test_generate_device_yaml_quotes_wifi_credentials(ssid: str, psk: str) -> No
 
 def test_generate_device_yaml_emits_fallback_ap_and_captive_portal() -> None:
     """ESP32 wizard YAML carries the fallback hotspot ssid + a captive_portal block."""
-    board = _make_esp32_board(variant=Esp32Variant.ESP32)
+    board = _make_esp32_board(variant="esp32")
     text = generate_device_yaml("kitchen", "Kitchen Lamp", board, ssid="Net", psk="pw")
 
     parsed = yaml.safe_load(text)
@@ -1534,7 +1533,7 @@ def test_generate_device_yaml_emits_fallback_ap_and_captive_portal() -> None:
 
 def test_generate_device_yaml_fallback_ap_password_is_per_device() -> None:
     """The fallback-hotspot psk is freshly generated each call."""
-    board = _make_esp32_board(variant=Esp32Variant.ESP32)
+    board = _make_esp32_board(variant="esp32")
     a = yaml.safe_load(generate_device_yaml("k", "K", board, ssid="N", psk="p"))
     b = yaml.safe_load(generate_device_yaml("k", "K", board, ssid="N", psk="p"))
     assert a["wifi"]["ap"]["password"] != b["wifi"]["ap"]["password"]
@@ -1558,7 +1557,7 @@ def test_generate_device_yaml_fallback_ap_ssid_respects_32_char_cap(
     friendly_name: str, expected: str
 ) -> None:
     """AP ssid keeps the " Fallback Hotspot" marker, trimming the name to stay within 32 chars."""
-    board = _make_esp32_board(variant=Esp32Variant.ESP32)
+    board = _make_esp32_board(variant="esp32")
     text = generate_device_yaml("dev", friendly_name, board, ssid="Net", psk="pw")
     ap_ssid = yaml.safe_load(text)["wifi"]["ap"]["ssid"]
     assert ap_ssid == expected
@@ -1578,7 +1577,7 @@ def test_generate_device_yaml_fallback_ap_ssid_respects_32_char_cap(
 def _make_board(
     *,
     platform: Platform,
-    variant: Esp32Variant | None = None,
+    variant: str | None = None,
     pio_board: str = "",
     connectivity: list[Connectivity] | None = None,
 ) -> BoardCatalogEntry:
@@ -1606,14 +1605,12 @@ def _make_board(
 @pytest.mark.parametrize(
     ("board", "expect_fallback"),
     [
-        pytest.param(
-            _make_board(platform=Platform.ESP32, variant=Esp32Variant.ESP32C3), True, id="esp32"
-        ),
+        pytest.param(_make_board(platform=Platform.ESP32, variant="esp32c3"), True, id="esp32"),
         pytest.param(
             _make_board(platform=Platform.RP2040, pio_board="rpipicow"), True, id="rp2040_picow"
         ),
         pytest.param(
-            _make_board(platform=Platform.ESP32, variant=Esp32Variant.ESP32H2),
+            _make_board(platform=Platform.ESP32, variant="esp32h2"),
             False,
             id="esp32h2_no_wifi",
         ),
@@ -1647,7 +1644,7 @@ def test_generate_yaml_omits_wifi_for_esp32h2_without_explicit_connectivity() ->
     future no-Wi-Fi variant added upstream is picked up
     automatically.
     """
-    board = _make_board(platform=Platform.ESP32, variant=Esp32Variant.ESP32H2)
+    board = _make_board(platform=Platform.ESP32, variant="esp32h2")
     yaml = generate_device_yaml("kitchen", "Kitchen", board, ssid="", psk="")
     assert "wifi:" not in yaml
 
@@ -1667,7 +1664,7 @@ def test_generate_yaml_omits_api_and_ota_for_no_wifi_board() -> None:
     ``ota:`` in backticks so naive ``"api:" not in yaml`` would
     false-positive on the guidance text.
     """
-    board = _make_board(platform=Platform.ESP32, variant=Esp32Variant.ESP32H2)
+    board = _make_board(platform=Platform.ESP32, variant="esp32h2")
     yaml = generate_device_yaml("kitchen", "Kitchen", board, ssid="", psk="")
     lines = yaml.splitlines()
     assert "api:" not in lines
@@ -1683,7 +1680,7 @@ def test_generate_yaml_no_wifi_board_emits_network_todo_comment() -> None:
     have a starting point. Pin a couple of stable substrings so a
     rewording that drops the guidance entirely surfaces here.
     """
-    board = _make_board(platform=Platform.ESP32, variant=Esp32Variant.ESP32H2)
+    board = _make_board(platform=Platform.ESP32, variant="esp32h2")
     yaml = generate_device_yaml("kitchen", "Kitchen", board, ssid="", psk="")
     assert "no native Wi-Fi" in yaml
     assert "network" in yaml
@@ -1696,7 +1693,7 @@ def test_generate_yaml_keeps_api_and_ota_for_wifi_board() -> None:
     every ESP32 / ESP8266 / Pico-W config keeps the api +
     encryption + ota blocks the wizard always produced.
     """
-    board = _make_board(platform=Platform.ESP32, variant=Esp32Variant.ESP32C3)
+    board = _make_board(platform=Platform.ESP32, variant="esp32c3")
     yaml = generate_device_yaml("kitchen", "Kitchen", board, ssid="", psk="")
     lines = yaml.splitlines()
     assert "api:" in lines
@@ -1713,7 +1710,7 @@ def test_generate_yaml_emits_wifi_for_esp32c3_without_explicit_connectivity() ->
     without spelling out the connectivity list still get a
     compilable basic config.
     """
-    board = _make_board(platform=Platform.ESP32, variant=Esp32Variant.ESP32C3)
+    board = _make_board(platform=Platform.ESP32, variant="esp32c3")
     yaml = generate_device_yaml("kitchen", "Kitchen", board, ssid="", psk="")
     assert "wifi:" in yaml
 
@@ -1769,7 +1766,7 @@ def test_generate_yaml_explicit_connectivity_overrides_inference() -> None:
     # radio provider in defaults wins.
     h2_with_wifi = _make_board(
         platform=Platform.ESP32,
-        variant=Esp32Variant.ESP32H2,
+        variant="esp32h2",
         connectivity=[Connectivity.WIFI],
     )
     hosted = _hosted_defaults()
@@ -1785,7 +1782,7 @@ def test_generate_yaml_explicit_connectivity_overrides_inference() -> None:
     # Inference says wifi (plain ESP32), explicit ethernet-only opts out.
     eth_only = _make_board(
         platform=Platform.ESP32,
-        variant=Esp32Variant.ESP32,
+        variant="esp32",
         connectivity=[Connectivity.ETHERNET],
     )
     yaml = generate_device_yaml("kitchen", "Kitchen", eth_only, ssid="", psk="")
@@ -2003,7 +2000,7 @@ def test_infer_native_wifi_routes_through_module_alias(
 
     monkeypatch.setattr(device_yaml._generation, "_has_native_wifi", _stub)
 
-    esp32_board = _make_board(platform=Platform.ESP32, variant=Esp32Variant.ESP32C3)
+    esp32_board = _make_board(platform=Platform.ESP32, variant="esp32c3")
     rp2040_board = _make_board(platform=Platform.RP2040, pio_board="rpipicow")
 
     assert device_yaml._infer_native_wifi(esp32_board) is False
@@ -3061,7 +3058,7 @@ def test_generate_device_yaml_network_default_wins_over_no_wifi_secrets() -> Non
 
 def test_generate_device_yaml_hosted_radio_enables_wifi_on_p4() -> None:
     """An ``esp32_hosted`` default makes a wifi-claiming P4 emit a real ``wifi:``."""
-    board = _make_esp32_board(variant=Esp32Variant.ESP32P4, framework="esp-idf")
+    board = _make_esp32_board(variant="esp32p4", framework="esp-idf")
     defaults = _hosted_defaults()
     out = generate_device_yaml("kitchen", "Kitchen", board, ssid="net", psk="pw", defaults=defaults)
     assert "wifi:" in out
@@ -3073,7 +3070,7 @@ def test_generate_device_yaml_hosted_radio_enables_wifi_on_p4() -> None:
 
 def test_generate_device_yaml_hosted_default_appends_firmware_update() -> None:
     """An ``esp32_hosted`` default appends ``http_request:`` and its update entity."""
-    board = _make_esp32_board(variant=Esp32Variant.ESP32P4, framework="esp-idf")
+    board = _make_esp32_board(variant="esp32p4", framework="esp-idf")
     out = generate_device_yaml(
         "kitchen", "Kitchen", board, ssid="net", psk="pw", defaults=_hosted_defaults()
     )
@@ -3093,7 +3090,7 @@ def test_generate_device_yaml_hosted_default_appends_firmware_update() -> None:
 def test_generate_device_yaml_hosted_variant_without_firmware_manifest_skips_update() -> None:
     """No published firmware manifest for the variant → no update entity, no dead URL."""
     defaults = [(_make_component("esp32_hosted"), {"variant": "ESP32C3"})]
-    board = _make_esp32_board(variant=Esp32Variant.ESP32P4, framework="esp-idf")
+    board = _make_esp32_board(variant="esp32p4", framework="esp-idf")
     out = generate_device_yaml("kitchen", "Kitchen", board, ssid="net", psk="pw", defaults=defaults)
 
     assert "http_request:" not in out
@@ -3102,7 +3099,7 @@ def test_generate_device_yaml_hosted_variant_without_firmware_manifest_skips_upd
 
 def test_generate_device_yaml_no_hosted_default_appends_no_update() -> None:
     """Boards without a hosted radio get neither ``http_request:`` nor ``update:``."""
-    board = _make_esp32_board(variant=Esp32Variant.ESP32S3, framework="esp-idf")
+    board = _make_esp32_board(variant="esp32s3", framework="esp-idf")
     out = generate_device_yaml("kitchen", "Kitchen", board, ssid="net", psk="pw")
 
     assert "http_request:" not in out
@@ -3116,7 +3113,7 @@ def test_generate_device_yaml_p4_wifi_claim_without_radio_gets_network_todo() ->
     component esp32_hosted on ESP32P4"), so the generator falls back to
     the no-network TODO stub instead of an invalid config.
     """
-    board = _make_esp32_board(variant=Esp32Variant.ESP32P4, framework="esp-idf")
+    board = _make_esp32_board(variant="esp32p4", framework="esp-idf")
     out = generate_device_yaml("kitchen", "Kitchen", board, ssid="net", psk="pw")
     lines = out.splitlines()
     assert "wifi:" not in lines
@@ -3132,7 +3129,7 @@ def test_generate_device_yaml_ethernet_beats_hosted_radio() -> None:
     dual-network boards must come out wired-first; the hosted block still
     lands so switching to Wi-Fi is a block swap, not a pin hunt.
     """
-    board = _make_esp32_board(variant=Esp32Variant.ESP32P4, framework="esp-idf")
+    board = _make_esp32_board(variant="esp32p4", framework="esp-idf")
     defaults = [(_make_component("ethernet"), {"type": "IP101"}), *_hosted_defaults()]
     out = generate_device_yaml("kitchen", "Kitchen", board, ssid="", psk="", defaults=defaults)
     assert "ethernet:" in out
@@ -3143,7 +3140,7 @@ def test_generate_device_yaml_ethernet_beats_hosted_radio() -> None:
 
 def test_generate_device_yaml_hosted_radio_without_secrets_gets_wifi_todo() -> None:
     """A hosted-radio P4 with no credentials gets the no-secrets TODO, not no-network."""
-    board = _make_esp32_board(variant=Esp32Variant.ESP32P4, framework="esp-idf")
+    board = _make_esp32_board(variant="esp32p4", framework="esp-idf")
     defaults = _hosted_defaults()
     out = generate_device_yaml(
         "kitchen",

--- a/tests/test_esp32_board_pins.py
+++ b/tests/test_esp32_board_pins.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import importlib
 
 import pytest
+from esphome.components.esp32.const import VARIANTS
 
 from esphome_device_builder.models import (
     BoardCatalogResponse,
     BoardPin,
-    Esp32Variant,
     PinFeature,
 )
 from script.sync_boards import (
@@ -21,13 +21,13 @@ from script.sync_boards import (
 pytestmark = pytest.mark.xdist_group("board_sync")
 
 
-def test_every_esphome_variant_maps_to_enum() -> None:
+def test_every_esphome_board_variant_is_a_known_variant() -> None:
+    """Pins the invariant the capability emitters rely on: BOARDS ⊆ VARIANTS."""
     module = importlib.import_module(_ESP32_BOARDS_MODULE)
     board_list = getattr(module, _ESP32_BOARDS_ATTR)
     variants = {meta["variant"] for meta in board_list.values()}
     assert variants, "esphome should expose esp32 boards"
-    for variant in variants:
-        assert Esp32Variant(variant.lower())
+    assert variants <= set(VARIANTS)
 
 
 def test_catalog_generates_board_with_derived_pins(
@@ -40,7 +40,7 @@ def test_catalog_generates_board_with_derived_pins(
     assert "adafruit_feather_esp32_v2" in boards
     board = boards["adafruit_feather_esp32_v2"]
     assert board.esphome.platform.value == "esp32"
-    assert board.esphome.variant is Esp32Variant.ESP32
+    assert board.esphome.variant == "esp32"
     feats = {f for pin in board.pins for f in pin.features}
     assert {PinFeature.I2C_SDA, PinFeature.I2C_SCL, PinFeature.UART_TX} <= feats
     # Aliases enrich, not replace, the variant pinout: the full generic-esp32
@@ -59,7 +59,7 @@ def test_sparse_board_keeps_full_variant_pinout(
     boards = {b.id: b for b in generated_board_catalog.boards}
     assert "mhetesp32minikit" in boards
     board = boards["mhetesp32minikit"]
-    assert board.esphome.variant is Esp32Variant.ESP32
+    assert board.esphome.variant == "esp32"
     generic_gpios = {p.gpio for p in boards["generic-esp32"].pins}
     assert {p.gpio for p in board.pins} == generic_gpios
     assert {1, 3, 16} <= generic_gpios
@@ -99,7 +99,7 @@ def test_catalog_falls_back_to_generic_variant_pins(
     # so it inherits the generic-esp32s3 pinout.
     assert "adafruit_camera_esp32s3" in boards
     board = boards["adafruit_camera_esp32s3"]
-    assert board.esphome.variant is Esp32Variant.ESP32S3
+    assert board.esphome.variant == "esp32s3"
     generic = boards["generic-esp32s3"]
     assert board.pins, "fallback board should carry the generic variant pins"
     assert [p.to_dict() for p in board.pins] == [p.to_dict() for p in generic.pins]

--- a/tests/test_esp32_board_pins.py
+++ b/tests/test_esp32_board_pins.py
@@ -7,12 +7,12 @@ import importlib
 import pytest
 
 from esphome_device_builder.definitions import load_platform_capabilities_index
+from esphome_device_builder.helpers.chips import normalize_chip_variant
 from esphome_device_builder.models import (
     BoardCatalogResponse,
     BoardPin,
     PinFeature,
 )
-from esphome_device_builder.models.boards import normalize_chip_variant
 from script.sync_boards import (
     _ESP32_BOARDS_ATTR,
     _ESP32_BOARDS_MODULE,

--- a/tests/test_esp32_board_pins.py
+++ b/tests/test_esp32_board_pins.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import importlib
 
 import pytest
-from esphome.components.esp32.const import VARIANTS
 
+from esphome_device_builder.definitions import load_platform_capabilities_index
 from esphome_device_builder.models import (
     BoardCatalogResponse,
     BoardPin,
     PinFeature,
 )
+from esphome_device_builder.models.boards import normalize_chip_variant
 from script.sync_boards import (
     _ESP32_BOARDS_ATTR,
     _ESP32_BOARDS_MODULE,
@@ -21,13 +22,14 @@ from script.sync_boards import (
 pytestmark = pytest.mark.xdist_group("board_sync")
 
 
-def test_every_esphome_board_variant_is_a_known_variant() -> None:
-    """Pins the invariant the capability emitters rely on: BOARDS ⊆ VARIANTS."""
+def test_every_esphome_board_variant_is_in_the_committed_snapshot() -> None:
+    """The tripwire the deleted enum provided: our snapshot keeps up with upstream."""
+    known = {normalize_chip_variant(v) for v in load_platform_capabilities_index().esp32_variants}
     module = importlib.import_module(_ESP32_BOARDS_MODULE)
     board_list = getattr(module, _ESP32_BOARDS_ATTR)
-    variants = {meta["variant"] for meta in board_list.values()}
+    variants = {normalize_chip_variant(meta["variant"]) for meta in board_list.values()}
     assert variants, "esphome should expose esp32 boards"
-    assert variants <= set(VARIANTS)
+    assert variants <= known
 
 
 def test_catalog_generates_board_with_derived_pins(

--- a/tests/test_platform_capabilities.py
+++ b/tests/test_platform_capabilities.py
@@ -22,7 +22,7 @@ from esphome.components.rp2040.boards import BOARDS
 from esphome.components.wifi import NO_WIFI_VARIANTS
 
 from esphome_device_builder.definitions import (
-    PlatformCapabilities,
+    EMPTY_PLATFORM_CAPABILITIES,
     _load_platform_capabilities,
     _parse_download_types,
     load_platform_capabilities_index,
@@ -30,8 +30,6 @@ from esphome_device_builder.definitions import (
 from script.sync_components import _logger_interface_snapshot  # type: ignore[import-not-found]
 
 from .conftest import catalog_releases_ahead as _catalog_releases_ahead
-
-_EMPTY = PlatformCapabilities([], [], [], [], {}, [], {}, {}, [])
 
 
 def test_loader_returns_known_platforms() -> None:
@@ -115,21 +113,21 @@ def test_logger_interface_snapshot_within_installed_esphome() -> None:
 
 def test_load_missing_index_is_empty(tmp_path: Path) -> None:
     """A missing index degrades to empty (fail-open), not a raise."""
-    assert _load_platform_capabilities(tmp_path / "absent.json") == _EMPTY
+    assert _load_platform_capabilities(tmp_path / "absent.json") == EMPTY_PLATFORM_CAPABILITIES
 
 
 def test_load_malformed_index_is_empty(tmp_path: Path) -> None:
     """Unparsable JSON degrades to empty."""
     path = tmp_path / "bad.json"
     path.write_bytes(b"{not valid json")
-    assert _load_platform_capabilities(path) == _EMPTY
+    assert _load_platform_capabilities(path) == EMPTY_PLATFORM_CAPABILITIES
 
 
 def test_load_non_mapping_index_is_empty(tmp_path: Path) -> None:
     """A top-level JSON array (not an object) degrades to empty."""
     path = tmp_path / "list.json"
     path.write_bytes(b"[]")
-    assert _load_platform_capabilities(path) == _EMPTY
+    assert _load_platform_capabilities(path) == EMPTY_PLATFORM_CAPABILITIES
 
 
 def test_load_coerces_non_list_fields(tmp_path: Path) -> None:

--- a/tests/test_rmii_data_pins.py
+++ b/tests/test_rmii_data_pins.py
@@ -6,7 +6,6 @@ from esphome_device_builder.models import (
     BoardCatalogEntry,
     BoardEsphomeConfig,
     BoardPin,
-    Esp32Variant,
     FeaturedComponent,
     Platform,
 )
@@ -19,7 +18,7 @@ _RMII_GPIOS = {19, 21, 22, 25, 26, 27}
 def _board(
     *,
     platform: Platform = Platform.ESP32,
-    variant: Esp32Variant | None = Esp32Variant.ESP32,
+    variant: str | None = "esp32",
     eth_fields: dict[str, object] | None = None,
     pins: list[BoardPin] | None = None,
 ) -> BoardCatalogEntry:
@@ -100,7 +99,7 @@ def test_non_esp32_board_skipped() -> None:
 def test_esp32p4_board_uses_p4_pins() -> None:
     """An esp32p4 RMII board gets the P4 default data pins, not the classic set."""
     board = _board(
-        variant=Esp32Variant.ESP32P4,
+        variant="esp32p4",
         eth_fields={"type": "LAN8720", "mdc_pin": "GPIO23"},
     )
     _augment_rmii_data_pins([board])
@@ -113,7 +112,7 @@ def test_esp32p4_board_uses_p4_pins() -> None:
 def test_esp32_variant_without_emac_skipped() -> None:
     """An esp32 variant with no RMII pin map (e.g. esp32s3) is left untouched."""
     board = _board(
-        variant=Esp32Variant.ESP32S3,
+        variant="esp32s3",
         eth_fields={"type": "LAN8720", "mdc_pin": "GPIO23"},
     )
     _augment_rmii_data_pins([board])


### PR DESCRIPTION
# What does this implement/fix?

Deletes the hand-maintained `Esp32Variant` StrEnum; the variant vocabulary now comes from the live `esp32_variants` snapshot (runtime) or esphome's own `VARIANTS` (script side). Behavior-free: variants were already serialized as their string values, so the wire shape is unchanged everywhere.

Originally chained on #2312 for its `normalize_chip_variant` helper; now rebased onto `main` (which contains it).

Per site:

- `BoardEsphomeConfig.variant` becomes `str | None` (lowercase catalog form documented on the field).
- The definitions loader (sync-time only; the runtime deserializes via mashumaro) normalizes the value and raises on one outside the snapshot, feeding the manifest walk's existing `strict` mode — same loud-gate semantics the enum constructor had, restored after review. A degraded/empty snapshot fails open and accepts anything. The vocabulary set is cached once (`_known_esp32_variants`), not rebuilt per board.
- `chip_detect.py` derives its esptool-family map from the snapshot, so the USB chip prober recognizes a new variant after one catalog sync with no code change (previously it required a human to grow the enum).
- `sync_boards.py` / `sync_esphome_devices.py` use plain strings via `normalize_chip_variant` / live `VARIANTS`; the RMII pin map keys become literals.
- The enum's tripwire is restored against our own artifact: `test_every_esphome_board_variant_is_in_the_committed_snapshot` fails when upstream adds a variant our committed snapshot lacks — the exact state the deleted enum test caught. `_CHIP_FAMILY_MAP` seeds the classic `esp32` row unconditionally (a degraded index degrades chip detection to less precise, never to empty) and gains its first direct test.
- Test fixtures construct variants as plain strings.

Verified: full suite (7181 passed), mypy clean across the package, `validate_definitions.py` green on all 572 boards, and the `generated_board_catalog` fixture exercises the board-generation pipeline end-to-end with string variants.

**Related issue or feature (if applicable):**

- fixes #2313

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
