### PR TITLE
Scale the submit-ack window with the bundle size

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link_client/_submit.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/_submit.py
@@ -35,11 +35,21 @@ if TYPE_CHECKING:
     from .client import PeerLinkClient
 
 
-# 60s headroom for the receiver's worst-case bundle-finalise +
-# extract + queue-acquire path on a constrained SoC, without
-# pinning the offloader's submit handler forever if the wire
-# goes silent.
+# Flat floor for every ack: headroom for the receiver's queue-acquire
+# path on a constrained SoC, without pinning the offloader's submit
+# handler forever if the wire goes silent.
 _SUBMIT_JOB_ACK_TIMEOUT_SECONDS = 60.0
+
+# The receiver writes and extracts the whole bundle before acking a
+# submit, so that ack's window grows with bundle size — sized for
+# SD-card-backed SoCs sustaining only a few MiB/s (a max 128 MiB
+# bundle adds ~64s on top of the floor).
+_ACK_BYTES_PER_SECOND = 2 * 1024 * 1024
+
+
+def _submit_ack_timeout(bundle_size: int) -> float:
+    """Return the submit-ack window: the flat floor plus size-proportional headroom."""
+    return _SUBMIT_JOB_ACK_TIMEOUT_SECONDS + bundle_size / _ACK_BYTES_PER_SECOND
 
 
 async def submit_job(
@@ -80,7 +90,13 @@ async def submit_job(
             device_friendly_name=device_friendly_name,
             target_esphome_version=target_esphome_version,
         )
-        return await _await_ack(client, ack_fut, job_id=job_id, label="submit_job")
+        return await _await_ack(
+            client,
+            ack_fut,
+            job_id=job_id,
+            label="submit_job",
+            timeout_seconds=_submit_ack_timeout(len(bundle_bytes)),
+        )
     finally:
         client._submit_job_acks.pop(job_id, None)
 
@@ -243,13 +259,15 @@ async def _await_ack[AckT](
     *,
     job_id: str,
     label: str,
+    timeout_seconds: float | None = None,
 ) -> AckT:
     """Park on *ack_fut* with a bounded timeout; raise structured errors."""
+    timeout = timeout_seconds if timeout_seconds is not None else _SUBMIT_JOB_ACK_TIMEOUT_SECONDS
     try:
-        return await asyncio.wait_for(ack_fut, timeout=_SUBMIT_JOB_ACK_TIMEOUT_SECONDS)
+        return await asyncio.wait_for(ack_fut, timeout=timeout)
     except TimeoutError as exc:
         raise SubmitJobTimeoutError(
             f"{label}: no ack from {client._hostname}:{client._port} "
-            f"after {_SUBMIT_JOB_ACK_TIMEOUT_SECONDS:.0f}s "
+            f"after {timeout:.0f}s "
             f"(job_id={job_id!r})"
         ) from exc

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/_submit.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/_submit.py
@@ -44,12 +44,12 @@ _SUBMIT_JOB_ACK_TIMEOUT_SECONDS = 60.0
 # submit, so that ack's window grows with bundle size — sized for
 # SD-card-backed SoCs sustaining only a few MiB/s (a max 128 MiB
 # bundle adds ~64s on top of the floor).
-_ACK_BYTES_PER_SECOND = 2 * 1024 * 1024
+_SUBMIT_ACK_BYTES_PER_SECOND = 2 * 1024 * 1024
 
 
 def _submit_ack_timeout(bundle_size: int) -> float:
     """Return the submit-ack window: the flat floor plus size-proportional headroom."""
-    return _SUBMIT_JOB_ACK_TIMEOUT_SECONDS + bundle_size / _ACK_BYTES_PER_SECOND
+    return _SUBMIT_JOB_ACK_TIMEOUT_SECONDS + bundle_size / _SUBMIT_ACK_BYTES_PER_SECOND
 
 
 async def submit_job(

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -5031,6 +5031,13 @@ async def test_submit_job_sends_header_chunks_and_returns_ack(
     assert [c["is_last"] for c in chunks] == [False, False, True]
 
 
+def test_submit_ack_timeout_scales_with_bundle_size() -> None:
+    """The floor covers small bundles; a max-size bundle earns write+extract headroom."""
+    timeout = remote_build_peer_link_client._submit._submit_ack_timeout
+    assert timeout(0) == 60.0
+    assert timeout(128 * 1024 * 1024) == pytest.approx(124.0)
+
+
 async def test_submit_job_times_out_when_no_ack_arrives(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -87,6 +87,7 @@ from esphome_device_builder.controllers.remote_build.peer_link_lifecycle import 
 )
 from esphome_device_builder.helpers import json as _json
 from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.helpers.bundle_limits import BUNDLE_MAX_TOTAL_BYTES
 from esphome_device_builder.helpers.event_bus import EventBus
 from esphome_device_builder.helpers.peer_link_bundle import (
     chunk_bundle,
@@ -5035,7 +5036,9 @@ def test_submit_ack_timeout_scales_with_bundle_size() -> None:
     """The floor covers small bundles; a max-size bundle earns write+extract headroom."""
     timeout = remote_build_peer_link_client._submit._submit_ack_timeout
     assert timeout(0) == 60.0
-    assert timeout(128 * 1024 * 1024) == pytest.approx(124.0)
+    assert timeout(BUNDLE_MAX_TOTAL_BYTES) == pytest.approx(124.0), (
+        "bundle cap changed — re-derive the max-size ack window"
+    )
 
 
 async def test_submit_job_times_out_when_no_ack_arrives(


### PR DESCRIPTION
# What does this implement/fix?

The last open item of #2321 (items 1 and 3 landed in #2325 and #2324): the flat 60s submit-ack timeout now spans the receiver writing and extracting a bundle of up to 128 MiB, which gets tight on slow SD-backed storage.

The submit ack's window is now size-proportional: the 60s floor (unchanged for every other ack, and still the silence bound when the wire goes dead) plus write+extract headroom at a slow-SD 2 MiB/s — a max-size 128 MiB bundle gets ~124s, the realistic ~40 MB case ~80s, and a small bundle is unchanged. `_await_ack` takes an optional per-call window (the timeout error reports the actual value); `reset_build_env` keeps the flat floor. Pinned by a scaling test; the existing monkeypatched timeout test is unaffected because the floor constant still anchors the window.

**Related issue or feature (if applicable):**

- fixes #2321 (final item; #2324 / #2325 covered the other two)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
