### PR TITLE
Raise the import-bundle cap to match the remote-build bundle cap

### DIFF
--- a/esphome_device_builder/controllers/devices/mutations_import_bundle.py
+++ b/esphome_device_builder/controllers/devices/mutations_import_bundle.py
@@ -35,7 +35,10 @@ _LOGGER = logging.getLogger(__name__)
 
 # Compressed-upload cap. The 500 MB decompressed cap is enforced inside
 # esphome.bundle.extract_bundle; this guards the base64 payload itself.
-_MAX_BUNDLE_UPLOAD_BYTES = 64 * 1024 * 1024
+# Kept >= the peer-link remote-build bundle cap (BUNDLE_MAX_TOTAL_BYTES) so a
+# config that can be remote-built (image/font-heavy trees run tens of MiB) can
+# also be imported here; a test pins the ordering.
+_MAX_BUNDLE_UPLOAD_BYTES = 128 * 1024 * 1024
 
 
 async def import_bundle(

--- a/esphome_device_builder/controllers/devices/mutations_import_bundle.py
+++ b/esphome_device_builder/controllers/devices/mutations_import_bundle.py
@@ -21,6 +21,7 @@ from esphome.core import EsphomeError
 
 from ...constants import SECRETS_FILENAME
 from ...helpers.api import CommandError
+from ...helpers.bundle_limits import BUNDLE_MAX_TOTAL_BYTES
 from ...helpers.device_yaml import configuration_stem, parse_platform_from_yaml
 from ...helpers.secrets_state import merge_secrets_file
 from ...helpers.yaml import ESPHOME_FRIENDLY_NAME_PATH, read_yaml_scalar, write_user_yaml
@@ -34,11 +35,9 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 # Compressed-upload cap. The 500 MB decompressed cap is enforced inside
-# esphome.bundle.extract_bundle; this guards the base64 payload itself.
-# Kept >= the peer-link remote-build bundle cap (BUNDLE_MAX_TOTAL_BYTES) so a
-# config that can be remote-built (image/font-heavy trees run tens of MiB) can
-# also be imported here; a test pins the ordering.
-_MAX_BUNDLE_UPLOAD_BYTES = 128 * 1024 * 1024
+# esphome.bundle.extract_bundle; this guards the base64 payload itself. Shares
+# BUNDLE_MAX_TOTAL_BYTES so a config that can be remote-built can also be
+# imported (both materialise the whole compressed bundle in memory).
 
 
 async def import_bundle(
@@ -217,19 +216,19 @@ def _stage_bundle(file_content_b64: str, config_dir: Path, overwrite: list[str] 
 
 def _decode_bundle(file_content_b64: str) -> bytes:
     """Base64-decode the upload; reject non-base64, oversize, or non-gzip."""
-    limit_mb = _MAX_BUNDLE_UPLOAD_BYTES // (1024 * 1024)
+    limit_mb = BUNDLE_MAX_TOTAL_BYTES // (1024 * 1024)
     oversize = CommandError(
         ErrorCode.INVALID_ARGS, f"Bundle exceeds the {limit_mb} MB upload limit."
     )
     # base64 inflates ~4/3, so reject an obviously-oversize payload by its
     # encoded length before materialising the decoded bytes in memory.
-    if len(file_content_b64) > (_MAX_BUNDLE_UPLOAD_BYTES // 3 + 1) * 4:
+    if len(file_content_b64) > (BUNDLE_MAX_TOTAL_BYTES // 3 + 1) * 4:
         raise oversize
     try:
         raw = base64.b64decode(file_content_b64, validate=True)
     except (binascii.Error, ValueError) as exc:
         raise CommandError(ErrorCode.INVALID_ARGS, "Bundle upload isn't valid base64.") from exc
-    if len(raw) > _MAX_BUNDLE_UPLOAD_BYTES:
+    if len(raw) > BUNDLE_MAX_TOTAL_BYTES:
         raise oversize
     if raw[:2] != b"\x1f\x8b":
         raise CommandError(

--- a/esphome_device_builder/controllers/devices/mutations_import_bundle.py
+++ b/esphome_device_builder/controllers/devices/mutations_import_bundle.py
@@ -34,11 +34,6 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-# Compressed-upload cap. The 500 MB decompressed cap is enforced inside
-# esphome.bundle.extract_bundle; this guards the base64 payload itself. Shares
-# BUNDLE_MAX_TOTAL_BYTES so a config that can be remote-built can also be
-# imported (both materialise the whole compressed bundle in memory).
-
 
 async def import_bundle(
     controller: DevicesController,
@@ -216,6 +211,8 @@ def _stage_bundle(file_content_b64: str, config_dir: Path, overwrite: list[str] 
 
 def _decode_bundle(file_content_b64: str) -> bytes:
     """Base64-decode the upload; reject non-base64, oversize, or non-gzip."""
+    # Caps the compressed payload only; extract_bundle enforces the 500 MB
+    # decompressed cap.
     limit_mb = BUNDLE_MAX_TOTAL_BYTES // (1024 * 1024)
     oversize = CommandError(
         ErrorCode.INVALID_ARGS, f"Bundle exceeds the {limit_mb} MB upload limit."

--- a/esphome_device_builder/helpers/bundle_limits.py
+++ b/esphome_device_builder/helpers/bundle_limits.py
@@ -1,0 +1,21 @@
+"""Shared size cap for esphome config bundles.
+
+One number, referenced by every path that materialises a whole config
+bundle in memory, so the limits can't drift apart: the peer-link
+remote-build receiver (assembles the uploaded bundle) and the UI
+``import_bundle`` path (decodes the uploaded bundle). Because they share
+this constant, a config small enough to remote-build is always small
+enough to import, and vice versa.
+"""
+
+from __future__ import annotations
+
+# Hard cap on a compressed esphome config bundle (the gzipped ``.tar.gz``
+# ``ConfigBundleCreator`` emits). Most bundles are a few KiB, but
+# image/font-heavy include trees (many ``mdi:`` icons resized into embedded
+# ``BINARY`` images) have been observed near ~40 MiB in the wild. 128 MiB
+# leaves generous headroom while still bounding the RAM a single in-flight
+# bundle can pin (peak is ~2x the cap while a copy is held). A peer-link
+# receiver enforces this cap, so an offloader only benefits once the build
+# server runs a version carrying the larger value.
+BUNDLE_MAX_TOTAL_BYTES = 128 * 1024 * 1024

--- a/esphome_device_builder/helpers/peer_link_bundle.py
+++ b/esphome_device_builder/helpers/peer_link_bundle.py
@@ -45,6 +45,10 @@ from collections.abc import Iterator
 from enum import StrEnum
 from typing import NoReturn
 
+# Re-exported: the bundle-assembly cap lives in the neutral ``bundle_limits``
+# module so the UI import path can share it without importing peer-link code.
+from .bundle_limits import BUNDLE_MAX_TOTAL_BYTES
+
 # Raw bytes per chunk before b64 encoding. Sized so the
 # resulting JSON frame fits comfortably under
 # :data:`APP_FRAME_MAX_BYTES` (60 KiB after 5c-1's bump):
@@ -56,18 +60,6 @@ from typing import NoReturn
 # fixed per-frame overhead (Noise AEAD tag + JSON envelope)
 # in half on a typical ESPHome bundle.
 BUNDLE_CHUNK_SIZE_BYTES = 32 * 1024
-
-# Hard cap on the assembled bundle. Most ESPHome bundles are a
-# few KiB compressed, but image/font-heavy include trees (many
-# ``mdi:`` icons resized into embedded ``BINARY`` images) have
-# been observed near ~40 MiB in the wild. 128 MiB leaves generous
-# headroom while still bounding receiver RAM: peak is ~2x the cap
-# per in-flight session (``finalise`` copies the assembled
-# bytearray), and ``_inflight`` is keyed per paired offloader, so
-# concurrent submits multiply it. The receiver enforces this cap,
-# so an offloader only benefits once the build server is on a
-# version that carries the larger value.
-BUNDLE_MAX_TOTAL_BYTES = 128 * 1024 * 1024
 
 # Hard cap on the assembled firmware tarball. The materialise
 # pipeline ships the receiver's full build subtree (firmware

--- a/tests/controllers/devices/test_import_bundle.py
+++ b/tests/controllers/devices/test_import_bundle.py
@@ -20,9 +20,16 @@ from esphome_device_builder.controllers.config import (
 )
 from esphome_device_builder.controllers.devices import mutations_import_bundle
 from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.helpers.peer_link_bundle import BUNDLE_MAX_TOTAL_BYTES
 from esphome_device_builder.models import ErrorCode
 
 from .conftest import MakeControllerFactory
+
+
+def test_upload_cap_not_below_remote_build_bundle_cap() -> None:
+    """A config small enough to remote-build stays importable (import cap >= peer-link cap)."""
+    assert mutations_import_bundle._MAX_BUNDLE_UPLOAD_BYTES >= BUNDLE_MAX_TOTAL_BYTES
+
 
 MAIN_YAML = (
     "esphome:\n"

--- a/tests/controllers/devices/test_import_bundle.py
+++ b/tests/controllers/devices/test_import_bundle.py
@@ -20,16 +20,9 @@ from esphome_device_builder.controllers.config import (
 )
 from esphome_device_builder.controllers.devices import mutations_import_bundle
 from esphome_device_builder.helpers.api import CommandError
-from esphome_device_builder.helpers.peer_link_bundle import BUNDLE_MAX_TOTAL_BYTES
 from esphome_device_builder.models import ErrorCode
 
 from .conftest import MakeControllerFactory
-
-
-def test_upload_cap_not_below_remote_build_bundle_cap() -> None:
-    """A config small enough to remote-build stays importable (import cap >= peer-link cap)."""
-    assert mutations_import_bundle._MAX_BUNDLE_UPLOAD_BYTES >= BUNDLE_MAX_TOTAL_BYTES
-
 
 MAIN_YAML = (
     "esphome:\n"
@@ -291,7 +284,7 @@ def test_decode_bundle_rejects_oversize_before_decode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An over-long base64 payload is rejected by encoded length, pre-decode."""
-    monkeypatch.setattr(mutations_import_bundle, "_MAX_BUNDLE_UPLOAD_BYTES", 16)
+    monkeypatch.setattr(mutations_import_bundle, "BUNDLE_MAX_TOTAL_BYTES", 16)
 
     with pytest.raises(CommandError) as excinfo:
         mutations_import_bundle._decode_bundle("A" * 200)
@@ -398,7 +391,7 @@ def test_decode_bundle_rejects_oversize_after_decode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A payload that clears the encoded pre-check but decodes over the cap is rejected."""
-    monkeypatch.setattr(mutations_import_bundle, "_MAX_BUNDLE_UPLOAD_BYTES", 16)
+    monkeypatch.setattr(mutations_import_bundle, "BUNDLE_MAX_TOTAL_BYTES", 16)
     # 24 base64 chars equal the encoded-length ceiling but decode to 18 bytes.
     with pytest.raises(CommandError) as excinfo:
         mutations_import_bundle._decode_bundle("A" * 24)


### PR DESCRIPTION
# What does this implement/fix?

Addresses one of the follow-ups from #2321: the UI bundle-import cap (`_MAX_BUNDLE_UPLOAD_BYTES`) was 64 MiB, but #2320 raised the peer-link remote-build bundle cap (`BUNDLE_MAX_TOTAL_BYTES`) to 128 MiB. Both cap the compressed `esphome.bundle` gzipped tarball, so a config that can be remote-built (image/font-heavy include trees run tens of MiB) could be refused by the UI import path with "Bundle exceeds the 64 MB upload limit."

Raise the import cap to 128 MiB so a remote-buildable config stays importable, and add a test pinning `_MAX_BUNDLE_UPLOAD_BYTES >= BUNDLE_MAX_TOTAL_BYTES` so the two limits can't silently drift apart again. The base64 pre-check still rejects an oversize payload by its encoded length before decoding, and the 500 MB decompressed cap inside `esphome.bundle.extract_bundle` is unchanged.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder/issues/2321

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
