### PR TITLE
Fold upstream variant spellings through the shared normalizer

### DIFF
--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -581,9 +581,9 @@ def _resolve_board_and_variant(
     # never compile, so treat them the same as a missing board.
     if board is not None and _is_placeholder_value(board):
         board = None
-    # Upstream pages sometimes write the variant in uppercase (``ESP32C3``)
-    # — normalize to match our enum.
-    variant = raw_variant.lower() if isinstance(raw_variant, str) else None
+    # Upstream pages sometimes write the variant in uppercase or with
+    # separators (``ESP32-C3``) — fold onto the catalog spelling.
+    variant = normalize_chip_variant(raw_variant) if isinstance(raw_variant, str) else None
     framework: str | None = None
     if isinstance(raw_framework, dict):
         ftype = raw_framework.get("type")

--- a/tests/test_sync_esphome_devices_variant.py
+++ b/tests/test_sync_esphome_devices_variant.py
@@ -39,6 +39,13 @@ def test_explicit_variant_wins_over_inference() -> None:
     assert variant == "esp32s3"
 
 
+@pytest.mark.parametrize("spelling", ["ESP32-C3", "esp32_c3", "ESP32C3"])
+def test_explicit_variant_folds_separator_spellings(spelling: str) -> None:
+    """Dashed / underscored / uppercase upstream spellings fold onto the catalog form."""
+    _, variant, _ = _resolve_board_and_variant("esp32", {"variant": spelling})
+    assert variant == "esp32c3"
+
+
 def test_variant_default_boards_exist_in_esphome() -> None:
     """Every ``_ESP32_VARIANT_DEFAULT_BOARD`` value is a real ESPHome board id.
 

--- a/tests/test_sync_esphome_devices_variant.py
+++ b/tests/test_sync_esphome_devices_variant.py
@@ -42,8 +42,11 @@ def test_explicit_variant_wins_over_inference() -> None:
 @pytest.mark.parametrize("spelling", ["ESP32-C3", "esp32_c3", "ESP32C3"])
 def test_explicit_variant_folds_separator_spellings(spelling: str) -> None:
     """Dashed / underscored / uppercase upstream spellings fold onto the catalog form."""
-    _, variant, _ = _resolve_board_and_variant("esp32", {"variant": spelling})
+    board, variant, _ = _resolve_board_and_variant("esp32", {"variant": spelling})
     assert variant == "esp32c3"
+    # The canonical form is the lookup key that unlocks the default board;
+    # the pre-fix "esp32-c3" missed the map entirely.
+    assert board == "esp32-c3-devkitm-1"
 
 
 def test_variant_default_boards_exist_in_esphome() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #2317's final review: `sync_esphome_devices.py` still folded upstream variant spellings with a bare `.lower()` under a comment citing "our enum" — a referent #2314 retired. The fold now goes through the shared `normalize_chip_variant`, so a dashed upstream spelling like `ESP32-C3` lands on the catalog form instead of `esp32-c3` — which previously missed both the default-board and connectivity maps, mislabeling radioless chips with the classic wifi+bluetooth fallback. The comment names the actual behavior. The board-id regex fold three lines below already produces canonical output and is untouched.

**Related issue or feature (if applicable):**

- Follow-up to #2317 / #2313 (stale comment + last bare `.lower()` variant fold).

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
