### PR TITLE
Give the bundle-timeout test margin over child interpreter startup

### DIFF
--- a/tests/test_config_bundle.py
+++ b/tests/test_config_bundle.py
@@ -189,7 +189,11 @@ async def test_build_yaml_bundle_timeout_raises_bundle_build_error(
         tmp_path,
         "print('EARLY DIAGNOSTIC', flush=True)\ntime.sleep(30)\n",
     )
-    monkeypatch.setattr(config_bundle, "_BUNDLE_BUILD_TIMEOUT_SECONDS", 0.5)
+    # The timeout clock starts after spawn but still covers the child's Python
+    # interpreter cold-start + first print; on a loaded CI runner that can take
+    # most of a second, so keep comfortable margin or the timeout fires with an
+    # empty buffer and the pre-timeout-output assertion below flakes.
+    monkeypatch.setattr(config_bundle, "_BUNDLE_BUILD_TIMEOUT_SECONDS", 5.0)
 
     with pytest.raises(BundleBuildError, match="timed out") as exc_info:
         await build_yaml_bundle(yaml_path)


### PR DESCRIPTION
# What does this implement/fix?

Fixes the flaky `test_build_yaml_bundle_timeout_raises_bundle_build_error`, seen failing on `macos-latest` / Python 3.14:

```
>       assert "EARLY DIAGNOSTIC" in exc_info.value.output
E       AssertionError: assert 'EARLY DIAGNOSTIC' in ''
E        +  where '' = BundleBuildError('esphome bundle timed out after 0s').output
```

The test pins that a timed-out bundle build preserves its pre-timeout output. `run_subprocess_capture` starts its `asyncio.timeout` clock after `create_subprocess_exec` returns, but that window still covers the fake esphome's Python interpreter cold-start plus its first `print`. On a loaded runner that can eat most of a second, so the 0.5s test timeout fired before `EARLY DIAGNOSTIC` was captured, leaving an empty buffer and failing the assertion. It's a spawn/startup-latency vs fixed-timeout race, not a product bug (the code preserves output correctly; the test's budget was too tight).

Raise the test-only `_BUNDLE_BUILD_TIMEOUT_SECONDS` override from 0.5s to 5s so it comfortably clears child interpreter startup, and add a comment so it isn't re-tightened.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2322

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
