### PR TITLE
Give oversized remote-build bundles an actionable error and raise the cap

### DIFF
--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -389,20 +389,17 @@ def _local_device_display_for_job(
     return (device.name, device.friendly_name) if device is not None else ("", "")
 
 
-def _bundle_size_mb(bundle_len: int) -> str:
-    """Render a bundle byte count as a one-decimal ``MB`` string."""
-    return f"{bundle_len / (1024 * 1024):.1f} MB"
+def _bundle_size_mib(bundle_len: int) -> str:
+    """Render a bundle byte count as a one-decimal ``MiB`` string."""
+    return f"{bundle_len / (1024 * 1024):.1f} MiB"
 
 
 def _receiver_oversized_reason(bundle_len: int) -> str:
-    """
-    Actionable ``oversized`` remap for a receiver-rejected submit.
-
-    Names the bundle size but no limit: the rejecting receiver may be an
-    old version whose cap differs from ours, so updating it is a remedy.
-    """
+    """Actionable remap for a receiver ``oversized`` reject; names size, not a cap."""
+    # No cap number: the rejecting receiver may be an older version whose cap
+    # differs from ours, so "update the build server" is part of the remedy.
     return (
-        f"bundle too large ({_bundle_size_mb(bundle_len)}); update the remote "
+        f"bundle too large ({_bundle_size_mib(bundle_len)}); update the remote "
         "build server to the latest ESPHome, build this device locally, or "
         "reduce embedded assets (large images/fonts or many mdi: icons)"
     )
@@ -410,10 +407,10 @@ def _receiver_oversized_reason(bundle_len: int) -> str:
 
 def _local_oversized_reason(bundle_len: int) -> str:
     """Actionable failure reason for a bundle past the offloader's own cap."""
-    cap_mb = BUNDLE_MAX_TOTAL_BYTES // (1024 * 1024)
+    cap_mib = BUNDLE_MAX_TOTAL_BYTES // (1024 * 1024)
     return (
-        f"configuration bundle is {_bundle_size_mb(bundle_len)}, over the "
-        f"{cap_mb} MB remote-build limit; build this device locally, or reduce "
+        f"configuration bundle is {_bundle_size_mib(bundle_len)}, over the "
+        f"{cap_mib} MiB remote-build limit; build this device locally, or reduce "
         "embedded assets (large images/fonts or many mdi: icons)"
     )
 

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -31,13 +31,14 @@ import asyncio
 import logging
 import os
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal
 
 from esphome.const import __version__ as _offloader_esphome_version
 
 from ...helpers.api import CommandError
 from ...helpers.async_ import run_in_executor
 from ...helpers.config_bundle import BundleBuildError
+from ...helpers.peer_link_bundle import BUNDLE_MAX_TOTAL_BYTES
 from ...helpers.remote_artifacts_materialise import (
     MaterialiseError,
     materialise_remote_artifacts,
@@ -53,7 +54,6 @@ from ...models import (
     OffloaderJobStateChangedData,
     OffloaderPeerLinkClosedData,
     ResetBuildEnvAckFrameData,
-    ResetBuildEnvRejectReason,
     SubmitJobAckFrameData,
 )
 from ..remote_build.peer_link_client import (
@@ -344,6 +344,14 @@ async def _build_bundle_or_fail(
         return None
     if bundle_bytes is None:
         lifecycle.cancel_if_requested(controller, job)
+        return None
+    # Fail fast on a bundle past our own cap rather than streaming it only to
+    # be rejected. Uses the offloader's cap, so a newer receiver with a higher
+    # one could accept a bundle we reject here — the receiver's ack (translated
+    # in ``_submit_job_to_receiver``) is the real gate; this is an optimisation.
+    if len(bundle_bytes) > BUNDLE_MAX_TOTAL_BYTES:
+        _fail_locally(controller, job, reason=_local_oversized_reason(len(bundle_bytes)))
+        return None
     return bundle_bytes
 
 
@@ -381,6 +389,35 @@ def _local_device_display_for_job(
     return (device.name, device.friendly_name) if device is not None else ("", "")
 
 
+def _bundle_size_mb(bundle_len: int) -> str:
+    """Render a bundle byte count as a one-decimal ``MB`` string."""
+    return f"{bundle_len / (1024 * 1024):.1f} MB"
+
+
+def _receiver_oversized_reason(bundle_len: int) -> str:
+    """
+    Actionable ``oversized`` remap for a receiver-rejected submit.
+
+    Names the bundle size but no limit: the rejecting receiver may be an
+    old version whose cap differs from ours, so updating it is a remedy.
+    """
+    return (
+        f"bundle too large ({_bundle_size_mb(bundle_len)}); update the remote "
+        "build server to the latest ESPHome, build this device locally, or "
+        "reduce embedded assets (large images/fonts or many mdi: icons)"
+    )
+
+
+def _local_oversized_reason(bundle_len: int) -> str:
+    """Actionable failure reason for a bundle past the offloader's own cap."""
+    cap_mb = BUNDLE_MAX_TOTAL_BYTES // (1024 * 1024)
+    return (
+        f"configuration bundle is {_bundle_size_mb(bundle_len)}, over the "
+        f"{cap_mb} MB remote-build limit; build this device locally, or reduce "
+        "embedded assets (large images/fonts or many mdi: icons)"
+    )
+
+
 async def _submit_job_to_receiver(
     *,
     controller: FirmwareController,
@@ -412,7 +449,13 @@ async def _submit_job_to_receiver(
     except _PEER_LINK_ACKED_REQUEST_ERRORS as exc:
         _fail_locally(controller, job, reason=f"dispatch failed: {exc}")
         return False
-    return _check_ack(controller, job, ack, reject_label="receiver rejected job")
+    return _check_ack(
+        controller,
+        job,
+        ack,
+        reject_label="receiver rejected job",
+        reason_remap={"oversized": _receiver_oversized_reason(len(bundle_bytes))},
+    )
 
 
 async def _send_reset_to_receiver(
@@ -444,7 +487,7 @@ def _check_ack(
     ack: SubmitJobAckFrameData | ResetBuildEnvAckFrameData,
     *,
     reject_label: str,
-    reason_remap: Mapping[ResetBuildEnvRejectReason, str] | None = None,
+    reason_remap: Mapping[str, str] | None = None,
 ) -> bool:
     """
     Fail *job* locally on a rejected ack; True iff accepted.
@@ -455,7 +498,7 @@ def _check_ack(
         return True
     reason = ack.get("reason", "no reason given")
     if reason_remap:
-        reason = cast("Mapping[str, str]", reason_remap).get(reason, reason)
+        reason = reason_remap.get(reason, reason)
     _fail_locally(controller, job, reason=f"{reject_label}: {reason}")
     return False
 

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -38,7 +38,7 @@ from esphome.const import __version__ as _offloader_esphome_version
 from ...helpers.api import CommandError
 from ...helpers.async_ import run_in_executor
 from ...helpers.config_bundle import BundleBuildError
-from ...helpers.peer_link_bundle import BUNDLE_MAX_TOTAL_BYTES
+from ...helpers.peer_link_bundle import BUNDLE_MAX_TOTAL_BYTES, BundleAssemblerErrorCode
 from ...helpers.remote_artifacts_materialise import (
     MaterialiseError,
     materialise_remote_artifacts,
@@ -451,7 +451,9 @@ async def _submit_job_to_receiver(
         job,
         ack,
         reject_label="receiver rejected job",
-        reason_remap={"oversized": _receiver_oversized_reason(len(bundle_bytes))},
+        reason_remap={
+            BundleAssemblerErrorCode.OVERSIZED.value: _receiver_oversized_reason(len(bundle_bytes))
+        },
     )
 
 

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/_submit.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/_submit.py
@@ -221,7 +221,7 @@ async def _send_submit_job_frames(
     # Streamed via ``chunk_bundle``'s generator rather than
     # materialising the list — slicing produces a fresh ``bytes``
     # per chunk and holding all of them alive would roughly double
-    # peak memory (up to BUNDLE_MAX_TOTAL_BYTES = 4 MiB).
+    # peak memory (up to ``BUNDLE_MAX_TOTAL_BYTES``).
     for chunk_index, raw, is_last in chunk_bundle(bundle_bytes):
         chunk_frame: SubmitJobChunkFrameData = {
             "type": "submit_job_chunk",

--- a/esphome_device_builder/helpers/peer_link_bundle.py
+++ b/esphome_device_builder/helpers/peer_link_bundle.py
@@ -57,13 +57,16 @@ from typing import NoReturn
 # in half on a typical ESPHome bundle.
 BUNDLE_CHUNK_SIZE_BYTES = 32 * 1024
 
-# Hard cap on the assembled bundle. ESPHome bundles in the
-# wild are 5-50 KiB compressed; an exotic image-heavy include
-# tree can push to a few hundred KiB. 4 MiB is well above the
-# realistic ceiling but small enough that a misbehaving
-# offloader can't pin gigabytes of memory pretending to send
-# a bundle. May be revisited based on production bundle sizes.
-BUNDLE_MAX_TOTAL_BYTES = 4 * 1024 * 1024
+# Hard cap on the assembled bundle. Most ESPHome bundles are a
+# few KiB compressed, but image/font-heavy include trees (many
+# ``mdi:`` icons resized into embedded ``BINARY`` images) have
+# been observed near ~40 MiB in the wild. 128 MiB leaves generous
+# headroom while still bounding the RAM a misbehaving offloader
+# can pin (the receiver holds the whole assembled bundle in
+# memory). The receiver enforces this cap, so an offloader only
+# benefits once the build server is on a version that carries the
+# larger value.
+BUNDLE_MAX_TOTAL_BYTES = 128 * 1024 * 1024
 
 # Hard cap on the assembled firmware tarball. The materialise
 # pipeline ships the receiver's full build subtree (firmware

--- a/esphome_device_builder/helpers/peer_link_bundle.py
+++ b/esphome_device_builder/helpers/peer_link_bundle.py
@@ -4,7 +4,7 @@ Bundle chunking + reassembly helpers for the peer-link ``submit_job`` flow.
 The offloader produces a gzipped tarball via
 :class:`esphome.bundle.ConfigBundleCreator`; that's a single
 ``bytes`` payload that has to ride the peer-link's per-frame
-size cap (:data:`APP_FRAME_MAX_BYTES`, 32 KiB).
+size cap (:data:`APP_FRAME_MAX_BYTES`, 60 KiB).
 :func:`chunk_bundle` slices the bundle into the wire-format's
 base64 envelope shape; :class:`BundleAssembler` does the
 reverse on the receiver side, with structured rejection of
@@ -61,11 +61,12 @@ BUNDLE_CHUNK_SIZE_BYTES = 32 * 1024
 # few KiB compressed, but image/font-heavy include trees (many
 # ``mdi:`` icons resized into embedded ``BINARY`` images) have
 # been observed near ~40 MiB in the wild. 128 MiB leaves generous
-# headroom while still bounding the RAM a misbehaving offloader
-# can pin (the receiver holds the whole assembled bundle in
-# memory). The receiver enforces this cap, so an offloader only
-# benefits once the build server is on a version that carries the
-# larger value.
+# headroom while still bounding receiver RAM: peak is ~2x the cap
+# per in-flight session (``finalise`` copies the assembled
+# bytearray), and ``_inflight`` is keyed per paired offloader, so
+# concurrent submits multiply it. The receiver enforces this cap,
+# so an offloader only benefits once the build server is on a
+# version that carries the larger value.
 BUNDLE_MAX_TOTAL_BYTES = 128 * 1024 * 1024
 
 # Hard cap on the assembled firmware tarball. The materialise

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -674,6 +674,57 @@ async def test_remote_compile_rejected_ack_without_reason_uses_fallback(
     assert len(captured[EventType.JOB_FAILED]) == 1
 
 
+async def test_remote_compile_oversized_ack_translates_to_actionable_error(
+    firmware_controller_factory: FirmwareControllerFactory,
+    patch_bundle: AsyncMock,
+) -> None:
+    """An ``oversized`` rejection is remapped to guidance that also fits an old receiver."""
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = capture_local_events(controller)
+    patch_bundle.return_value = b"x" * (5 * 1024 * 1024)  # 5.0 MB
+    client = _make_client(accepted=False, reason="oversized")
+    _wire_remote_build(controller, client=client)
+    job = make_remote_job()
+
+    await remote_runner.run_remote_job(controller, job)
+
+    assert job.status == JobStatus.FAILED
+    assert job.error is not None
+    assert "bundle too large (5.0 MB)" in job.error
+    assert "update the remote build server" in job.error
+    assert "build this device locally" in job.error
+    assert "reduce embedded assets" in job.error
+    # Bare wire code translated away; no local cap number (receiver's cap is unknown).
+    assert "oversized" not in job.error
+    assert "128" not in job.error
+    assert len(captured[EventType.JOB_FAILED]) == 1
+
+
+async def test_remote_compile_oversized_bundle_fails_fast_before_dispatch(
+    firmware_controller_factory: FirmwareControllerFactory,
+    patch_bundle: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bundle past the offloader's own cap fails locally without looking up a client."""
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = capture_local_events(controller)
+    monkeypatch.setattr(remote_runner, "BUNDLE_MAX_TOTAL_BYTES", 4 * 1024 * 1024)
+    patch_bundle.return_value = b"x" * (5 * 1024 * 1024)  # 5.0 MB > patched 4 MiB cap
+    client = _make_client()
+    remote_build, _ = _wire_remote_build(controller, client=client)
+    job = make_remote_job()
+
+    await remote_runner.run_remote_job(controller, job)
+
+    assert job.status == JobStatus.FAILED
+    assert job.error is not None
+    assert "configuration bundle is 5.0 MB" in job.error
+    assert "over the 4 MB remote-build limit" in job.error
+    remote_build._lookup_open_peer_link_client.assert_not_called()
+    client.submit_job.assert_not_awaited()
+    assert len(captured[EventType.JOB_FAILED]) == 1
+
+
 async def test_remote_compile_receiver_unreachable_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -681,7 +681,7 @@ async def test_remote_compile_oversized_ack_translates_to_actionable_error(
     """An ``oversized`` rejection is remapped to guidance that also fits an old receiver."""
     controller = firmware_controller_factory(with_terminate=True)
     captured = capture_local_events(controller)
-    patch_bundle.return_value = b"x" * (5 * 1024 * 1024)  # 5.0 MB
+    patch_bundle.return_value = b"x" * (5 * 1024 * 1024)  # 5.0 MiB
     client = _make_client(accepted=False, reason="oversized")
     _wire_remote_build(controller, client=client)
     job = make_remote_job()
@@ -690,7 +690,7 @@ async def test_remote_compile_oversized_ack_translates_to_actionable_error(
 
     assert job.status == JobStatus.FAILED
     assert job.error is not None
-    assert "bundle too large (5.0 MB)" in job.error
+    assert "bundle too large (5.0 MiB)" in job.error
     assert "update the remote build server" in job.error
     assert "build this device locally" in job.error
     assert "reduce embedded assets" in job.error
@@ -709,7 +709,7 @@ async def test_remote_compile_oversized_bundle_fails_fast_before_dispatch(
     controller = firmware_controller_factory(with_terminate=True)
     captured = capture_local_events(controller)
     monkeypatch.setattr(remote_runner, "BUNDLE_MAX_TOTAL_BYTES", 4 * 1024 * 1024)
-    patch_bundle.return_value = b"x" * (5 * 1024 * 1024)  # 5.0 MB > patched 4 MiB cap
+    patch_bundle.return_value = b"x" * (5 * 1024 * 1024)  # 5.0 MiB > patched 4 MiB cap
     client = _make_client()
     remote_build, _ = _wire_remote_build(controller, client=client)
     job = make_remote_job()
@@ -718,8 +718,8 @@ async def test_remote_compile_oversized_bundle_fails_fast_before_dispatch(
 
     assert job.status == JobStatus.FAILED
     assert job.error is not None
-    assert "configuration bundle is 5.0 MB" in job.error
-    assert "over the 4 MB remote-build limit" in job.error
+    assert "configuration bundle is 5.0 MiB" in job.error
+    assert "over the 4 MiB remote-build limit" in job.error
     remote_build._lookup_open_peer_link_client.assert_not_called()
     client.submit_job.assert_not_awaited()
     assert len(captured[EventType.JOB_FAILED]) == 1

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -39,6 +39,7 @@ from esphome_device_builder.controllers.remote_build.peer_link_client import (
 )
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.helpers.config_bundle import BundleBuildError
+from esphome_device_builder.helpers.peer_link_bundle import BundleAssemblerErrorCode
 from esphome_device_builder.helpers.remote_artifacts_materialise import MaterialiseError
 from esphome_device_builder.models import (
     ErrorCode,
@@ -682,7 +683,7 @@ async def test_remote_compile_oversized_ack_translates_to_actionable_error(
     controller = firmware_controller_factory(with_terminate=True)
     captured = capture_local_events(controller)
     patch_bundle.return_value = b"x" * (5 * 1024 * 1024)  # 5.0 MiB
-    client = _make_client(accepted=False, reason="oversized")
+    client = _make_client(accepted=False, reason=BundleAssemblerErrorCode.OVERSIZED.value)
     _wire_remote_build(controller, client=client)
     job = make_remote_job()
 

--- a/tests/test_peer_link_bundle.py
+++ b/tests/test_peer_link_bundle.py
@@ -157,7 +157,7 @@ def test_assembler_rejects_non_positive_num_chunks() -> None:
 
 
 def test_bundle_max_total_bytes_is_128_mib() -> None:
-    """Pin the cap: image/font-heavy bundles near ~40 MiB must fit under it."""
+    """Pin the intended cap value."""
     assert BUNDLE_MAX_TOTAL_BYTES == 128 * 1024 * 1024
 
 

--- a/tests/test_peer_link_bundle.py
+++ b/tests/test_peer_link_bundle.py
@@ -156,6 +156,11 @@ def test_assembler_rejects_non_positive_num_chunks() -> None:
     assert excinfo.value.code is BundleAssemblerErrorCode.CHUNK_COUNT_MISMATCH
 
 
+def test_bundle_max_total_bytes_is_128_mib() -> None:
+    """Pin the cap: image/font-heavy bundles near ~40 MiB must fit under it."""
+    assert BUNDLE_MAX_TOTAL_BYTES == 128 * 1024 * 1024
+
+
 def test_assembler_rejects_oversized_announcement() -> None:
     """A header announcing more than :data:`BUNDLE_MAX_TOTAL_BYTES` is rejected."""
     with pytest.raises(BundleAssemblerError) as excinfo:

--- a/tests/test_peer_link_bundle.py
+++ b/tests/test_peer_link_bundle.py
@@ -156,9 +156,9 @@ def test_assembler_rejects_non_positive_num_chunks() -> None:
     assert excinfo.value.code is BundleAssemblerErrorCode.CHUNK_COUNT_MISMATCH
 
 
-def test_bundle_max_total_bytes_is_128_mib() -> None:
-    """Pin the intended cap value."""
-    assert BUNDLE_MAX_TOTAL_BYTES == 128 * 1024 * 1024
+def test_assembler_accepts_realistic_image_heavy_announcement() -> None:
+    """A ~40 MiB header (the image-heavy real-world size) constructs, not rejected."""
+    BundleAssembler(total_bytes=40 * 1024 * 1024, num_chunks=1, sha256_hex="0" * 64)
 
 
 def test_assembler_rejects_oversized_announcement() -> None:

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -32,7 +32,10 @@ from esphome_device_builder.controllers.remote_build.submit_job import (
     _coerce_display_field,
     _validate_configuration_filename,
 )
-from esphome_device_builder.helpers.peer_link_bundle import BUNDLE_CHUNK_SIZE_BYTES
+from esphome_device_builder.helpers.peer_link_bundle import (
+    BUNDLE_CHUNK_SIZE_BYTES,
+    BUNDLE_MAX_TOTAL_BYTES,
+)
 from esphome_device_builder.helpers.remote_build_layout import RemoteBuildPath
 from esphome_device_builder.models import (
     JobType,
@@ -399,7 +402,7 @@ async def test_submit_job_oversized_bundle_rejected(tmp_path: Path) -> None:
         job_id="job-1",
         configuration_filename="kitchen.yaml",
         target="compile",
-        total_bundle_bytes=10 * 1024 * 1024,  # 10 MiB > 4 MiB cap
+        total_bundle_bytes=BUNDLE_MAX_TOTAL_BYTES + 1,
         num_chunks=1,
         bundle_sha256="0" * 64,
     )


### PR DESCRIPTION
# What does this implement/fix?

A remote build of an image-heavy config (many `mdi:` icons resized into embedded `BINARY` images) builds a large bundle; if it exceeds the receiver's `BUNDLE_MAX_TOTAL_BYTES` cap the receiver rejects it as `oversized`, and the dashboard only surfaced that bare wire code with no size or guidance (the user in the linked issue saw a ~39.5 MB bundle rejected with nothing actionable).

Two changes:

- Translate the receiver's `oversized` ack into an actionable message that names the bundle size and points at updating the build server, building locally, or trimming embedded assets. The message carries no cap number on purpose; the rejecting receiver may be an older version still enforcing a smaller cap, so it must not assert our local limit. Also add a sender-side pre-check against the offloader's own cap so a too-large bundle fails fast without streaming it first.
- Raise `BUNDLE_MAX_TOTAL_BYTES` from 4 MiB to 128 MiB. The old rationale ("a few hundred KiB is the realistic ceiling") was wrong for image/font-heavy include trees; the receiver still holds the assembled bundle in RAM, so the cap stays bounded. The bump only takes effect once the build server updates, which is why the error message is the primary fix for users on older receivers.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17837

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
