### PR TITLE
Ack a submit_job before the receiver's write and extract hop

### DIFF
--- a/esphome_device_builder/controllers/remote_build/submit_job.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job.py
@@ -75,6 +75,7 @@ from ...helpers.remote_build_layout import REMOTE_BUILDS_SUBDIR, RemoteBuildPath
 from ...helpers.version_compat import coerce_pep440_version
 from ...models import (
     PAIRING_VERSION_MAX_LEN,
+    JobStateChangedFrameData,
     JobType,
     SubmitJobAckFrameData,
     SubmitJobChunkFrameData,
@@ -520,12 +521,18 @@ class SubmitJobReceiver:
     async def _finalise_and_queue(
         self, *, session: PeerLinkSession, pending: _PendingSubmit
     ) -> None:
-        """Pull the in-flight entry, finalise the bundle, extract + queue + ack.
+        """Pull the in-flight entry, finalise the bundle, ack, then extract + queue.
 
         Split out from :meth:`handle_submit_job_chunk` so the
         final-chunk path is read-on-its-own rather than tail-of-
         a-flat-cascade. Drops the in-flight entry first so any
         later failure can't leave a closed assembler dangling.
+
+        The ack is sent as soon as the bundle is assembled +
+        hash-validated, *before* the write + extract — that disk
+        hop can span the offloader's ack timeout on a slow disk,
+        so a post-ack failure is reported as a terminal
+        ``failed`` job-state frame instead.
         """
         self._inflight.pop(session.dashboard_id, None)
         try:
@@ -533,16 +540,14 @@ class SubmitJobReceiver:
         except BundleAssemblerError as exc:
             await self._reject_assembler(session, pending=pending, exc=exc)
             return
+        # Ack acceptance now (bundle received + hash-validated). Echo the
+        # offloader's ``job_id`` back so it can match the response; the
+        # receiver-side id rides :attr:`FirmwareJob.remote_peer` in the fan-out.
+        await self._send_ack_accepted(session, job_id=pending.job_id)
         try:
             await self._extract_and_queue(session=session, pending=pending, bundle_bytes=assembled)
         except _SubmitJobRejectionError as exc:
-            await self._reject(session, job_id=pending.job_id, reason=exc.reason)
-            return
-        # Echo the offloader's ``job_id`` back on the ack so the
-        # offloader can match the response to its submit; the
-        # receiver-side job id is threaded into the fan-out
-        # via :attr:`FirmwareJob.remote_peer` instead.
-        await self._send_ack_accepted(session, job_id=pending.job_id)
+            await self._report_post_ack_failure(session, pending=pending, reason=exc.reason)
 
     async def _reject_assembler(
         self,
@@ -579,10 +584,10 @@ class SubmitJobReceiver:
         """Write the tarball, extract it, queue a :class:`FirmwareJob`.
 
         Raises :class:`_SubmitJobRejectionError` on any failure
-        with a :class:`SubmitJobAckFrameData.reason`-shaped code
-        so the caller can convert into an ack reject without a
-        terminate (extract / queue failures are receiver-side
-        problems, not wire-level misbehaviour). The receiver-side
+        with a reason code; the caller has already acked
+        acceptance, so it converts the raise into a terminal
+        ``failed`` job-state frame (extract / queue failures are
+        receiver-side problems, not wire-level misbehaviour). The receiver-side
         job id is captured in :attr:`FirmwareJob.remote_peer` for
         the fan-out path; the offloader echoes against its
         own submit-tagged ``job_id`` rather than the receiver's
@@ -706,6 +711,30 @@ class SubmitJobReceiver:
         payload = SubmitJobAckFrameData(type="submit_job_ack", job_id=job_id, accepted=True)
         await session.send_app_frame(dict(payload))
 
+    async def _report_post_ack_failure(
+        self, session: PeerLinkSession, *, pending: _PendingSubmit, reason: str
+    ) -> None:
+        """Surface a post-ack extract/queue failure as a terminal ``failed`` frame.
+
+        The offloader already got ``accepted`` and is waiting on job-state
+        events, but no :class:`FirmwareJob` reached the queue so the
+        :class:`JobFanout` won't emit one; send the ``failed`` frame here,
+        keyed on the offloader's ``job_id``.
+        """
+        _LOGGER.warning(
+            "submit_job from %s: job %s failed after accept (%s)",
+            session.dashboard_id,
+            pending.job_id,
+            reason,
+        )
+        frame = JobStateChangedFrameData(
+            type="job_state_changed",
+            job_id=pending.job_id,
+            status="failed",
+            error_message=f"receiver could not process the bundle: {reason}",
+        )
+        await session.send_app_frame(dict(frame))
+
     async def _reject(
         self,
         session: PeerLinkSession,
@@ -724,11 +753,12 @@ class SubmitJobReceiver:
         *reason*, then optionally fires
         ``terminate{malformed_frame}`` on the session when the
         failure was wire-level misbehaviour (out-of-order
-        chunks, base64 garbage). Receiver-side problems
-        (``extract_failed`` / ``queue_rejected`` / header
-        validation that didn't reach an assembler) leave the
-        session intact so the offloader can retry on a fresh
-        submit.
+        chunks, base64 garbage). Header-validation reasons and
+        recoverable assembler codes leave the session intact so
+        the offloader can retry on a fresh submit. (Post-ack
+        extract / queue failures don't reach here — they surface
+        as a ``failed`` job-state frame via
+        :meth:`_report_post_ack_failure`.)
 
         Failures from ``send_app_frame`` are logged at the
         channel layer and don't propagate here — the session

--- a/esphome_device_builder/controllers/remote_build/submit_job.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job.py
@@ -521,18 +521,13 @@ class SubmitJobReceiver:
     async def _finalise_and_queue(
         self, *, session: PeerLinkSession, pending: _PendingSubmit
     ) -> None:
-        """Pull the in-flight entry, finalise the bundle, ack, then extract + queue.
+        """
+        Pull the in-flight entry, finalise the bundle, ack, then extract + queue.
 
-        Split out from :meth:`handle_submit_job_chunk` so the
-        final-chunk path is read-on-its-own rather than tail-of-
-        a-flat-cascade. Drops the in-flight entry first so any
-        later failure can't leave a closed assembler dangling.
-
-        The ack is sent as soon as the bundle is assembled +
-        hash-validated, *before* the write + extract — that disk
-        hop can span the offloader's ack timeout on a slow disk,
-        so a post-ack failure is reported as a terminal
-        ``failed`` job-state frame instead.
+        The ack precedes the write + extract (which can span the offloader's
+        ack timeout on a slow disk); a post-ack failure is reported as a
+        terminal ``failed`` job-state frame. Drops the in-flight entry first
+        so a later failure can't leave a closed assembler dangling.
         """
         self._inflight.pop(session.dashboard_id, None)
         try:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -586,13 +586,7 @@ def wire_receiver_firmware_recorder(instances: PairedInstances) -> list[Firmware
 async def wait_for_receiver_jobs(
     instances: PairedInstances, count: int, *, timeout: float = 5.0
 ) -> None:
-    """Wait until the receiver has extracted + enqueued *count* jobs.
-
-    The receiver acks acceptance before the extract + queue hop, so a
-    submitted job reaches the recorder only after the ack returns to the
-    offloader; tests inspecting receiver state must wait rather than read
-    synchronously.
-    """
+    """Wait until the receiver has extracted + enqueued *count* jobs (the ack precedes both)."""
     firmware = instances.receiver._db.firmware
     await wait_until(
         lambda: firmware._enqueue.await_count >= count,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -81,6 +81,7 @@ from ..conftest import (
     _CapturedEvents,
     capture_events,
     make_remote_build_controller,
+    wait_until,
     wire_firmware_remote_peer_api_mocks,
 )
 
@@ -469,6 +470,7 @@ async def run_offload_compile_round_trip(
         ),
     )
     assert ack["accepted"] is True
+    await wait_for_receiver_jobs(instances, 1)
     receiver_job = created_jobs[0]
 
     remote_build_path = parse_from_configuration(receiver_job.configuration)
@@ -579,6 +581,25 @@ def wire_receiver_firmware_recorder(instances: PairedInstances) -> list[Firmware
         return_value=QueueStatus(idle=True, running=False, queue_depth=0)
     )
     return created_jobs
+
+
+async def wait_for_receiver_jobs(
+    instances: PairedInstances, count: int, *, timeout: float = 5.0
+) -> None:
+    """Wait until the receiver has extracted + enqueued *count* jobs.
+
+    The receiver acks acceptance before the extract + queue hop, so a
+    submitted job reaches the recorder only after the ack returns to the
+    offloader; tests inspecting receiver state must wait rather than read
+    synchronously.
+    """
+    firmware = instances.receiver._db.firmware
+    await wait_until(
+        lambda: firmware._enqueue.await_count >= count,
+        timeout,
+        f"receiver to enqueue {count} job(s)",
+        interval=0.01,
+    )
 
 
 async def drive_remote_job_to_completed(

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -98,6 +98,7 @@ from .conftest import (
     PairedInstances,
     drive_remote_job_to_completed,
     make_real_bundle,
+    wait_for_receiver_jobs,
     wire_receiver_firmware_recorder,
 )
 
@@ -407,6 +408,7 @@ async def test_remote_install_submit_then_lifecycle_then_download_on_one_session
         bundle_bytes=bundle_bytes,
     )
     assert ack["accepted"] is True
+    await wait_for_receiver_jobs(paired_instances, 1)
     assert len(created_jobs) == 1
     receiver_job = created_jobs[0]
     assert receiver_job.remote_peer == paired_instances.offloader_dashboard_id
@@ -523,6 +525,7 @@ async def test_remote_compile_materialises_for_local_firmware_download(
         bundle_bytes=make_real_bundle(),
     )
     assert ack["accepted"] is True
+    await wait_for_receiver_jobs(paired_instances, 1)
     receiver_job = created_jobs[0]
     images = _write_build_artifacts_on_disk(tmp_path, configuration=receiver_job.configuration)
 
@@ -630,6 +633,7 @@ async def test_windows_receiver_tarball_materialises_for_local_firmware_download
         bundle_bytes=make_real_bundle(),
     )
     assert ack["accepted"] is True
+    await wait_for_receiver_jobs(paired_instances, 1)
     receiver_job = created_jobs[0]
     images = _write_build_artifacts_on_disk(tmp_path, configuration=receiver_job.configuration)
 
@@ -811,6 +815,7 @@ async def test_back_to_back_successful_jobs_keep_scheduler_routing_remote(
             bundle_bytes=bundle_bytes,
         )
         assert ack["accepted"] is True
+        await wait_for_receiver_jobs(paired_instances, cycle + 1)
         assert receiver_jobs[-1].remote_job_id == job_tag
 
         _drive_receiver_lifecycle(
@@ -869,6 +874,7 @@ async def test_failed_first_job_still_routes_remote_on_second_install(
         bundle_bytes=bundle_bytes,
     )
     assert ack["accepted"] is True
+    await wait_for_receiver_jobs(paired_instances, 1)
     _drive_receiver_lifecycle(paired_instances, receiver_jobs[-1], terminal=EventType.JOB_FAILED)
     await _wait_for_offloader_idle(paired_instances, queue_status_events)
     snapshot = paired_instances.offloader.build_scheduler_snapshot()
@@ -882,6 +888,7 @@ async def test_failed_first_job_still_routes_remote_on_second_install(
         bundle_bytes=bundle_bytes,
     )
     assert ack["accepted"] is True
+    await wait_for_receiver_jobs(paired_instances, 2)
     _drive_receiver_lifecycle(paired_instances, receiver_jobs[-1], terminal=EventType.JOB_COMPLETED)
     await _wait_for_offloader_idle(paired_instances, queue_status_events)
     snapshot = paired_instances.offloader.build_scheduler_snapshot()
@@ -930,6 +937,7 @@ async def test_remote_clean_round_trip_lands_clean_job_and_fans_state_back(
     # Receiver accepted the clean target on the same wire path
     # compile uses.
     assert ack["accepted"] is True
+    await wait_for_receiver_jobs(paired_instances, 1)
     assert len(receiver_jobs) == 1
     receiver_job = receiver_jobs[0]
     assert receiver_job.job_type is JobType.CLEAN

--- a/tests/e2e/test_submit_job.py
+++ b/tests/e2e/test_submit_job.py
@@ -63,7 +63,7 @@ from esphome_device_builder.models import (
 )
 
 from ..conftest import capture_events
-from .conftest import PairedInstances, make_real_bundle
+from .conftest import PairedInstances, make_real_bundle, wait_for_receiver_jobs
 
 
 def _wire_receiver_firmware_recorder(instances: PairedInstances) -> list[FirmwareJob]:
@@ -161,6 +161,8 @@ async def test_submit_job_round_trip_extracts_real_bundle_and_queues_job(
     assert ack["job_id"] == "off-job-1"
     assert "reason" not in ack
 
+    # The receiver extracts + creates + enqueues after acking now; wait for it.
+    await wait_for_receiver_jobs(paired_instances, 1)
     assert len(created_jobs) == 1
     job = created_jobs[0]
     assert job.remote_peer == paired_instances.offloader_dashboard_id
@@ -213,6 +215,7 @@ async def test_submit_job_round_trip_with_relative_receiver_config_dir(
     assert ack["job_id"] == "off-job-678"
     assert "reason" not in ack
 
+    await wait_for_receiver_jobs(instances, 1)
     assert len(created_jobs) == 1
     job = created_jobs[0]
     assert job.remote_peer == instances.offloader_dashboard_id
@@ -273,6 +276,7 @@ async def test_submit_job_round_trip_then_fanout_to_offloader_bus(
         bundle_bytes=make_real_bundle(),
     )
     assert ack["accepted"] is True
+    await wait_for_receiver_jobs(paired_instances, 1)
     assert len(created_jobs) == 1
     job = created_jobs[0]
 
@@ -341,6 +345,7 @@ async def test_submit_job_round_trip_carries_display_strings_to_receiver_job(
     )
 
     assert ack["accepted"] is True
+    await wait_for_receiver_jobs(paired_instances, 1)
     assert len(created_jobs) == 1
     job = created_jobs[0]
 

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -1013,8 +1013,7 @@ async def test_submit_job_path_traversal_dashboard_id_caught_at_extract(
         await receiver.handle_submit_job_chunk(session, chunk)
 
     frames = _sent_frames(session)
-    # Accepted up front; the escape is caught during extract and reported as a
-    # terminal failed frame (defence-in-depth still refuses to write outside root).
+    # The escape is caught post-ack, during extract.
     assert frames[0]["type"] == "submit_job_ack"
     assert frames[0]["accepted"] is True
     assert frames[-1]["type"] == "job_state_changed"

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -125,6 +125,11 @@ def _ack_payload(session: Any) -> dict[str, Any]:
     return payload
 
 
+def _sent_frames(session: Any) -> list[dict[str, Any]]:
+    """Every ``send_app_frame`` payload off *session*, in send order."""
+    return [call.args[0] for call in session.send_app_frame.call_args_list]
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -1007,16 +1012,48 @@ async def test_submit_job_path_traversal_dashboard_id_caught_at_extract(
     for chunk in _frame_chunks("job-1", bundle):
         await receiver.handle_submit_job_chunk(session, chunk)
 
-    payload = _ack_payload(session)
-    assert payload["accepted"] is False
-    assert payload["reason"] == "invalid_header"
+    frames = _sent_frames(session)
+    # Accepted up front; the escape is caught during extract and reported as a
+    # terminal failed frame (defence-in-depth still refuses to write outside root).
+    assert frames[0]["type"] == "submit_job_ack"
+    assert frames[0]["accepted"] is True
+    assert frames[-1]["type"] == "job_state_changed"
+    assert frames[-1]["status"] == "failed"
+    assert "invalid_header" in frames[-1]["error_message"]
     firmware._enqueue.assert_not_called()
 
 
-async def test_submit_job_enqueue_failure_rejects(
+async def test_submit_job_acks_before_extract(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A failure inside ``_enqueue`` rejects ``queue_rejected``; session stays."""
+    """The accepted ack is sent before the (slow) write + extract hop runs."""
+    firmware = _make_firmware_controller()
+    receiver = _make_receiver(tmp_path, firmware)
+    session = _make_session()
+    bundle = b"hello"
+    ack_before_extract = False
+
+    def _prepare(bundle_path: Path, target_dir: Path) -> Path:
+        nonlocal ack_before_extract
+        ack_before_extract = any(
+            call.args[0].get("type") == "submit_job_ack" and call.args[0].get("accepted")
+            for call in session.send_app_frame.call_args_list
+        )
+        return target_dir / "kitchen.yaml"
+
+    monkeypatch.setattr("esphome.bundle.prepare_bundle_for_compile", _prepare)
+
+    await receiver.handle_submit_job(session, _header(bundle=bundle))
+    for chunk in _frame_chunks("job-1", bundle):
+        await receiver.handle_submit_job_chunk(session, chunk)
+
+    assert ack_before_extract
+
+
+async def test_submit_job_enqueue_failure_reports_failed_after_ack(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A ``_enqueue`` failure acks accepted, then reports a terminal ``failed`` frame."""
     firmware = _make_firmware_controller()
     firmware._enqueue = AsyncMock(side_effect=RuntimeError("queue full"))
     receiver = _make_receiver(tmp_path, firmware)
@@ -1032,16 +1069,22 @@ async def test_submit_job_enqueue_failure_rejects(
     for chunk in _frame_chunks("job-1", bundle):
         await receiver.handle_submit_job_chunk(session, chunk)
 
-    payload = _ack_payload(session)
-    assert payload["accepted"] is False
-    assert payload["reason"] == "queue_rejected"
+    frames = _sent_frames(session)
+    # Accepted up front, before the extract/queue hop...
+    assert frames[0]["type"] == "submit_job_ack"
+    assert frames[0]["accepted"] is True
+    # ...then a terminal failed frame carrying the reason; the wire stays good.
+    assert frames[-1]["type"] == "job_state_changed"
+    assert frames[-1]["status"] == "failed"
+    assert frames[-1]["job_id"] == "job-1"
+    assert "queue_rejected" in frames[-1]["error_message"]
     session.terminate.assert_not_called()
 
 
-async def test_submit_job_extract_failure_rejects_without_terminate(
+async def test_submit_job_extract_failure_reports_failed_without_terminate(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A failure inside ``prepare_bundle_for_compile`` rejects ``extract_failed``; session stays."""
+    """A ``prepare_bundle_for_compile`` failure acks accepted, then reports ``failed``."""
     firmware = _make_firmware_controller()
     receiver = _make_receiver(tmp_path, firmware)
     session = _make_session()
@@ -1059,12 +1102,14 @@ async def test_submit_job_extract_failure_rejects_without_terminate(
     for chunk in _frame_chunks("job-1", bundle):
         await receiver.handle_submit_job_chunk(session, chunk)
 
-    payload = _ack_payload(session)
-    assert payload["accepted"] is False
-    assert payload["reason"] == "extract_failed"
-    # Receiver-side problem; the wire is still good.
+    frames = _sent_frames(session)
+    assert frames[0]["type"] == "submit_job_ack"
+    assert frames[0]["accepted"] is True
+    assert frames[-1]["type"] == "job_state_changed"
+    assert frames[-1]["status"] == "failed"
+    assert "extract_failed" in frames[-1]["error_message"]
+    # Receiver-side problem; the wire is still good and no job was queued.
     session.terminate.assert_not_called()
-    # No job was queued.
     firmware._enqueue.assert_not_called()
 
 


### PR DESCRIPTION
# What does this implement/fix?

Addresses the ack-timeout follow-up from #2321. The remote-build receiver acked a `submit_job` only *after* writing the assembled bundle to disk and running `prepare_bundle_for_compile` (the extract). On a slow disk that write+extract hop can span the offloader's fixed 60s ack timeout (`_SUBMIT_JOB_ACK_TIMEOUT_SECONDS`), so the offloader raises `SubmitJobTimeoutError` and fails the job locally while the receiver keeps going — an orphan build. Large bundles are rare, but slow disks/systems are not.

Ack acceptance as soon as the bundle is assembled and hash-validated (an in-memory step), *before* the write+extract. A post-ack extract/queue failure is reported as a terminal `failed` `job_state_changed` frame instead of an ack reject: the offloader attaches its `OFFLOADER_JOB_STATE_CHANGED` listener before it submits, so the frame is caught by the same `_await_terminal` path that consumes a normal build failure. Pre-ack failures (assembler / header validation, which are wire-level) keep their existing ack-reject + optional terminate path — the seam is drawn at "has the ack been sent yet?", which matches the offloader's two wait-states (blocked on the ack future, vs. awaiting job-state frames).

Because the receiver now creates/queues the job asynchronously after the ack, the e2e harness waits for it via a shared `wait_for_receiver_jobs` helper (delegating to the existing `wait_until`).

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder/issues/2321

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
