### PR TITLE
Free the assembler's working buffer once finalise memoises the result

### DIFF
--- a/esphome_device_builder/helpers/peer_link_bundle.py
+++ b/esphome_device_builder/helpers/peer_link_bundle.py
@@ -263,6 +263,10 @@ class BundleAssembler:
         self._buf = bytearray()
         self._next_index = 0
         self._closed = False
+        # Set once on the first successful ``finalise``; the working buffer is
+        # released then, so peak isn't doubled through the caller's downstream
+        # use (disk write / extract), only during the one-shot copy itself.
+        self._result: bytes | None = None
 
     def feed(self, chunk_index: int, raw: bytes, *, is_last: bool) -> None:
         """Accept one chunk. Raises :class:`BundleAssemblerError` on mismatch."""
@@ -305,8 +309,12 @@ class BundleAssembler:
         assembler hasn't seen its announced last chunk, or
         :attr:`BundleAssemblerErrorCode.HASH_MISMATCH` if the
         SHA-256 of the assembled bytes doesn't match the
-        offloader's announced digest.
+        offloader's announced digest. Memoised: the result is
+        cached and the working buffer freed on the first call,
+        so a second call returns the same bytes without re-work.
         """
+        if self._result is not None:
+            return self._result
         if not self._closed:
             _fail(
                 _Code.UNDERSIZED,
@@ -324,4 +332,8 @@ class BundleAssembler:
                 _Code.HASH_MISMATCH,
                 f"assembled bundle sha256 {actual} != announced {self._sha256_hex}",
             )
-        return bytes(self._buf)
+        self._result = bytes(self._buf)
+        # Drop the working buffer: the cached result is the single retained copy
+        # (the caller holds the same object), so peak returns to 1x immediately.
+        self._buf = bytearray()
+        return self._result

--- a/esphome_device_builder/helpers/peer_link_bundle.py
+++ b/esphome_device_builder/helpers/peer_link_bundle.py
@@ -263,9 +263,8 @@ class BundleAssembler:
         self._buf = bytearray()
         self._next_index = 0
         self._closed = False
-        # Set once on the first successful ``finalise``; the working buffer is
-        # released then, so peak isn't doubled through the caller's downstream
-        # use (disk write / extract), only during the one-shot copy itself.
+        # Set on the first successful ``finalise``; the working buffer is
+        # released at the same point.
         self._result: bytes | None = None
 
     def feed(self, chunk_index: int, raw: bytes, *, is_last: bool) -> None:
@@ -333,7 +332,6 @@ class BundleAssembler:
                 f"assembled bundle sha256 {actual} != announced {self._sha256_hex}",
             )
         self._result = bytes(self._buf)
-        # Drop the working buffer: the cached result is the single retained copy
-        # (the caller holds the same object), so peak returns to 1x immediately.
+        # Release the working buffer once the result is cached.
         self._buf = bytearray()
         return self._result

--- a/tests/test_peer_link_bundle.py
+++ b/tests/test_peer_link_bundle.py
@@ -298,10 +298,12 @@ def test_assembler_finalise_frees_buffer_and_shares_result() -> None:
     data = b"hash me once"
     asm = BundleAssembler(**_header(data, chunk_size=len(data)))
     asm.feed(0, data, is_last=True)
+    buf_before = asm._buf
     first = asm.finalise()
-    # Working buffer released, so peak isn't held at 2x through downstream use...
-    assert asm._buf == bytearray()
-    # ...and the second call hands back the same object, not a fresh copy.
+    # The working buffer is dropped, not cleared in place: the identity change
+    # proves the allocation is released rather than emptied while still held.
+    assert asm._buf is not buf_before
+    # The second call hands back the same object, not a fresh copy.
     assert asm.finalise() is first
 
 

--- a/tests/test_peer_link_bundle.py
+++ b/tests/test_peer_link_bundle.py
@@ -278,22 +278,31 @@ def test_assembler_finalise_hash_mismatch() -> None:
 def test_assembler_finalise_is_idempotent() -> None:
     """A second ``finalise()`` on a closed assembler returns the same bytes.
 
-    The closed-flag guard lives in :meth:`feed`, not
-    :meth:`finalise`; ``finalise`` re-validates the
-    aggregate (length + hash) against the stored header and
-    returns the buffer regardless of whether it's been called
-    before. Pinned to document the actual contract: callers
-    don't *need* to memoise the return value, and re-calling
-    is a no-op rather than an error. If a future change adds
-    a single-use guard (raising ``POST_COMPLETION`` on the
-    second call), this test should be flipped to assert that
-    raise instead, alongside the production change.
+    ``finalise`` memoises: the first call validates the
+    aggregate (length + hash), caches the result, and frees
+    the working buffer; a second call returns the cached bytes
+    without re-validating. Pinned to document the contract:
+    re-calling is a no-op rather than an error, and callers
+    share the single cached object rather than each getting a
+    fresh copy.
     """
     data = b"hash me"
     asm = BundleAssembler(**_header(data, chunk_size=len(data)))
     asm.feed(0, data, is_last=True)
     assert asm.finalise() == data
     assert asm.finalise() == data
+
+
+def test_assembler_finalise_frees_buffer_and_shares_result() -> None:
+    """Finalise releases the working buffer and hands back the single cached object."""
+    data = b"hash me once"
+    asm = BundleAssembler(**_header(data, chunk_size=len(data)))
+    asm.feed(0, data, is_last=True)
+    first = asm.finalise()
+    # Working buffer released, so peak isn't held at 2x through downstream use...
+    assert asm._buf == bytearray()
+    # ...and the second call hands back the same object, not a fresh copy.
+    assert asm.finalise() is first
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

Addresses one of the follow-ups from #2321: `BundleAssembler.finalise` returned `bytes(self._buf)` — a fresh copy — while the assembler kept the working `bytearray` alive on `self._buf`. So peak RAM stayed at ~2x the bundle size (working buffer + returned copy) for the whole duration the caller used the result downstream (the receiver's tarball write + `prepare_bundle_for_compile` extract, or the offloader's artifacts materialise). At the 128 MiB bundle cap that's a ~256 MiB sustained transient on the receiver.

Cache the result and drop the working buffer on the first `finalise`: the caller and the assembler then hold the same single object, so sustained peak returns to 1x. The one-shot `bytes(self._buf)` copy still spikes momentarily (unavoidable without a zero-copy hand-off, which would ripple the `bytes` return type through `DownloadArtifactsResult.tarball`), but the sustained doubling through the slow downstream phase is gone.

Idempotency is preserved and now explicit: a second `finalise` returns the cached object without re-validating. A new test pins both the buffer release and the shared-object contract.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder/issues/2321

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
