### PR TITLE
Split controllers/remote_build/submit_job.py into a package

### DIFF
--- a/esphome_device_builder/controllers/remote_build/submit_job/__init__.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job/__init__.py
@@ -1,0 +1,5 @@
+"""Receiver-side ``submit_job`` flow for the remote-build peer-link."""
+
+from .controller import SubmitJobReceiver
+
+__all__ = ["SubmitJobReceiver"]

--- a/esphome_device_builder/controllers/remote_build/submit_job/_extract_window.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job/_extract_window.py
@@ -7,7 +7,7 @@ from collections.abc import Coroutine
 from functools import partial
 from typing import Any
 
-from ...helpers.async_ import drain_tasks, log_task_exit
+from ....helpers.async_ import drain_tasks, log_task_exit
 
 _Key = tuple[str, str]
 

--- a/esphome_device_builder/controllers/remote_build/submit_job/_post_ack.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job/_post_ack.py
@@ -1,0 +1,383 @@
+"""Post-ack extract, queue, and terminal-frame reporting for ``submit_job``."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Literal
+
+from ....helpers.api import CommandError
+from ....helpers.async_ import run_in_executor
+from ....helpers.lazy_module import async_import_module
+from ....helpers.paths import PathEscapeError, resolve_under_root
+from ....helpers.remote_build_layout import REMOTE_BUILDS_SUBDIR, RemoteBuildPath
+from ....models import ErrorCode, JobStateChangedFrameData
+from .const import (
+    REASON_EXTRACT_FAILED,
+    REASON_INVALID_HEADER,
+    REASON_QUEUE_REJECTED,
+    TARGET_TO_JOB_TYPE,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from ....models import FirmwareJob
+    from ..peer_link import PeerLinkSession
+    from ._extract_window import ExtractWindow
+    from .controller import SubmitJobReceiver, _PendingSubmit
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def run_post_ack_extract(
+    receiver: SubmitJobReceiver,
+    *,
+    session: PeerLinkSession,
+    pending: _PendingSubmit,
+    bundle_bytes: bytes,
+) -> None:
+    """Extract + queue one accepted bundle, serialized per peer."""
+    extracts = receiver._extracts
+    key = (session.dashboard_id, pending.job_id)
+    try:
+        _raise_if_cancel_flagged(extracts, key)
+        # The (FIFO) lock keeps per-peer enqueue order and keeps a
+        # same-configuration resubmit off a target dir mid-extract.
+        async with extracts.lock(session.dashboard_id):
+            job = await receiver._extract_and_queue(
+                session=session, pending=pending, bundle_bytes=bundle_bytes, cancel_key=key
+            )
+    except _SubmitJobRejectionError as exc:
+        await report_post_ack_failure(session, pending=pending, reason=exc.reason)
+    except _ExtractCancelledError:
+        await send_job_cancelled(session, job_id=pending.job_id)
+    except Exception:
+        # The offloader already got ``accepted`` and is waiting on
+        # job-state events; an unreported crash strands it forever.
+        _LOGGER.exception(
+            "submit_job from %s: unexpected extract failure for job %s",
+            session.dashboard_id,
+            pending.job_id,
+        )
+        await report_post_ack_failure(session, pending=pending, reason=REASON_EXTRACT_FAILED)
+    else:
+        # No await between the enqueue and this block (the lock's exit
+        # doesn't yield), so dropping the index here leaves no
+        # unroutable window. The job is live in the queue; nothing
+        # past this point may report ``failed``.
+        extracts.handoff(key)
+        if extracts.consume(key):
+            await cancel_queued_job(receiver, session, pending=pending, job=job)
+    finally:
+        extracts.consume(key)
+
+
+async def extract_and_queue(
+    receiver: SubmitJobReceiver,
+    *,
+    session: PeerLinkSession,
+    pending: _PendingSubmit,
+    bundle_bytes: bytes,
+    cancel_key: tuple[str, str],
+) -> FirmwareJob:
+    """Write the tarball, extract it, queue and return the :class:`FirmwareJob`.
+
+    Raises :class:`_SubmitJobRejectionError` on any failure
+    with a reason code; the caller has already acked
+    acceptance, so it converts the raise into a terminal
+    ``failed`` job-state frame (extract / queue failures are
+    receiver-side problems, not wire-level misbehaviour). The receiver-side
+    job id is captured in :attr:`FirmwareJob.remote_peer` for
+    the fan-out path; the offloader echoes against its
+    own submit-tagged ``job_id`` rather than the receiver's
+    local one.
+
+    Disk I/O hops to the executor:
+    ``prepare_bundle_for_compile`` walks the tar, validates
+    members, writes to disk; bundling that into one
+    ``run_in_executor`` keeps the receiver's WS dispatch
+    coroutine non-blocking through a multi-MB write.
+    """
+    _raise_if_cancel_flagged(receiver._extracts, cancel_key)
+    # Subtree (extract target) + bundle (sibling tarball)
+    # flow through the layout helper so the writer here and
+    # the 6c sweeper read one source of truth for the
+    # on-disk shape. Sibling-not-child is load-bearing:
+    # upstream prepare_bundle_for_compile wipes target_dir
+    # before extract_bundle reads from bundle_path, so a
+    # bundle inside target_dir would be deleted mid-flow
+    # (PR #552).
+    key = RemoteBuildPath(dashboard_id=session.dashboard_id, device_name=pending.device_stem)
+    target_dir = key.subtree(receiver._config_dir)
+    bundle_path = key.bundle(receiver._config_dir)
+    remote_builds_root = receiver._config_dir / REMOTE_BUILDS_SUBDIR
+
+    # ``esphome.bundle`` is ~1 MB of upstream code; load it through
+    # the shared lazy-import executor so the receiver's idle resident
+    # set stays lean until a peer-link offload actually lands. Pass
+    # the resolved callable into the executor so the worker doesn't
+    # rely on a preload-ordering invariant in this caller.
+    bundle = await async_import_module("esphome.bundle")
+    prepare = bundle.prepare_bundle_for_compile
+    try:
+        configuration = await run_in_executor(
+            _validate_write_extract_bundle,
+            bundle_path,
+            bundle_bytes,
+            target_dir,
+            remote_builds_root,
+            receiver._config_dir,
+            prepare,
+        )
+    except PathEscapeError as exc:
+        # Wire-shape problem (traversal via ``configuration_filename``
+        # / ``dashboard_id``), not a receiver-side I/O failure — maps
+        # to ``invalid_header``, distinct from ``extract_failed``.
+        _LOGGER.warning(
+            "submit_job from %s: target_dir %s escaped remote-builds root; rejecting",
+            session.dashboard_id,
+            target_dir,
+        )
+        raise _SubmitJobRejectionError(REASON_INVALID_HEADER) from exc
+    except (bundle.EsphomeError, OSError) as exc:
+        _LOGGER.warning(
+            "submit_job from %s: extract failed for job %s (%s): %s",
+            session.dashboard_id,
+            pending.job_id,
+            pending.configuration_filename,
+            exc,
+        )
+        raise _SubmitJobRejectionError(REASON_EXTRACT_FAILED) from exc
+
+    # Snapshot the offloader's display label so the
+    # firmware-tasks UI can render "from {label}" without
+    # re-looking-up the (potentially since-renamed) peer.
+    # Goes through :meth:`ReceiverController.approved_peer_label`
+    # so the receiver doesn't couple to the private
+    # ``_approved_peers`` layout — a future refactor of the
+    # peer registry (e.g. moving APPROVED rows into a per-
+    # file ``Store`` like ``_pairings``) only has to keep
+    # the accessor's contract.
+    remote_peer_label = ""
+    receiver_controller = receiver._firmware._db.remote_build_receiver
+    if receiver_controller is not None:
+        remote_peer_label = receiver_controller.approved_peer_label(session.dashboard_id)
+
+    _raise_if_cancel_flagged(receiver._extracts, cancel_key)
+    try:
+        job = receiver._firmware._create_job(
+            configuration=configuration,
+            job_type=TARGET_TO_JOB_TYPE[pending.target],
+            remote_peer=session.dashboard_id,
+            remote_peer_label=remote_peer_label,
+            remote_job_id=pending.job_id,
+            # ``device_name`` / ``device_friendly_name`` come
+            # off the wire header — the offloader already
+            # knows both from its local Device list at install
+            # time, so the receiver doesn't re-parse the
+            # bundled YAML just to render a title. Defaults
+            # to ``""`` for older offloaders that don't set
+            # the (NotRequired) fields; the frontend's title
+            # then falls back to the configuration path.
+            device_name=pending.device_name,
+            device_friendly_name=pending.device_friendly_name,
+            target_esphome_version=pending.target_esphome_version,
+        )
+        await receiver._firmware._enqueue(job)
+    except Exception as exc:
+        _LOGGER.warning(
+            "submit_job from %s: enqueue failed for job %s: %s",
+            session.dashboard_id,
+            pending.job_id,
+            exc,
+        )
+        raise _SubmitJobRejectionError(REASON_QUEUE_REJECTED) from exc
+
+    _LOGGER.info(
+        "submit_job from %s: queued job %s (%s, target=%s)",
+        session.dashboard_id,
+        job.job_id,
+        configuration,
+        pending.target,
+    )
+    # No awaits between the enqueue and this return; the caller's
+    # handoff relies on it.
+    return job
+
+
+async def cancel_queued_job(
+    receiver: SubmitJobReceiver,
+    session: PeerLinkSession,
+    *,
+    pending: _PendingSubmit,
+    job: FirmwareJob,
+) -> None:
+    """
+    Route a cancel flagged in the enqueue window through the firmware queue.
+
+    An already-terminal refusal defers to the fan-out's frame; a vanished
+    job gets the terminal ``cancelled`` frame directly; any other failure
+    sends nothing (the job is live in the queue).
+    """
+    try:
+        await receiver._firmware.cancel(job_id=job.job_id)
+    except CommandError as exc:
+        if exc.code is ErrorCode.INVALID_ARGS:
+            _LOGGER.debug(
+                "submit_job from %s: firmware refused post-enqueue cancel for job %s: %s",
+                session.dashboard_id,
+                job.job_id,
+                exc.message,
+            )
+            return
+        _LOGGER.warning(
+            "submit_job from %s: post-enqueue cancel for job %s failed (%s): %s",
+            session.dashboard_id,
+            job.job_id,
+            exc.code,
+            exc.message,
+        )
+        await send_terminal_state(
+            session,
+            job_id=pending.job_id,
+            status="cancelled",
+            error_message="cancelled after queueing; job no longer present",
+        )
+    except Exception:
+        _LOGGER.exception(
+            "submit_job from %s: post-enqueue cancel for job %s crashed; job remains queued",
+            session.dashboard_id,
+            job.job_id,
+        )
+
+
+async def send_job_cancelled(session: PeerLinkSession, *, job_id: str) -> None:
+    """Report a peer-cancelled extract as a terminal ``cancelled`` frame."""
+    _LOGGER.info(
+        "submit_job from %s: job %s cancelled mid-extract",
+        session.dashboard_id,
+        job_id,
+    )
+    await send_terminal_state(
+        session,
+        job_id=job_id,
+        status="cancelled",
+        error_message="cancelled by the offloader before the build was queued",
+    )
+
+
+async def send_terminal_state(
+    session: PeerLinkSession,
+    *,
+    job_id: str,
+    status: Literal["failed", "cancelled"],
+    error_message: str,
+) -> None:
+    """Send a terminal ``job_state_changed`` frame keyed on the offloader's *job_id*."""
+    frame = JobStateChangedFrameData(
+        type="job_state_changed",
+        job_id=job_id,
+        status=status,
+        error_message=error_message,
+    )
+    await session.send_app_frame(dict(frame))
+
+
+async def report_post_ack_failure(
+    session: PeerLinkSession, *, pending: _PendingSubmit, reason: str
+) -> None:
+    """Surface a post-ack extract/queue failure as a terminal ``failed`` frame.
+
+    The offloader already got ``accepted`` and is waiting on job-state
+    events, but no :class:`FirmwareJob` reached the queue so the
+    :class:`JobFanout` won't emit one; send the ``failed`` frame here,
+    keyed on the offloader's ``job_id``.
+    """
+    _LOGGER.warning(
+        "submit_job from %s: job %s failed after accept (%s)",
+        session.dashboard_id,
+        pending.job_id,
+        reason,
+    )
+    await send_terminal_state(
+        session,
+        job_id=pending.job_id,
+        status="failed",
+        error_message=f"receiver could not process the bundle: {reason}",
+    )
+
+
+class _SubmitJobRejectionError(Exception):
+    """Internal: surface a typed rejection reason out of :func:`extract_and_queue`.
+
+    Carries a :class:`SubmitJobAckFrameData.reason`-shaped
+    string. Caught by :func:`run_post_ack_extract` and converted
+    to a terminal ``failed`` frame; never leaks past that
+    boundary.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+class _ExtractCancelledError(Exception):
+    """Internal: a peer ``cancel_job`` hit the post-ack extract window."""
+
+
+def _raise_if_cancel_flagged(extracts: ExtractWindow, key: tuple[str, str]) -> None:
+    """Consume any cancellation flag for *key* and raise if one was set."""
+    if extracts.consume(key):
+        raise _ExtractCancelledError
+
+
+def _validate_write_extract_bundle(
+    bundle_path: Path,
+    bundle_bytes: bytes,
+    target_dir: Path,
+    remote_builds_root: Path,
+    config_dir: Path,
+    prepare_bundle_for_compile: Callable[[Path, Path], Path],
+) -> str:
+    """Sync helper: validate path, write tarball, extract, return wire-shape ``configuration``.
+
+    All four steps run in the executor so the receiver's WS
+    dispatch coroutine stays non-blocking through every
+    ``Path.resolve`` walk (which calls ``os.path.realpath``,
+    which calls the blocking ``os.path.abspath`` syscall) and
+    the multi-MB tarball write. ``Path.resolve`` is a stat-y
+    syscall; it has to run in a thread.
+
+    Validation order: (1) resolve-and-stay-under-root check
+    *before* writing anything to disk so a malicious
+    ``configuration_filename`` or ``dashboard_id`` can't
+    materialise even an empty tarball outside the remote-builds
+    subtree. (2) Write the tarball. (3) Extract via
+    ``prepare_bundle_for_compile`` (preserves ``.esphome`` /
+    ``.pioenvs`` for incremental compiles). (4) Compute the
+    POSIX-relative ``configuration`` string for the
+    :class:`FirmwareJob` wire field, resolving *config_dir* so a
+    receiver started with a relative configuration arg
+    (#678) still produces an absolute-vs-absolute
+    ``relative_to`` pair.
+
+    Raises :class:`PathEscapeError` on the path-escape branch
+    so the caller can distinguish "bad input shape" from
+    "extract failed". Raises
+    :class:`esphome.bundle.EsphomeError` / :class:`OSError`
+    untouched for the extract / write paths.
+    """
+    # The upstream filename validator catches separator / ``..``
+    # in ``configuration_filename`` upfront, but ``dashboard_id``
+    # flows through unvalidated from the Noise handshake /
+    # receiver-side registration; this gate catches anything an
+    # exotic ``dashboard_id`` shape would slip past.
+    resolve_under_root(target_dir, remote_builds_root)
+    bundle_path.parent.mkdir(parents=True, exist_ok=True)
+    bundle_path.write_bytes(bundle_bytes)
+    extracted: Path = prepare_bundle_for_compile(bundle_path, target_dir)
+    # ``as_posix`` keeps the wire-side ``configuration`` string
+    # stable across receiver platforms — ``str(rel_yaml)`` would
+    # emit ``\\``-separated paths on Windows.
+    return extracted.relative_to(config_dir.resolve()).as_posix()

--- a/esphome_device_builder/controllers/remote_build/submit_job/const.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job/const.py
@@ -1,0 +1,47 @@
+"""Shared vocabulary for the receiver-side ``submit_job`` package."""
+
+from __future__ import annotations
+
+from ....models import JobType
+
+# Reject reason codes carried on
+# :class:`SubmitJobAckFrameData.reason` when ``accepted=False``.
+# Distinct from :class:`BundleAssemblerErrorCode` (wire-level
+# bundle problems): these cover the receiver-side dispatch path
+# where the bundle assembled cleanly but something else went
+# wrong (path traversal, extraction failure, queue rejection).
+# The offloader's submitter maps these to user-facing error
+# messages.
+REASON_DUPLICATE_SUBMIT = "duplicate_submit"
+REASON_INVALID_HEADER = "invalid_header"
+REASON_INVALID_CHUNK = "invalid_chunk"
+REASON_NO_INFLIGHT = "no_inflight_submit"
+REASON_JOB_ID_MISMATCH = "job_id_mismatch"
+REASON_CHUNK_DECODE_FAILED = "chunk_decode_failed"
+REASON_EXTRACT_FAILED = "extract_failed"
+REASON_QUEUE_REJECTED = "queue_rejected"
+REASON_UPLOAD_UNSUPPORTED = "upload_unsupported"
+
+# Allowed values of :attr:`SubmitJobFrameData.target`.
+# ``Literal["compile", "upload", "clean"]`` on the TypedDict is
+# the type-time gate; this set is the runtime gate so a
+# misbehaving offloader sending ``target="install"`` (or anything
+# else) gets a clean reject rather than a downstream JobType
+# construction failure.
+#
+# ``target="clean"`` rides the same submit_job pipeline as
+# compile — receiver re-extracts the YAML to the
+# per-offloader subtree, then runs ``esphome clean`` against it,
+# which wipes ``<data_dir>/build/<device_name>/``. The receiver's
+# 6c TTL sweep eventually reclaims the subtree itself; an
+# explicit clean is about freeing the shared per-device build
+# tree, not the per-offloader sidecar. The offloader fans out
+# clean to every connected peer when the operator clicks "Clean
+# build files" so receivers that have built this device locally
+# also drop their stale artifacts.
+# ``target="upload"`` is deliberately absent — rejected with
+# ``upload_unsupported`` in :meth:`SubmitJobReceiver.handle_submit_job`.
+TARGET_TO_JOB_TYPE: dict[str, JobType] = {
+    "compile": JobType.COMPILE,
+    "clean": JobType.CLEAN,
+}

--- a/esphome_device_builder/controllers/remote_build/submit_job/controller.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job/controller.py
@@ -58,59 +58,43 @@ from __future__ import annotations
 import binascii
 import logging
 from dataclasses import dataclass
-from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, cast
 
-from ...helpers.api import CommandError
-from ...helpers.async_ import run_in_executor
-from ...helpers.lazy_module import async_import_module
-from ...helpers.paths import PathEscapeError, resolve_under_root
-from ...helpers.peer_link_bundle import (
+from ....helpers.peer_link_bundle import (
     BundleAssembler,
     BundleAssemblerError,
     BundleAssemblerErrorCode,
     decode_chunk,
 )
-from ...helpers.peer_link_frames import frame_schema, is_valid_frame, safe_job_id
-from ...helpers.remote_build_layout import REMOTE_BUILDS_SUBDIR, RemoteBuildPath
-from ...helpers.version_compat import coerce_pep440_version
-from ...models import (
+from ....helpers.peer_link_frames import frame_schema, is_valid_frame, safe_job_id
+from ....helpers.version_compat import coerce_pep440_version
+from ....models import (
     PAIRING_VERSION_MAX_LEN,
-    ErrorCode,
-    JobStateChangedFrameData,
-    JobType,
     SubmitJobAckFrameData,
     SubmitJobChunkFrameData,
     SubmitJobFrameData,
 )
+from . import _post_ack
 from ._extract_window import ExtractWindow
+from .const import (
+    REASON_CHUNK_DECODE_FAILED,
+    REASON_DUPLICATE_SUBMIT,
+    REASON_INVALID_CHUNK,
+    REASON_INVALID_HEADER,
+    REASON_JOB_ID_MISMATCH,
+    REASON_NO_INFLIGHT,
+    REASON_UPLOAD_UNSUPPORTED,
+    TARGET_TO_JOB_TYPE,
+)
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from pathlib import Path
 
-    from ...models import FirmwareJob
-    from ..firmware import FirmwareController
-    from .peer_link import PeerLinkSession
+    from ....models import FirmwareJob
+    from ...firmware import FirmwareController
+    from ..peer_link import PeerLinkSession
 
 _LOGGER = logging.getLogger(__name__)
-
-# Reject reason codes carried on
-# :class:`SubmitJobAckFrameData.reason` when ``accepted=False``.
-# Distinct from :class:`BundleAssemblerErrorCode` (wire-level
-# bundle problems): these cover the receiver-side dispatch path
-# where the bundle assembled cleanly but something else went
-# wrong (path traversal, extraction failure, queue rejection).
-# The offloader's submitter maps these to user-facing error
-# messages.
-_REASON_DUPLICATE_SUBMIT = "duplicate_submit"
-_REASON_INVALID_HEADER = "invalid_header"
-_REASON_INVALID_CHUNK = "invalid_chunk"
-_REASON_NO_INFLIGHT = "no_inflight_submit"
-_REASON_JOB_ID_MISMATCH = "job_id_mismatch"
-_REASON_CHUNK_DECODE_FAILED = "chunk_decode_failed"
-_REASON_EXTRACT_FAILED = "extract_failed"
-_REASON_QUEUE_REJECTED = "queue_rejected"
-_REASON_UPLOAD_UNSUPPORTED = "upload_unsupported"
 
 # Cap on the peer-controlled display strings the header carries
 # (``device_name`` / ``device_friendly_name``). The schema gate
@@ -163,30 +147,6 @@ _SUBMIT_JOB_CHUNK_SCHEMA = frame_schema(
 # in-flight-key derivation all flow through one source of
 # truth. See that module's :class:`RemoteBuildPath` for the
 # canonical key shape.
-
-# Allowed values of :attr:`SubmitJobFrameData.target`.
-# ``Literal["compile", "upload", "clean"]`` on the TypedDict is
-# the type-time gate; this set is the runtime gate so a
-# misbehaving offloader sending ``target="install"`` (or anything
-# else) gets a clean reject rather than a downstream JobType
-# construction failure.
-#
-# ``target="clean"`` rides the same submit_job pipeline as
-# compile — receiver re-extracts the YAML to the
-# per-offloader subtree, then runs ``esphome clean`` against it,
-# which wipes ``<data_dir>/build/<device_name>/``. The receiver's
-# 6c TTL sweep eventually reclaims the subtree itself; an
-# explicit clean is about freeing the shared per-device build
-# tree, not the per-offloader sidecar. The offloader fans out
-# clean to every connected peer when the operator clicks "Clean
-# build files" so receivers that have built this device locally
-# also drop their stale artifacts.
-# ``target="upload"`` is deliberately absent — rejected with
-# ``upload_unsupported`` in :meth:`SubmitJobReceiver.handle_submit_job`.
-_TARGET_TO_JOB_TYPE: dict[str, JobType] = {
-    "compile": JobType.COMPILE,
-    "clean": JobType.CLEAN,
-}
 
 # Bundle-assembler error codes that map to a clean
 # ``submit_job_ack`` rejection (the offloader can fix-and-retry
@@ -432,7 +392,7 @@ class SubmitJobReceiver:
             await self._reject(
                 session,
                 job_id=safe_job_id(raw),
-                reason=_REASON_INVALID_HEADER,
+                reason=REASON_INVALID_HEADER,
                 terminate_session=True,
             )
             return
@@ -442,16 +402,16 @@ class SubmitJobReceiver:
         if session.dashboard_id in self._inflight or self._extracts.is_tracked(
             (session.dashboard_id, job_id)
         ):
-            await self._reject(session, job_id=job_id, reason=_REASON_DUPLICATE_SUBMIT)
+            await self._reject(session, job_id=job_id, reason=REASON_DUPLICATE_SUBMIT)
             return
         target = frame["target"]
         if target == "upload":
             # Distinct from ``invalid_header`` so an older offloader's
             # dialog surfaces a recognisable refusal, not "bad frame".
-            await self._reject(session, job_id=job_id, reason=_REASON_UPLOAD_UNSUPPORTED)
+            await self._reject(session, job_id=job_id, reason=REASON_UPLOAD_UNSUPPORTED)
             return
-        if target not in _TARGET_TO_JOB_TYPE:
-            await self._reject(session, job_id=job_id, reason=_REASON_INVALID_HEADER)
+        if target not in TARGET_TO_JOB_TYPE:
+            await self._reject(session, job_id=job_id, reason=REASON_INVALID_HEADER)
             return
         # Validate the peer-supplied filename — it becomes the
         # second path segment under
@@ -461,7 +421,7 @@ class SubmitJobReceiver:
         # outside the intended subtree.
         device_stem = _validate_configuration_filename(frame["configuration_filename"])
         if device_stem is None:
-            await self._reject(session, job_id=job_id, reason=_REASON_INVALID_HEADER)
+            await self._reject(session, job_id=job_id, reason=REASON_INVALID_HEADER)
             return
         try:
             assembler = BundleAssembler(
@@ -515,17 +475,17 @@ class SubmitJobReceiver:
             await self._reject(
                 session,
                 job_id=safe_job_id(chunk_dict),
-                reason=_REASON_INVALID_CHUNK,
+                reason=REASON_INVALID_CHUNK,
                 drop_inflight=True,
                 terminate_session=True,
             )
             return
         pending = self._inflight.get(session.dashboard_id)
         if pending is None:
-            await self._reject(session, job_id=frame["job_id"], reason=_REASON_NO_INFLIGHT)
+            await self._reject(session, job_id=frame["job_id"], reason=REASON_NO_INFLIGHT)
             return
         if frame["job_id"] != pending.job_id:
-            await self._reject(session, job_id=frame["job_id"], reason=_REASON_JOB_ID_MISMATCH)
+            await self._reject(session, job_id=frame["job_id"], reason=REASON_JOB_ID_MISMATCH)
             return
         try:
             raw = decode_chunk(frame["data_b64"])
@@ -533,7 +493,7 @@ class SubmitJobReceiver:
             await self._reject(
                 session,
                 job_id=pending.job_id,
-                reason=_REASON_CHUNK_DECODE_FAILED,
+                reason=REASON_CHUNK_DECODE_FAILED,
                 drop_inflight=True,
                 terminate_session=True,
             )
@@ -574,52 +534,10 @@ class SubmitJobReceiver:
         # while a slow extract runs.
         self._extracts.spawn(
             (session.dashboard_id, pending.job_id),
-            self._run_post_ack_extract(session=session, pending=pending, bundle_bytes=assembled),
+            _post_ack.run_post_ack_extract(
+                self, session=session, pending=pending, bundle_bytes=assembled
+            ),
         )
-
-    async def _run_post_ack_extract(
-        self, *, session: PeerLinkSession, pending: _PendingSubmit, bundle_bytes: bytes
-    ) -> None:
-        """Extract + queue one accepted bundle, serialized per peer."""
-        key = (session.dashboard_id, pending.job_id)
-        try:
-            self._raise_if_cancel_flagged(key)
-            # The (FIFO) lock keeps per-peer enqueue order and keeps a
-            # same-configuration resubmit off a target dir mid-extract.
-            async with self._extracts.lock(session.dashboard_id):
-                job = await self._extract_and_queue(
-                    session=session, pending=pending, bundle_bytes=bundle_bytes, cancel_key=key
-                )
-        except _SubmitJobRejectionError as exc:
-            await self._report_post_ack_failure(session, pending=pending, reason=exc.reason)
-        except _ExtractCancelledError:
-            await self._send_job_cancelled(session, job_id=pending.job_id)
-        except Exception:
-            # The offloader already got ``accepted`` and is waiting on
-            # job-state events; an unreported crash strands it forever.
-            _LOGGER.exception(
-                "submit_job from %s: unexpected extract failure for job %s",
-                session.dashboard_id,
-                pending.job_id,
-            )
-            await self._report_post_ack_failure(
-                session, pending=pending, reason=_REASON_EXTRACT_FAILED
-            )
-        else:
-            # No await between the enqueue and this block (the lock's exit
-            # doesn't yield), so dropping the index here leaves no
-            # unroutable window. The job is live in the queue; nothing
-            # past this point may report ``failed``.
-            self._extracts.handoff(key)
-            if self._extracts.consume(key):
-                await self._cancel_queued_job(session, pending=pending, job=job)
-        finally:
-            self._extracts.consume(key)
-
-    def _raise_if_cancel_flagged(self, key: tuple[str, str]) -> None:
-        """Consume any cancellation flag for *key* and raise if one was set."""
-        if self._extracts.consume(key):
-            raise _ExtractCancelledError
 
     async def _reject_assembler(
         self,
@@ -654,229 +572,19 @@ class SubmitJobReceiver:
         bundle_bytes: bytes,
         cancel_key: tuple[str, str],
     ) -> FirmwareJob:
-        """Write the tarball, extract it, queue and return the :class:`FirmwareJob`.
-
-        Raises :class:`_SubmitJobRejectionError` on any failure
-        with a reason code; the caller has already acked
-        acceptance, so it converts the raise into a terminal
-        ``failed`` job-state frame (extract / queue failures are
-        receiver-side problems, not wire-level misbehaviour). The receiver-side
-        job id is captured in :attr:`FirmwareJob.remote_peer` for
-        the fan-out path; the offloader echoes against its
-        own submit-tagged ``job_id`` rather than the receiver's
-        local one.
-
-        Disk I/O hops to the executor:
-        ``prepare_bundle_for_compile`` walks the tar, validates
-        members, writes to disk; bundling that into one
-        ``run_in_executor`` keeps the receiver's WS dispatch
-        coroutine non-blocking through a multi-MB write.
-        """
-        self._raise_if_cancel_flagged(cancel_key)
-        # Subtree (extract target) + bundle (sibling tarball)
-        # flow through the layout helper so the writer here and
-        # the 6c sweeper read one source of truth for the
-        # on-disk shape. Sibling-not-child is load-bearing:
-        # upstream prepare_bundle_for_compile wipes target_dir
-        # before extract_bundle reads from bundle_path, so a
-        # bundle inside target_dir would be deleted mid-flow
-        # (PR #552).
-        key = RemoteBuildPath(dashboard_id=session.dashboard_id, device_name=pending.device_stem)
-        target_dir = key.subtree(self._config_dir)
-        bundle_path = key.bundle(self._config_dir)
-        remote_builds_root = self._config_dir / REMOTE_BUILDS_SUBDIR
-
-        # ``esphome.bundle`` is ~1 MB of upstream code; load it through
-        # the shared lazy-import executor so the receiver's idle resident
-        # set stays lean until a peer-link offload actually lands. Pass
-        # the resolved callable into the executor so the worker doesn't
-        # rely on a preload-ordering invariant in this caller.
-        bundle = await async_import_module("esphome.bundle")
-        prepare = bundle.prepare_bundle_for_compile
-        try:
-            configuration = await run_in_executor(
-                _validate_write_extract_bundle,
-                bundle_path,
-                bundle_bytes,
-                target_dir,
-                remote_builds_root,
-                self._config_dir,
-                prepare,
-            )
-        except PathEscapeError as exc:
-            # Wire-shape problem (traversal via ``configuration_filename``
-            # / ``dashboard_id``), not a receiver-side I/O failure — maps
-            # to ``invalid_header``, distinct from ``extract_failed``.
-            _LOGGER.warning(
-                "submit_job from %s: target_dir %s escaped remote-builds root; rejecting",
-                session.dashboard_id,
-                target_dir,
-            )
-            raise _SubmitJobRejectionError(_REASON_INVALID_HEADER) from exc
-        except (bundle.EsphomeError, OSError) as exc:
-            _LOGGER.warning(
-                "submit_job from %s: extract failed for job %s (%s): %s",
-                session.dashboard_id,
-                pending.job_id,
-                pending.configuration_filename,
-                exc,
-            )
-            raise _SubmitJobRejectionError(_REASON_EXTRACT_FAILED) from exc
-
-        # Snapshot the offloader's display label so the
-        # firmware-tasks UI can render "from {label}" without
-        # re-looking-up the (potentially since-renamed) peer.
-        # Goes through :meth:`ReceiverController.approved_peer_label`
-        # so the receiver doesn't couple to the private
-        # ``_approved_peers`` layout — a future refactor of the
-        # peer registry (e.g. moving APPROVED rows into a per-
-        # file ``Store`` like ``_pairings``) only has to keep
-        # the accessor's contract.
-        remote_peer_label = ""
-        receiver = self._firmware._db.remote_build_receiver
-        if receiver is not None:
-            remote_peer_label = receiver.approved_peer_label(session.dashboard_id)
-
-        self._raise_if_cancel_flagged(cancel_key)
-        try:
-            job = self._firmware._create_job(
-                configuration=configuration,
-                job_type=_TARGET_TO_JOB_TYPE[pending.target],
-                remote_peer=session.dashboard_id,
-                remote_peer_label=remote_peer_label,
-                remote_job_id=pending.job_id,
-                # ``device_name`` / ``device_friendly_name`` come
-                # off the wire header — the offloader already
-                # knows both from its local Device list at install
-                # time, so the receiver doesn't re-parse the
-                # bundled YAML just to render a title. Defaults
-                # to ``""`` for older offloaders that don't set
-                # the (NotRequired) fields; the frontend's title
-                # then falls back to the configuration path.
-                device_name=pending.device_name,
-                device_friendly_name=pending.device_friendly_name,
-                target_esphome_version=pending.target_esphome_version,
-            )
-            await self._firmware._enqueue(job)
-        except Exception as exc:
-            _LOGGER.warning(
-                "submit_job from %s: enqueue failed for job %s: %s",
-                session.dashboard_id,
-                pending.job_id,
-                exc,
-            )
-            raise _SubmitJobRejectionError(_REASON_QUEUE_REJECTED) from exc
-
-        _LOGGER.info(
-            "submit_job from %s: queued job %s (%s, target=%s)",
-            session.dashboard_id,
-            job.job_id,
-            configuration,
-            pending.target,
+        """Write the tarball, extract it, queue and return the :class:`FirmwareJob`."""
+        return await _post_ack.extract_and_queue(
+            self,
+            session=session,
+            pending=pending,
+            bundle_bytes=bundle_bytes,
+            cancel_key=cancel_key,
         )
-        # No awaits between the enqueue and this return; the caller's
-        # handoff relies on it.
-        return job
-
-    async def _cancel_queued_job(
-        self, session: PeerLinkSession, *, pending: _PendingSubmit, job: FirmwareJob
-    ) -> None:
-        """
-        Route a cancel flagged in the enqueue window through the firmware queue.
-
-        An already-terminal refusal defers to the fan-out's frame; a vanished
-        job gets the terminal ``cancelled`` frame directly; any other failure
-        sends nothing (the job is live in the queue).
-        """
-        try:
-            await self._firmware.cancel(job_id=job.job_id)
-        except CommandError as exc:
-            if exc.code is ErrorCode.INVALID_ARGS:
-                _LOGGER.debug(
-                    "submit_job from %s: firmware refused post-enqueue cancel for job %s: %s",
-                    session.dashboard_id,
-                    job.job_id,
-                    exc.message,
-                )
-                return
-            _LOGGER.warning(
-                "submit_job from %s: post-enqueue cancel for job %s failed (%s): %s",
-                session.dashboard_id,
-                job.job_id,
-                exc.code,
-                exc.message,
-            )
-            await self._send_terminal_state(
-                session,
-                job_id=pending.job_id,
-                status="cancelled",
-                error_message="cancelled after queueing; job no longer present",
-            )
-        except Exception:
-            _LOGGER.exception(
-                "submit_job from %s: post-enqueue cancel for job %s crashed; job remains queued",
-                session.dashboard_id,
-                job.job_id,
-            )
 
     async def _send_ack_accepted(self, session: PeerLinkSession, *, job_id: str) -> None:
         """Send the success-path ``submit_job_ack`` (no ``reason`` field)."""
         payload = SubmitJobAckFrameData(type="submit_job_ack", job_id=job_id, accepted=True)
         await session.send_app_frame(dict(payload))
-
-    async def _send_job_cancelled(self, session: PeerLinkSession, *, job_id: str) -> None:
-        """Report a peer-cancelled extract as a terminal ``cancelled`` frame."""
-        _LOGGER.info(
-            "submit_job from %s: job %s cancelled mid-extract",
-            session.dashboard_id,
-            job_id,
-        )
-        await self._send_terminal_state(
-            session,
-            job_id=job_id,
-            status="cancelled",
-            error_message="cancelled by the offloader before the build was queued",
-        )
-
-    async def _send_terminal_state(
-        self,
-        session: PeerLinkSession,
-        *,
-        job_id: str,
-        status: Literal["failed", "cancelled"],
-        error_message: str,
-    ) -> None:
-        """Send a terminal ``job_state_changed`` frame keyed on the offloader's *job_id*."""
-        frame = JobStateChangedFrameData(
-            type="job_state_changed",
-            job_id=job_id,
-            status=status,
-            error_message=error_message,
-        )
-        await session.send_app_frame(dict(frame))
-
-    async def _report_post_ack_failure(
-        self, session: PeerLinkSession, *, pending: _PendingSubmit, reason: str
-    ) -> None:
-        """Surface a post-ack extract/queue failure as a terminal ``failed`` frame.
-
-        The offloader already got ``accepted`` and is waiting on job-state
-        events, but no :class:`FirmwareJob` reached the queue so the
-        :class:`JobFanout` won't emit one; send the ``failed`` frame here,
-        keyed on the offloader's ``job_id``.
-        """
-        _LOGGER.warning(
-            "submit_job from %s: job %s failed after accept (%s)",
-            session.dashboard_id,
-            pending.job_id,
-            reason,
-        )
-        await self._send_terminal_state(
-            session,
-            job_id=pending.job_id,
-            status="failed",
-            error_message=f"receiver could not process the bundle: {reason}",
-        )
 
     async def _reject(
         self,
@@ -913,7 +621,7 @@ class SubmitJobReceiver:
         # module via :class:`SubmitJobReceiver`-shaped duck
         # typing in its receive loop, but only the
         # ``TerminateReason`` enum reads back the other way.
-        from .peer_link import TerminateReason  # noqa: PLC0415
+        from ..peer_link import TerminateReason  # noqa: PLC0415
 
         if drop_inflight:
             self._inflight.pop(session.dashboard_id, None)
@@ -923,72 +631,3 @@ class SubmitJobReceiver:
         await session.send_app_frame(dict(payload))
         if terminate_session:
             await session.terminate(TerminateReason.MALFORMED_FRAME)
-
-
-class _SubmitJobRejectionError(Exception):
-    """Internal: surface a typed rejection reason out of ``_extract_and_queue``.
-
-    Carries a :class:`SubmitJobAckFrameData.reason`-shaped
-    string. Caught by :meth:`SubmitJobReceiver.handle_submit_job_chunk`
-    on the final-chunk path and converted to an ack reject; never
-    leaks past that boundary.
-    """
-
-    def __init__(self, reason: str) -> None:
-        super().__init__(reason)
-        self.reason = reason
-
-
-class _ExtractCancelledError(Exception):
-    """Internal: a peer ``cancel_job`` hit the post-ack extract window."""
-
-
-def _validate_write_extract_bundle(
-    bundle_path: Path,
-    bundle_bytes: bytes,
-    target_dir: Path,
-    remote_builds_root: Path,
-    config_dir: Path,
-    prepare_bundle_for_compile: Callable[[Path, Path], Path],
-) -> str:
-    """Sync helper: validate path, write tarball, extract, return wire-shape ``configuration``.
-
-    All four steps run in the executor so the receiver's WS
-    dispatch coroutine stays non-blocking through every
-    ``Path.resolve`` walk (which calls ``os.path.realpath``,
-    which calls the blocking ``os.path.abspath`` syscall) and
-    the multi-MB tarball write. ``Path.resolve`` is a stat-y
-    syscall; it has to run in a thread.
-
-    Validation order: (1) resolve-and-stay-under-root check
-    *before* writing anything to disk so a malicious
-    ``configuration_filename`` or ``dashboard_id`` can't
-    materialise even an empty tarball outside the remote-builds
-    subtree. (2) Write the tarball. (3) Extract via
-    ``prepare_bundle_for_compile`` (preserves ``.esphome`` /
-    ``.pioenvs`` for incremental compiles). (4) Compute the
-    POSIX-relative ``configuration`` string for the
-    :class:`FirmwareJob` wire field, resolving *config_dir* so a
-    receiver started with a relative configuration arg
-    (#678) still produces an absolute-vs-absolute
-    ``relative_to`` pair.
-
-    Raises :class:`PathEscapeError` on the path-escape branch
-    so the caller can distinguish "bad input shape" from
-    "extract failed". Raises
-    :class:`esphome.bundle.EsphomeError` / :class:`OSError`
-    untouched for the extract / write paths.
-    """
-    # The upstream filename validator catches separator / ``..``
-    # in ``configuration_filename`` upfront, but ``dashboard_id``
-    # flows through unvalidated from the Noise handshake /
-    # receiver-side registration; this gate catches anything an
-    # exotic ``dashboard_id`` shape would slip past.
-    resolve_under_root(target_dir, remote_builds_root)
-    bundle_path.parent.mkdir(parents=True, exist_ok=True)
-    bundle_path.write_bytes(bundle_bytes)
-    extracted: Path = prepare_bundle_for_compile(bundle_path, target_dir)
-    # ``as_posix`` keeps the wire-side ``configuration`` string
-    # stable across receiver platforms — ``str(rel_yaml)`` would
-    # emit ``\\``-separated paths on Windows.
-    return extracted.relative_to(config_dir.resolve()).as_posix()

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -27,10 +27,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from esphome.bundle import EsphomeError
 
-from esphome_device_builder.controllers.remote_build._extract_window import ExtractWindow
-from esphome_device_builder.controllers.remote_build.submit_job import (
+from esphome_device_builder.controllers.remote_build.submit_job import SubmitJobReceiver
+from esphome_device_builder.controllers.remote_build.submit_job._extract_window import (
+    ExtractWindow,
+)
+from esphome_device_builder.controllers.remote_build.submit_job.controller import (
     _DEVICE_DISPLAY_FIELD_MAX_LEN,
-    SubmitJobReceiver,
     _coerce_display_field,
     _PendingSubmit,
     _validate_configuration_filename,
@@ -1307,7 +1309,7 @@ async def test_cancel_extract_flagged_mid_extract_skips_the_queue(
         return "kitchen.yaml"
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.submit_job.run_in_executor",
+        "esphome_device_builder.controllers.remote_build.submit_job._post_ack.run_in_executor",
         _executor_with_late_cancel,
     )
 


### PR DESCRIPTION
# What does this implement/fix?

Behavior-free package split of `controllers/remote_build/submit_job.py`, which was over the 800-line soft cap before #2335 and ended at 994 lines after it. Follows the repo's canonical split shape (`controllers/devices/`, `controllers/firmware/`, `controllers/remote_build/` itself):

| Module | Lines | Concern |
|---|---|---|
| `submit_job/controller.py` | ~630 | `SubmitJobReceiver` public API: header validation, chunk assembly, ack/reject paths, `_PendingSubmit` |
| `submit_job/_post_ack.py` | ~380 | The off-loop extract task body, cancel-window routing, terminal-frame senders, the executor helper, both internal exceptions |
| `submit_job/const.py` | ~50 | Shared vocabulary: the `submit_job_ack` reason codes and the target-to-`JobType` map (used by both siblings) |
| `submit_job/_extract_window.py` | (moved) | Unchanged; relocated beside its only consumer |

`__init__.py` re-exports `SubmitJobReceiver`, so the two production importers (`receiver.py`, `_receiver_state.py`) and the peer-link test are untouched. `_post_ack` functions take the receiver as first argument, mirroring `peer_link_sessions.py` / `firmware/jobs.py`; the one thin delegate kept on the class is `_extract_and_queue`, which is the seam both the production call path and the test suite intercept. The reason constants dropped their leading underscore on the move to `const.py`; no other renames.

Test changes are import-path only: the `_extract_window` import, the module-internal helper imports now coming from `submit_job.controller`, and the `run_in_executor` monkeypatch target now pointing at `submit_job._post_ack`.

Verified behavior-free: full suite 7212 passed, mypy clean across the tree, 100% coverage on every module in the new package, and the cold-import budget check passes.

**Related issue or feature (if applicable):**

- fixes #2337

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
