### PR TITLE
Retire the schema's hand variant enum and fold variant filter spellings

### DIFF
--- a/esphome_device_builder/controllers/boards.py
+++ b/esphome_device_builder/controllers/boards.py
@@ -10,6 +10,7 @@ from ..definitions import (
     load_board_index,
 )
 from ..helpers.api import api_command
+from ..helpers.chips import normalize_chip_variant
 from ..helpers.device_yaml import board_requires_wifi
 from ..helpers.lazy_catalog import LazyBodyStore
 from ..models import (
@@ -41,9 +42,13 @@ def _board_sort_key(board: BoardCatalogIndex) -> tuple[bool, bool, bool, str]:
 
 
 def _filter_by_variant(boards: list[BoardCatalogIndex], variant: str) -> list[BoardCatalogIndex]:
-    """Boards whose variant equals *variant*, case-insensitively (empty if none)."""
-    target = variant.lower()
-    return [b for b in boards if b.esphome.variant and b.esphome.variant.lower() == target]
+    """Boards whose variant matches *variant* under the shared spelling fold (empty if none)."""
+    target = normalize_chip_variant(variant)
+    return [
+        b
+        for b in boards
+        if b.esphome.variant and normalize_chip_variant(b.esphome.variant) == target
+    ]
 
 
 class BoardCatalog:

--- a/esphome_device_builder/definitions/schemas/board.schema.json
+++ b/esphome_device_builder/definitions/schemas/board.schema.json
@@ -41,8 +41,7 @@
         },
         "variant": {
           "type": ["string", "null"],
-          "description": "ESP32 chip variant, lowercase (e.g. esp32c3). Only for esp32 platform; canonical spelling and the esp32_variants vocabulary are enforced by validate_definitions.",
-          "pattern": "^[Ee][Ss][Pp]32[A-Za-z0-9_-]*$"
+          "description": "ESP32 chip variant, lowercase (e.g. esp32c3). Only for esp32 platform; spelling and the esp32_variants vocabulary are enforced by validate_definitions."
         },
         "framework": {
           "type": ["string", "null"],

--- a/esphome_device_builder/definitions/schemas/board.schema.json
+++ b/esphome_device_builder/definitions/schemas/board.schema.json
@@ -41,8 +41,8 @@
         },
         "variant": {
           "type": ["string", "null"],
-          "description": "ESP32 chip variant, lowercase (e.g. esp32c3). Only for esp32 platform; the vocabulary is the esp32_variants snapshot, enforced by validate_definitions.",
-          "pattern": "^esp32[a-z0-9]*$"
+          "description": "ESP32 chip variant, lowercase (e.g. esp32c3). Only for esp32 platform; canonical spelling and the esp32_variants vocabulary are enforced by validate_definitions.",
+          "pattern": "^[Ee][Ss][Pp]32[A-Za-z0-9_-]*$"
         },
         "framework": {
           "type": ["string", "null"],

--- a/esphome_device_builder/definitions/schemas/board.schema.json
+++ b/esphome_device_builder/definitions/schemas/board.schema.json
@@ -41,8 +41,8 @@
         },
         "variant": {
           "type": ["string", "null"],
-          "description": "ESP32 chip variant. Only for esp32 platform.",
-          "enum": ["esp32", "esp32s2", "esp32s3", "esp32c2", "esp32c3", "esp32c5", "esp32c6", "esp32c61", "esp32h2", "esp32p4", null]
+          "description": "ESP32 chip variant, lowercase (e.g. esp32c3). Only for esp32 platform; the vocabulary is the esp32_variants snapshot, enforced by validate_definitions.",
+          "pattern": "^esp32[a-z0-9]*$"
         },
         "framework": {
           "type": ["string", "null"],

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -81,8 +81,16 @@ def _load_capabilities_snapshot() -> dict:
 
 
 def _snapshot_variant_set(caps: dict, key: str) -> frozenset[str]:
-    """Return the normalized variant set for *key* in the parsed snapshot."""
-    return frozenset(normalize_chip_variant(str(v)) for v in caps.get(key, []))
+    """Return the normalized variant set for *key*; empty (and loud) when malformed."""
+    values = caps.get(key)
+    if not isinstance(values, list):
+        print(
+            f"warning: {key} missing or malformed in platform_capabilities.index.json; "
+            "the variant vocabulary check is disabled",
+            file=sys.stderr,
+        )
+        return frozenset()
+    return frozenset(normalize_chip_variant(str(v)) for v in values)
 
 
 _CAPS_SNAPSHOT = _load_capabilities_snapshot()
@@ -247,12 +255,18 @@ def validate_board(
 
 
 def _validate_variant_vocabulary(board_id: str, data: dict) -> list[str]:
-    """Reject a variant outside the snapshot vocabulary; fail open on an empty snapshot."""
+    """Reject a non-canonical or out-of-vocabulary variant; fail open on an empty snapshot."""
     esphome_cfg = data.get("esphome")
     declared = esphome_cfg.get("variant") if isinstance(esphome_cfg, dict) else None
-    if not isinstance(declared, str) or not _ESP32_VARIANTS:
+    if not isinstance(declared, str):
         return []
-    if normalize_chip_variant(declared) not in _ESP32_VARIANTS:
+    canonical = normalize_chip_variant(declared)
+    if declared != canonical:
+        return [
+            f"{board_id}: esphome.variant '{declared}' must be the canonical lowercase "
+            f"spelling '{canonical}'"
+        ]
+    if _ESP32_VARIANTS and canonical not in _ESP32_VARIANTS:
         return [
             f"{board_id}: esphome.variant '{declared}' is not a known esp32 variant "
             "(vocabulary: esp32_variants in platform_capabilities.index.json)"

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -86,7 +86,7 @@ def _snapshot_variant_set(caps: dict, key: str) -> frozenset[str]:
     if not isinstance(values, list):
         print(
             f"warning: {key} missing or malformed in platform_capabilities.index.json; "
-            "the variant vocabulary check is disabled",
+            "the check backed by it is disabled",
             file=sys.stderr,
         )
         return frozenset()
@@ -265,6 +265,11 @@ def _validate_variant_vocabulary(board_id: str, data: dict) -> list[str]:
         return [
             f"{board_id}: esphome.variant '{declared}' must be the canonical lowercase "
             f"spelling '{canonical}'"
+        ]
+    if not canonical.startswith("esp32"):
+        return [
+            f"{board_id}: esphome.variant '{declared}' must be an esp32-family variant "
+            "(e.g. esp32c3)"
         ]
     if _ESP32_VARIANTS and canonical not in _ESP32_VARIANTS:
         return [
@@ -537,7 +542,9 @@ def _validate_featured(  # noqa: C901
 
 def _validate_wifi_radio_claim(board_id: str, data: dict) -> list[str]:
     """Require a radio-provider default when a no-native-Wi-Fi variant claims wifi."""
-    esphome_cfg = data.get("esphome") or {}
+    esphome_cfg = data.get("esphome")
+    if not isinstance(esphome_cfg, dict):
+        return []
     variant = normalize_chip_variant(str(esphome_cfg.get("variant") or ""))
     if esphome_cfg.get("platform") != "esp32" or variant not in _ESP32_NO_WIFI_VARIANTS:
         return []

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -269,15 +269,17 @@ def _validate_variant_vocabulary(board_id: str, data: dict) -> list[str]:
             f"{board_id}: esphome.variant '{declared}' must be an esp32-family variant "
             "(e.g. esp32c3)"
         ]
-    if declared != canonical:
-        return [
-            f"{board_id}: esphome.variant '{declared}' must be the canonical lowercase "
-            f"spelling '{canonical}'"
-        ]
+    # Vocabulary before spelling: the spelling message proposes the folded
+    # value, so it must only fire when that value is actually accepted.
     if _ESP32_VARIANTS and canonical not in _ESP32_VARIANTS:
         return [
             f"{board_id}: esphome.variant '{declared}' is not a known esp32 variant "
             "(vocabulary: esp32_variants in platform_capabilities.index.json)"
+        ]
+    if declared != canonical:
+        return [
+            f"{board_id}: esphome.variant '{declared}' must be the canonical lowercase "
+            f"spelling '{canonical}'"
         ]
     return []
 

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -82,6 +82,23 @@ def _load_esp32_no_wifi_variants() -> frozenset[str]:
 
 _ESP32_NO_WIFI_VARIANTS = _load_esp32_no_wifi_variants()
 
+
+def _load_esp32_variants() -> frozenset[str]:
+    """
+    Read the ``esp32_variants`` vocabulary from the capabilities snapshot.
+
+    Same stdlib-json / fail-open shape as ``_load_esp32_no_wifi_variants``.
+    """
+    caps_path = DEFINITIONS_DIR / "platform_capabilities.index.json"
+    try:
+        caps = json.loads(caps_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return frozenset()
+    return frozenset(normalize_chip_variant(str(v)) for v in caps.get("esp32_variants", []))
+
+
+_ESP32_VARIANTS = _load_esp32_variants()
+
 # Required shape for featured-component ids: lowercase letters, digits, and
 # underscores only, starting with a letter. Mirrors what ESPHome accepts
 # as a valid identifier and what the sync script's auto-id format produces.
@@ -222,6 +239,7 @@ def validate_board(
     # intersection check for these; the rest of featured-component
     # validation (component_id present, fields key match,
     # GPIO declared) still runs.
+    errors.extend(_validate_variant_vocabulary(board_id, data))
     errors.extend(_validate_pins_from(board_id, data, all_boards))
 
     is_imported = isinstance(data.get("source"), dict) and bool(data["source"].get("type"))
@@ -235,6 +253,19 @@ def validate_board(
     errors.extend(_validate_image_paths(board_id, data))
 
     return errors
+
+
+def _validate_variant_vocabulary(board_id: str, data: dict) -> list[str]:
+    """Reject a variant outside the snapshot vocabulary; fail open on an empty snapshot."""
+    declared = (data.get("esphome") or {}).get("variant")
+    if not isinstance(declared, str) or not _ESP32_VARIANTS:
+        return []
+    if normalize_chip_variant(declared) not in _ESP32_VARIANTS:
+        return [
+            f"{board_id}: esphome.variant '{declared}' is not a known esp32 variant "
+            "(vocabulary: esp32_variants in platform_capabilities.index.json)"
+        ]
+    return []
 
 
 def _validate_pins_from(

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -261,15 +261,18 @@ def _validate_variant_vocabulary(board_id: str, data: dict) -> list[str]:
     if not isinstance(declared, str):
         return []
     canonical = normalize_chip_variant(declared)
-    if declared != canonical:
-        return [
-            f"{board_id}: esphome.variant '{declared}' must be the canonical lowercase "
-            f"spelling '{canonical}'"
-        ]
+    # Family membership first, decided on the folded value — a mixed-case
+    # non-esp32 typo gets the real diagnosis in one round, not after a
+    # lowercasing round-trip.
     if not canonical.startswith("esp32"):
         return [
             f"{board_id}: esphome.variant '{declared}' must be an esp32-family variant "
             "(e.g. esp32c3)"
+        ]
+    if declared != canonical:
+        return [
+            f"{board_id}: esphome.variant '{declared}' must be the canonical lowercase "
+            f"spelling '{canonical}'"
         ]
     if _ESP32_VARIANTS and canonical not in _ESP32_VARIANTS:
         return [

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -63,37 +63,31 @@ _FEATURED_CATEGORY_EXCEPTIONS = {"ethernet"}
 _WIFI_RADIO_COMPONENT_IDS = {"esp32_hosted"}
 
 
-def _load_esp32_no_wifi_variants() -> frozenset[str]:
+def _load_capabilities_snapshot() -> dict:
     """
-    Read ``esp32_no_wifi_variants`` from the capabilities snapshot.
+    Parse the capabilities snapshot; empty mapping when unreadable.
 
     Stdlib json rather than ``load_platform_capabilities_index`` — the
     pre-commit hook env has no ``orjson``, so the runtime loader isn't
-    importable here. An unreadable snapshot degrades to an empty set
+    importable here. An unreadable snapshot degrades to empty vocabularies
     (fail-open), matching the runtime loader's behaviour.
     """
     caps_path = DEFINITIONS_DIR / "platform_capabilities.index.json"
     try:
         caps = json.loads(caps_path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
-        return frozenset()
-    return frozenset(str(v).lower() for v in caps.get("esp32_no_wifi_variants", []))
+        return {}
+    return caps if isinstance(caps, dict) else {}
 
 
-_ESP32_NO_WIFI_VARIANTS = _load_esp32_no_wifi_variants()
+def _snapshot_variant_set(caps: dict, key: str) -> frozenset[str]:
+    """Return the normalized variant set for *key* in the parsed snapshot."""
+    return frozenset(normalize_chip_variant(str(v)) for v in caps.get(key, []))
 
 
-def _load_esp32_variants() -> frozenset[str]:
-    """Read the ``esp32_variants`` vocabulary from the snapshot; empty when unreadable."""
-    caps_path = DEFINITIONS_DIR / "platform_capabilities.index.json"
-    try:
-        caps = json.loads(caps_path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return frozenset()
-    return frozenset(normalize_chip_variant(str(v)) for v in caps.get("esp32_variants", []))
-
-
-_ESP32_VARIANTS = _load_esp32_variants()
+_CAPS_SNAPSHOT = _load_capabilities_snapshot()
+_ESP32_NO_WIFI_VARIANTS = _snapshot_variant_set(_CAPS_SNAPSHOT, "esp32_no_wifi_variants")
+_ESP32_VARIANTS = _snapshot_variant_set(_CAPS_SNAPSHOT, "esp32_variants")
 
 # Required shape for featured-component ids: lowercase letters, digits, and
 # underscores only, starting with a letter. Mirrors what ESPHome accepts
@@ -229,13 +223,14 @@ def validate_board(
                 seen_gpios.add(gpio)
                 pins_by_gpio[gpio] = pin
 
+    errors.extend(_validate_variant_vocabulary(board_id, data))
+
     # Imported boards (source.type set) carry only synthesized pin
     # entries with empty ``features`` — we don't have a per-chip pin-
     # feature DB to populate them. Skip the per-pin feature
     # intersection check for these; the rest of featured-component
     # validation (component_id present, fields key match,
     # GPIO declared) still runs.
-    errors.extend(_validate_variant_vocabulary(board_id, data))
     errors.extend(_validate_pins_from(board_id, data, all_boards))
 
     is_imported = isinstance(data.get("source"), dict) and bool(data["source"].get("type"))
@@ -529,7 +524,7 @@ def _validate_featured(  # noqa: C901
 def _validate_wifi_radio_claim(board_id: str, data: dict) -> list[str]:
     """Require a radio-provider default when a no-native-Wi-Fi variant claims wifi."""
     esphome_cfg = data.get("esphome") or {}
-    variant = str(esphome_cfg.get("variant") or "").lower()
+    variant = normalize_chip_variant(str(esphome_cfg.get("variant") or ""))
     if esphome_cfg.get("platform") != "esp32" or variant not in _ESP32_NO_WIFI_VARIANTS:
         return []
     connectivity = (data.get("hardware") or {}).get("connectivity") or []

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -84,11 +84,7 @@ _ESP32_NO_WIFI_VARIANTS = _load_esp32_no_wifi_variants()
 
 
 def _load_esp32_variants() -> frozenset[str]:
-    """
-    Read the ``esp32_variants`` vocabulary from the capabilities snapshot.
-
-    Same stdlib-json / fail-open shape as ``_load_esp32_no_wifi_variants``.
-    """
+    """Read the ``esp32_variants`` vocabulary from the snapshot; empty when unreadable."""
     caps_path = DEFINITIONS_DIR / "platform_capabilities.index.json"
     try:
         caps = json.loads(caps_path.read_text(encoding="utf-8"))
@@ -257,7 +253,8 @@ def validate_board(
 
 def _validate_variant_vocabulary(board_id: str, data: dict) -> list[str]:
     """Reject a variant outside the snapshot vocabulary; fail open on an empty snapshot."""
-    declared = (data.get("esphome") or {}).get("variant")
+    esphome_cfg = data.get("esphome")
+    declared = esphome_cfg.get("variant") if isinstance(esphome_cfg, dict) else None
     if not isinstance(declared, str) or not _ESP32_VARIANTS:
         return []
     if normalize_chip_variant(declared) not in _ESP32_VARIANTS:

--- a/tests/controllers/test_boards.py
+++ b/tests/controllers/test_boards.py
@@ -228,18 +228,14 @@ async def test_get_boards_filters_by_variant_case_insensitive(
 ) -> None:
     """``variant`` filter is case-insensitive — ``ESP32C3`` matches ``esp32c3``.
 
-    Frontend may send the upper-cased enum name (``ESP32C3``)
-    while the catalog stores the lowercase value (``esp32c3``).
-    The controller lowercases both sides so the dropdown's
-    selected value round-trips.
+    ``variant`` folds spellings — ``ESP32C3`` and ``ESP32-C3`` both
+    match the catalog's ``esp32c3``.
     """
     resp = await catalog.get_boards(variant="ESP32C3")
 
     assert resp.total == 2
     assert {b.id for b in resp.boards} == {"seeed-xiao-esp32c3", "generic-esp32c3"}
 
-    # Dashed spellings (copy-pasted from esphome docs / esptool output) fold
-    # through the shared normalizer instead of returning an empty page.
     dashed = await catalog.get_boards(variant="ESP32-C3")
     assert {b.id for b in dashed.boards} == {"seeed-xiao-esp32c3", "generic-esp32c3"}
 

--- a/tests/controllers/test_boards.py
+++ b/tests/controllers/test_boards.py
@@ -238,6 +238,11 @@ async def test_get_boards_filters_by_variant_case_insensitive(
     assert resp.total == 2
     assert {b.id for b in resp.boards} == {"seeed-xiao-esp32c3", "generic-esp32c3"}
 
+    # Dashed spellings (copy-pasted from esphome docs / esptool output) fold
+    # through the shared normalizer instead of returning an empty page.
+    dashed = await catalog.get_boards(variant="ESP32-C3")
+    assert {b.id for b in dashed.boards} == {"seeed-xiao-esp32c3", "generic-esp32c3"}
+
 
 async def test_get_boards_filters_by_tag(catalog: BoardCatalog) -> None:
     """``tag=display`` returns only the entry tagged for it."""

--- a/tests/controllers/test_boards.py
+++ b/tests/controllers/test_boards.py
@@ -223,14 +223,10 @@ async def test_get_boards_filters_by_platform(catalog: BoardCatalog) -> None:
     assert {b.id for b in resp.boards} == {"d1-mini", "generic-esp8266"}
 
 
-async def test_get_boards_filters_by_variant_case_insensitive(
+async def test_get_boards_filters_by_variant_spelling_fold(
     catalog: BoardCatalog,
 ) -> None:
-    """``variant`` filter is case-insensitive — ``ESP32C3`` matches ``esp32c3``.
-
-    ``variant`` folds spellings — ``ESP32C3`` and ``ESP32-C3`` both
-    match the catalog's ``esp32c3``.
-    """
+    """``variant`` folds spellings — ``ESP32C3`` / ``ESP32-C3`` both match ``esp32c3``."""
     resp = await catalog.get_boards(variant="ESP32C3")
 
     assert resp.total == 2

--- a/tests/test_validate_variant_vocabulary.py
+++ b/tests/test_validate_variant_vocabulary.py
@@ -47,6 +47,10 @@ def test_degraded_snapshot_fails_open_but_keeps_the_prefix_guard(
 def test_unknown_variant_rejected() -> None:
     errors = _validate_variant_vocabulary("b", {"esphome": {"variant": "esp32z9"}})
     assert errors and "not a known esp32 variant" in errors[0]
+    # An inner space folds to a value the vocabulary rejects; the gate must
+    # not propose that value as the fix.
+    errors = _validate_variant_vocabulary("b", {"esphome": {"variant": "ESP32 C3"}})
+    assert errors and "not a known esp32 variant" in errors[0]
 
 
 def test_absent_variant_passes() -> None:

--- a/tests/test_validate_variant_vocabulary.py
+++ b/tests/test_validate_variant_vocabulary.py
@@ -1,0 +1,28 @@
+"""Pins the manifest validator's snapshot-backed variant vocabulary gate."""
+
+from __future__ import annotations
+
+from script.validate_definitions import (  # type: ignore[import-not-found]
+    _ESP32_VARIANTS,
+    _validate_variant_vocabulary,
+)
+
+
+def test_snapshot_vocabulary_loaded() -> None:
+    assert "esp32c3" in _ESP32_VARIANTS
+    assert "esp32s31" in _ESP32_VARIANTS  # missing from the old hand schema enum
+
+
+def test_known_variant_passes_any_spelling() -> None:
+    assert _validate_variant_vocabulary("b", {"esphome": {"variant": "esp32c3"}}) == []
+    assert _validate_variant_vocabulary("b", {"esphome": {"variant": "ESP32-C3"}}) == []
+
+
+def test_unknown_variant_rejected() -> None:
+    errors = _validate_variant_vocabulary("b", {"esphome": {"variant": "esp32z9"}})
+    assert errors and "not a known esp32 variant" in errors[0]
+
+
+def test_absent_variant_passes() -> None:
+    assert _validate_variant_vocabulary("b", {"esphome": {}}) == []
+    assert _validate_variant_vocabulary("b", {}) == []

--- a/tests/test_validate_variant_vocabulary.py
+++ b/tests/test_validate_variant_vocabulary.py
@@ -27,6 +27,13 @@ def test_non_canonical_spelling_gets_the_friendly_error() -> None:
         assert errors and "canonical lowercase spelling 'esp32c3'" in errors[0]
 
 
+def test_non_esp32_prefix_gets_the_friendly_error() -> None:
+    # Snapshot-independent, so the field stays guarded even on a degraded index.
+    for value in ("c3", "esp8266"):
+        errors = _validate_variant_vocabulary("b", {"esphome": {"variant": value}})
+        assert errors and "must be an esp32-family variant" in errors[0]
+
+
 def test_unknown_variant_rejected() -> None:
     errors = _validate_variant_vocabulary("b", {"esphome": {"variant": "esp32z9"}})
     assert errors and "not a known esp32 variant" in errors[0]

--- a/tests/test_validate_variant_vocabulary.py
+++ b/tests/test_validate_variant_vocabulary.py
@@ -9,8 +9,9 @@ from script.validate_definitions import (  # type: ignore[import-not-found]
 
 
 def test_snapshot_vocabulary_loaded() -> None:
-    assert "esp32c3" in _ESP32_VARIANTS
-    assert "esp32s31" in _ESP32_VARIANTS  # missing from the old hand schema enum
+    assert _ESP32_VARIANTS, "committed snapshot should carry the vocabulary"
+    assert all(v.startswith("esp32") for v in _ESP32_VARIANTS)
+    assert "esp32" in _ESP32_VARIANTS  # the classic chip is always a member
 
 
 def test_known_variant_passes_any_spelling() -> None:

--- a/tests/test_validate_variant_vocabulary.py
+++ b/tests/test_validate_variant_vocabulary.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from script.validate_definitions import (  # type: ignore[import-not-found]
     _ESP32_VARIANTS,
     _validate_variant_vocabulary,
+    validate_board,
 )
 
 
@@ -14,9 +17,14 @@ def test_snapshot_vocabulary_loaded() -> None:
     assert "esp32" in _ESP32_VARIANTS  # the classic chip is always a member
 
 
-def test_known_variant_passes_any_spelling() -> None:
+def test_canonical_variant_passes() -> None:
     assert _validate_variant_vocabulary("b", {"esphome": {"variant": "esp32c3"}}) == []
-    assert _validate_variant_vocabulary("b", {"esphome": {"variant": "ESP32-C3"}}) == []
+
+
+def test_non_canonical_spelling_gets_the_friendly_error() -> None:
+    for spelling in ("ESP32-C3", "esp32_c3", "ESP32C3"):
+        errors = _validate_variant_vocabulary("b", {"esphome": {"variant": spelling}})
+        assert errors and "canonical lowercase spelling 'esp32c3'" in errors[0]
 
 
 def test_unknown_variant_rejected() -> None:
@@ -29,3 +37,15 @@ def test_absent_variant_passes() -> None:
     assert _validate_variant_vocabulary("b", {}) == []
     # Malformed shapes are the schema step's job; the manual check stays quiet.
     assert _validate_variant_vocabulary("b", {"esphome": ["not-a-dict"]}) == []
+
+
+def test_gate_is_wired_into_validate_board() -> None:
+    """The unknown-variant diagnostic surfaces through the public walk, not just the helper."""
+    data = {
+        "id": "fake-board",
+        "name": "Fake",
+        "description": "d",
+        "esphome": {"platform": "esp32", "board": "esp32dev", "variant": "esp32z9"},
+    }
+    errors = validate_board(Path("fake-board/manifest.yaml"), data=data, all_boards={})
+    assert any("not a known esp32 variant" in e for e in errors)

--- a/tests/test_validate_variant_vocabulary.py
+++ b/tests/test_validate_variant_vocabulary.py
@@ -26,3 +26,5 @@ def test_unknown_variant_rejected() -> None:
 def test_absent_variant_passes() -> None:
     assert _validate_variant_vocabulary("b", {"esphome": {}}) == []
     assert _validate_variant_vocabulary("b", {}) == []
+    # Malformed shapes are the schema step's job; the manual check stays quiet.
+    assert _validate_variant_vocabulary("b", {"esphome": ["not-a-dict"]}) == []

--- a/tests/test_validate_variant_vocabulary.py
+++ b/tests/test_validate_variant_vocabulary.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from script.validate_definitions import (  # type: ignore[import-not-found]
+import pytest
+
+import script.validate_definitions as vd  # type: ignore[import-not-found]
+from script.validate_definitions import (
     _ESP32_VARIANTS,
     _validate_variant_vocabulary,
     validate_board,
@@ -28,10 +31,17 @@ def test_non_canonical_spelling_gets_the_friendly_error() -> None:
 
 
 def test_non_esp32_prefix_gets_the_friendly_error() -> None:
-    # Snapshot-independent, so the field stays guarded even on a degraded index.
-    for value in ("c3", "esp8266"):
+    for value in ("c3", "esp8266", "ESP8266"):
         errors = _validate_variant_vocabulary("b", {"esphome": {"variant": value}})
         assert errors and "must be an esp32-family variant" in errors[0]
+
+
+def test_degraded_snapshot_fails_open_but_keeps_the_prefix_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(vd, "_ESP32_VARIANTS", frozenset())
+    assert vd._validate_variant_vocabulary("b", {"esphome": {"variant": "esp32z9"}}) == []
+    assert vd._validate_variant_vocabulary("b", {"esphome": {"variant": "esp8266"}})
 
 
 def test_unknown_variant_rejected() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #2314, closing the two pre-existing items its final review surfaced:

- **The last hand-maintained variant vocabulary is retired.** `board.schema.json` hard-coded the variant enum by hand and had already drifted (it lacked `esp32s31` / `esp32h4` / `esp32h21`, all present in the committed snapshot), which capped #2314's "new variant syncs with no code change" claim: a manifest declaring one would fail the pre-commit schema step with a raw JSON-schema error. The schema now constrains type only, and `_validate_variant_vocabulary` is the sole gate: family membership, then vocabulary (backed by the `esp32_variants` snapshot; stdlib-json read, fail-open-but-loud on a degraded index), then canonical spelling — every rejected shape gets a friendly first-run diagnostic and the vocabulary has exactly one source.
- **The variant filter folds spellings at all three call sites.** `_filter_by_variant` compared with a bare `.lower()`, so a client sending `ESP32-C3` got an empty page; both sides now go through the shared `normalize_chip_variant` (serving `boards/get_boards`, `find_by_pio_board`, and `find_by_platform_variant`), pinned by a dashed-spelling case in the controller tests.

Verified: full suite green, `validate_definitions.py` green on all 572 boards with the new gate, mypy clean, and the validator import chain re-checked under a blocked-dependency environment matching the pre-commit hook (vocabulary loads, 13 variants).

**Related issue or feature (if applicable):**

- Follow-up to #2314 / #2313 (final review, pre-existing items).

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
