### PR TITLE
Reject a path-escaping submit_job header before the ack

### DIFF
--- a/esphome_device_builder/controllers/remote_build/submit_job/_post_ack.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job/_post_ack.py
@@ -334,11 +334,9 @@ def _validate_write_extract_bundle(
     the caller can distinguish bad input shape from an extract failure;
     ``EsphomeError`` / ``OSError`` propagate untouched.
     """
-    # The upstream filename validator catches separator / ``..``
-    # in ``configuration_filename`` upfront, but ``dashboard_id``
-    # flows through unvalidated from the Noise handshake /
-    # receiver-side registration; this gate catches anything an
-    # exotic ``dashboard_id`` shape would slip past.
+    # Defence-in-depth re-check of the pre-ack header gate: the
+    # header-time resolve can be invalidated by a symlink created
+    # under the remote-builds root between ack and extract.
     resolve_under_root(target_dir, remote_builds_root)
     bundle_path.parent.mkdir(parents=True, exist_ok=True)
     bundle_path.write_bytes(bundle_bytes)

--- a/esphome_device_builder/controllers/remote_build/submit_job/_post_ack.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job/_post_ack.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING, Literal
 from ....helpers.api import CommandError
 from ....helpers.async_ import run_in_executor
 from ....helpers.lazy_module import async_import_module
-from ....helpers.paths import PathEscapeError, resolve_under_root
-from ....helpers.remote_build_layout import REMOTE_BUILDS_SUBDIR, RemoteBuildPath
+from ....helpers.paths import PathEscapeError
+from ....helpers.remote_build_layout import RemoteBuildPath
 from ....models import ErrorCode, JobStateChangedFrameData
 from .const import (
     REASON_EXTRACT_FAILED,
@@ -88,18 +88,7 @@ async def extract_and_queue(
     all disk I/O runs in a single executor hop.
     """
     _raise_if_cancel_flagged(receiver._extracts, cancel_key)
-    # Subtree (extract target) + bundle (sibling tarball)
-    # flow through the layout helper so the writer here and
-    # the 6c sweeper read one source of truth for the
-    # on-disk shape. Sibling-not-child is load-bearing:
-    # upstream prepare_bundle_for_compile wipes target_dir
-    # before extract_bundle reads from bundle_path, so a
-    # bundle inside target_dir would be deleted mid-flow
-    # (PR #552).
     key = RemoteBuildPath(dashboard_id=session.dashboard_id, device_name=pending.device_stem)
-    target_dir = key.subtree(receiver._config_dir)
-    bundle_path = key.bundle(receiver._config_dir)
-    remote_builds_root = receiver._config_dir / REMOTE_BUILDS_SUBDIR
 
     # ``esphome.bundle`` is ~1 MB of upstream code; load it through
     # the shared lazy-import executor so the receiver's idle resident
@@ -111,10 +100,8 @@ async def extract_and_queue(
     try:
         configuration = await run_in_executor(
             _validate_write_extract_bundle,
-            bundle_path,
+            key,
             bundle_bytes,
-            target_dir,
-            remote_builds_root,
             receiver._config_dir,
             prepare,
         )
@@ -123,9 +110,9 @@ async def extract_and_queue(
         # / ``dashboard_id``), not a receiver-side I/O failure — maps
         # to ``invalid_header``, distinct from ``extract_failed``.
         _LOGGER.warning(
-            "submit_job from %s: target_dir %s escaped remote-builds root; rejecting",
+            "submit_job from %s: target dir for %r escaped remote-builds root; rejecting",
             session.dashboard_id,
-            target_dir,
+            pending.configuration_filename,
         )
         raise _SubmitJobRejectionError(REASON_INVALID_HEADER) from exc
     except (bundle.EsphomeError, OSError) as exc:
@@ -318,10 +305,8 @@ def _raise_if_cancel_flagged(extracts: ExtractWindow, key: tuple[str, str]) -> N
 
 
 def _validate_write_extract_bundle(
-    bundle_path: Path,
+    key: RemoteBuildPath,
     bundle_bytes: bytes,
-    target_dir: Path,
-    remote_builds_root: Path,
     config_dir: Path,
     prepare_bundle_for_compile: Callable[[Path, Path], Path],
 ) -> str:
@@ -337,7 +322,13 @@ def _validate_write_extract_bundle(
     # Defence-in-depth re-check of the pre-ack header gate: the
     # header-time resolve can be invalidated by a symlink created
     # under the remote-builds root between ack and extract.
-    resolve_under_root(target_dir, remote_builds_root)
+    key.resolved_subtree(config_dir)
+    target_dir = key.subtree(config_dir)
+    # Sibling-not-child is load-bearing: upstream
+    # prepare_bundle_for_compile wipes target_dir before
+    # extract_bundle reads from bundle_path, so a bundle inside
+    # target_dir would be deleted mid-flow (PR #552).
+    bundle_path = key.bundle(config_dir)
     bundle_path.parent.mkdir(parents=True, exist_ok=True)
     bundle_path.write_bytes(bundle_bytes)
     extracted: Path = prepare_bundle_for_compile(bundle_path, target_dir)

--- a/esphome_device_builder/controllers/remote_build/submit_job/controller.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job/controller.py
@@ -38,7 +38,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 from ....helpers.async_ import run_in_executor
-from ....helpers.paths import PathEscapeError, resolve_under_root
+from ....helpers.paths import PathEscapeError
 from ....helpers.peer_link_bundle import (
     BundleAssembler,
     BundleAssemblerError,
@@ -46,7 +46,7 @@ from ....helpers.peer_link_bundle import (
     decode_chunk,
 )
 from ....helpers.peer_link_frames import frame_schema, is_valid_frame, safe_job_id
-from ....helpers.remote_build_layout import REMOTE_BUILDS_SUBDIR, RemoteBuildPath
+from ....helpers.remote_build_layout import RemoteBuildPath
 from ....helpers.version_compat import coerce_pep440_version
 from ....models import (
     PAIRING_VERSION_MAX_LEN,
@@ -463,11 +463,7 @@ class SubmitJobReceiver:
         key = RemoteBuildPath(dashboard_id=session.dashboard_id, device_name=device_stem)
         try:
             # ``Path.resolve`` walks the filesystem; keep it off the loop.
-            await run_in_executor(
-                resolve_under_root,
-                key.subtree(self._config_dir),
-                self._config_dir / REMOTE_BUILDS_SUBDIR,
-            )
+            await run_in_executor(key.resolved_subtree, self._config_dir)
         except PathEscapeError:
             _LOGGER.warning(
                 "submit_job from %s: target dir for %r escapes the remote-builds root; rejecting",

--- a/esphome_device_builder/controllers/remote_build/submit_job/controller.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job/controller.py
@@ -37,6 +37,8 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
+from ....helpers.async_ import run_in_executor
+from ....helpers.paths import PathEscapeError, resolve_under_root
 from ....helpers.peer_link_bundle import (
     BundleAssembler,
     BundleAssemblerError,
@@ -44,6 +46,7 @@ from ....helpers.peer_link_bundle import (
     decode_chunk,
 )
 from ....helpers.peer_link_frames import frame_schema, is_valid_frame, safe_job_id
+from ....helpers.remote_build_layout import REMOTE_BUILDS_SUBDIR, RemoteBuildPath
 from ....helpers.version_compat import coerce_pep440_version
 from ....models import (
     PAIRING_VERSION_MAX_LEN,
@@ -330,7 +333,7 @@ class SubmitJobReceiver:
         # An unvalidated separator / ``..`` here would let a
         # malicious offloader write the assembled tarball
         # outside the intended subtree.
-        device_stem = _validate_configuration_filename(frame["configuration_filename"])
+        device_stem = await self._resolve_device_stem(session, frame)
         if device_stem is None:
             await self._reject(session, job_id=job_id, reason=REASON_INVALID_HEADER)
             return
@@ -443,6 +446,36 @@ class SubmitJobReceiver:
                 self, session=session, pending=pending, bundle_bytes=assembled
             ),
         )
+
+    async def _resolve_device_stem(
+        self, session: PeerLinkSession, frame: SubmitJobFrameData
+    ) -> str | None:
+        """
+        Return the validated YAML stem for *frame*, or ``None`` to reject.
+
+        Combines the filename gate with the resolve-and-stay-under-root check
+        on the derived extract dir, so a traversing ``configuration_filename``
+        or ``dashboard_id`` is refused pre-ack, before any bundle bytes stream.
+        """
+        device_stem = _validate_configuration_filename(frame["configuration_filename"])
+        if device_stem is None:
+            return None
+        key = RemoteBuildPath(dashboard_id=session.dashboard_id, device_name=device_stem)
+        try:
+            # ``Path.resolve`` walks the filesystem; keep it off the loop.
+            await run_in_executor(
+                resolve_under_root,
+                key.subtree(self._config_dir),
+                self._config_dir / REMOTE_BUILDS_SUBDIR,
+            )
+        except PathEscapeError:
+            _LOGGER.warning(
+                "submit_job from %s: target dir for %r escapes the remote-builds root; rejecting",
+                session.dashboard_id,
+                frame["configuration_filename"],
+            )
+            return None
+        return device_stem
 
     async def _reject_assembler(
         self,

--- a/esphome_device_builder/controllers/remote_build/submit_job/controller.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job/controller.py
@@ -453,9 +453,8 @@ class SubmitJobReceiver:
         """
         Return the validated YAML stem for *frame*, or ``None`` to reject.
 
-        Combines the filename gate with the resolve-and-stay-under-root check
-        on the derived extract dir, so a traversing ``configuration_filename``
-        or ``dashboard_id`` is refused pre-ack, before any bundle bytes stream.
+        Runs the filename gate plus the under-root resolve on the derived
+        extract dir.
         """
         device_stem = _validate_configuration_filename(frame["configuration_filename"])
         if device_stem is None:

--- a/esphome_device_builder/controllers/remote_build/submit_job/controller.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job/controller.py
@@ -140,9 +140,9 @@ _RECOVERABLE_ASSEMBLER_ERRORS: frozenset[BundleAssemblerErrorCode] = frozenset(
 # ``configuration_filename``. Path separators (both flavours so
 # the rule holds across receiver platforms) and the NUL byte.
 # The rule's job is to catch obviously-malicious shapes early;
-# the resolve-and-stay-under-root check at extract time is the
-# defence-in-depth gate that catches anything an exotic filename
-# would slip past this.
+# the header-time resolve-and-stay-under-root check (re-run at
+# extract) catches anything an exotic filename would slip past
+# this.
 _FORBIDDEN_FILENAME_CHARS: frozenset[str] = frozenset({"/", "\\", "\x00"})
 
 
@@ -285,8 +285,8 @@ class SubmitJobReceiver:
         * Header field shapes the wire-format TypedDict can't
           enforce at runtime (target outside the
           ``compile`` / ``clean`` set, malformed
-          ``configuration_filename``), plus the explicit
-          ``upload_unsupported`` reject.
+          ``configuration_filename``, a path-escaping extract
+          dir), plus the explicit ``upload_unsupported`` reject.
         * Assembler-construction validation (oversized total,
           empty bundle, etc.) — a ``submit_job_ack`` rejection,
           not a ``terminate``: the chunk stream hasn't started,
@@ -311,6 +311,17 @@ class SubmitJobReceiver:
             )
             return
         job_id = frame["job_id"]
+        # Validate the peer-supplied filename and the derived extract dir —
+        # the stem becomes the second path segment under
+        # ``.esphome/.remote_builds/<dashboard_id>/<device_name>/``, so a
+        # separator / ``..`` / escaping resolve would let a malicious
+        # offloader write outside the intended subtree. Runs before the
+        # duplicate gate: its executor hop is the only await here, keeping
+        # the check-then-register region below atomic on the loop.
+        device_stem = await self._resolve_device_stem(session, frame)
+        if device_stem is None:
+            await self._reject(session, job_id=job_id, reason=REASON_INVALID_HEADER)
+            return
         # A resubmit of a job_id whose accepted bundle is still mid-extract
         # would overwrite the extract index and mis-route a cancel.
         if session.dashboard_id in self._inflight or self._extracts.is_tracked(
@@ -325,16 +336,6 @@ class SubmitJobReceiver:
             await self._reject(session, job_id=job_id, reason=REASON_UPLOAD_UNSUPPORTED)
             return
         if target not in TARGET_TO_JOB_TYPE:
-            await self._reject(session, job_id=job_id, reason=REASON_INVALID_HEADER)
-            return
-        # Validate the peer-supplied filename — it becomes the
-        # second path segment under
-        # ``.esphome/.remote_builds/<dashboard_id>/<device_name>/``.
-        # An unvalidated separator / ``..`` here would let a
-        # malicious offloader write the assembled tarball
-        # outside the intended subtree.
-        device_stem = await self._resolve_device_stem(session, frame)
-        if device_stem is None:
             await self._reject(session, job_id=job_id, reason=REASON_INVALID_HEADER)
             return
         try:

--- a/esphome_device_builder/helpers/remote_build_layout.py
+++ b/esphome_device_builder/helpers/remote_build_layout.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
+from .paths import resolve_under_root
+
 # Leading-dot hides the directory from a casual ``ls`` of the
 # parent tree, alongside the user's own files.
 REMOTE_BUILDS_NAME = ".remote_builds"
@@ -83,6 +85,15 @@ class RemoteBuildPath:
     def subtree(self, config_dir: Path) -> Path:
         """Return the absolute extract directory under *config_dir*."""
         return config_dir / REMOTE_BUILDS_SUBDIR / self.dir_id / self.device_name
+
+    def resolved_subtree(self, config_dir: Path) -> Path:
+        """
+        Resolve :meth:`subtree` and require it stays under the remote-builds root.
+
+        Raises :class:`.paths.PathEscapeError` on escape. Blocking
+        (``Path.resolve`` walks the filesystem); call from executor threads.
+        """
+        return resolve_under_root(self.subtree(config_dir), config_dir / REMOTE_BUILDS_SUBDIR)
 
     def bundle(self, config_dir: Path) -> Path:
         """Return the absolute bundle tarball path, sibling to :meth:`subtree`."""

--- a/tests/test_remote_build_layout.py
+++ b/tests/test_remote_build_layout.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from esphome_device_builder.helpers.paths import PathEscapeError
 from esphome_device_builder.helpers.remote_build_layout import (
     BUNDLE_SUFFIX,
     REMOTE_BUILDS_SUBDIR,
@@ -25,6 +26,19 @@ def test_subtree_builds_dashboard_device_path(tmp_path: Path) -> None:
     """Subtree path is ``<config>/.esphome/.remote_builds/<dashboard>/<device>/``."""
     key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
     assert key.subtree(tmp_path) == (tmp_path / ".esphome" / ".remote_builds" / "alpha" / "kitchen")
+
+
+def test_resolved_subtree_accepts_a_contained_key(tmp_path: Path) -> None:
+    """A well-formed key resolves to its subtree under the remote-builds root."""
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    assert key.resolved_subtree(tmp_path).name == "kitchen"
+
+
+def test_resolved_subtree_rejects_a_climbing_dashboard_id(tmp_path: Path) -> None:
+    """A traversing ``dashboard_id`` resolves outside the root and raises."""
+    key = RemoteBuildPath(dashboard_id="../../escape", device_name="kitchen")
+    with pytest.raises(PathEscapeError):
+        key.resolved_subtree(tmp_path)
 
 
 def test_bundle_sits_as_sibling_of_subtree(tmp_path: Path) -> None:

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -1063,11 +1063,7 @@ async def test_extract_recheck_catches_an_escape_appearing_post_ack(
         return target
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.submit_job.controller.resolve_under_root",
-        _escape_on_recheck,
-    )
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.submit_job._post_ack.resolve_under_root",
+        "esphome_device_builder.helpers.remote_build_layout.resolve_under_root",
         _escape_on_recheck,
     )
 

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -38,6 +38,7 @@ from esphome_device_builder.controllers.remote_build.submit_job.controller impor
     _validate_configuration_filename,
 )
 from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.helpers.paths import PathEscapeError
 from esphome_device_builder.helpers.peer_link_bundle import (
     BUNDLE_CHUNK_SIZE_BYTES,
     BUNDLE_MAX_TOTAL_BYTES,
@@ -1019,28 +1020,55 @@ async def test_submit_job_intermediate_chunk_no_ack(tmp_path: Path) -> None:
     session.terminate.assert_not_called()
 
 
-async def test_submit_job_path_traversal_dashboard_id_caught_at_extract(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A malicious ``dashboard_id`` shape escapes the filename validator but is caught at extract.
+async def test_submit_job_path_traversal_dashboard_id_rejected_at_header(tmp_path: Path) -> None:
+    """A malicious ``dashboard_id`` shape is refused pre-ack, before any chunk streams.
 
-    Pins the defence-in-depth resolve-and-stay-under-root check
-    inside ``_extract_and_queue``. The filename validator
-    catches separators / ``..`` in ``configuration_filename``,
-    but ``dashboard_id`` flows through unvalidated from the
-    Noise handshake / receiver-side registration. A future
-    regression there would hit this gate.
+    The filename validator catches separators / ``..`` in
+    ``configuration_filename``, but ``dashboard_id`` flows
+    through unvalidated from the Noise handshake; the header-time
+    resolve-and-stay-under-root gate is what refuses it.
     """
     firmware = _make_firmware_controller()
     receiver = _make_receiver(tmp_path, firmware)
-    # Climbing dashboard_id; the resolve-and-relative-to defense
-    # rejects because the resulting target_dir resolves outside
+    # Climbing dashboard_id; the resulting target_dir resolves outside
     # ``<config>/.esphome/.remote_builds/``.
     session = _make_session(dashboard_id="../../escape")
+
+    await receiver.handle_submit_job(session, _header())
+
+    payload = _ack_payload(session)
+    assert payload["accepted"] is False
+    assert payload["reason"] == "invalid_header"
+    session.terminate.assert_not_called()
+    assert session.dashboard_id not in receiver._inflight
+    firmware._enqueue.assert_not_called()
+
+
+async def test_extract_recheck_catches_an_escape_appearing_post_ack(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The in-executor under-root re-check still guards a post-header escape."""
+    firmware = _make_firmware_controller()
+    receiver = _make_receiver(tmp_path, firmware)
+    session = _make_session()
     bundle = b"hello"
+    checks: list[None] = []
+
+    def _escape_on_recheck(target: Path, root: Path) -> Path:
+        # First call is the pre-ack header gate; the re-check runs in
+        # the executor hop, after e.g. a symlink swap under the root.
+        if checks:
+            raise PathEscapeError(str(target))
+        checks.append(None)
+        return target
+
     monkeypatch.setattr(
-        "esphome.bundle.prepare_bundle_for_compile",
-        lambda _bundle, _target: tmp_path / "kitchen.yaml",
+        "esphome_device_builder.controllers.remote_build.submit_job.controller.resolve_under_root",
+        _escape_on_recheck,
+    )
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.submit_job._post_ack.resolve_under_root",
+        _escape_on_recheck,
     )
 
     await receiver.handle_submit_job(session, _header(bundle=bundle))
@@ -1049,7 +1077,6 @@ async def test_submit_job_path_traversal_dashboard_id_caught_at_extract(
     await _drain_extracts(receiver)
 
     frames = _sent_frames(session)
-    # The escape is caught post-ack, during extract.
     assert frames[0]["type"] == "submit_job_ack"
     assert frames[0]["accepted"] is True
     assert frames[-1]["type"] == "job_state_changed"

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -1021,13 +1021,7 @@ async def test_submit_job_intermediate_chunk_no_ack(tmp_path: Path) -> None:
 
 
 async def test_submit_job_path_traversal_dashboard_id_rejected_at_header(tmp_path: Path) -> None:
-    """A malicious ``dashboard_id`` shape is refused pre-ack, before any chunk streams.
-
-    The filename validator catches separators / ``..`` in
-    ``configuration_filename``, but ``dashboard_id`` flows
-    through unvalidated from the Noise handshake; the header-time
-    resolve-and-stay-under-root gate is what refuses it.
-    """
+    """A traversing ``dashboard_id`` is refused pre-ack with ``invalid_header``."""
     firmware = _make_firmware_controller()
     receiver = _make_receiver(tmp_path, firmware)
     # Climbing dashboard_id; the resulting target_dir resolves outside


### PR DESCRIPTION
# What does this implement/fix?

#2330 drew its seam at "has the ack been sent yet", but one genuinely wire-shape failure landed on the wrong side: `resolve_under_root(target_dir, remote_builds_root)` raising `PathEscapeError` maps to `invalid_header`, and it fired post-ack. A peer whose `dashboard_id` (unvalidated off the Noise handshake) or `configuration_filename` traverses got `accepted=True` followed by a terminal `failed` frame, a protocol violation dressed up as a build failure.

The check needs no bundle bytes (`target_dir` derives only from the session's `dashboard_id` and the header's filename stem), so it now runs at header time: the new `_resolve_device_stem` combines the existing filename gate with the resolve-and-stay-under-root check (via `run_in_executor`, since `Path.resolve` walks the filesystem) and a failing header is refused pre-ack with `invalid_header`, before the receiver streams the whole bundle.

The in-executor check inside `_validate_write_extract_bundle` stays as a defence-in-depth re-check, since the header-time resolve can be invalidated by a symlink created under the remote-builds root between ack and extract; its comment now says so. Only true receiver-side problems (`extract_failed`, `queue_rejected`) remain on the post-ack terminal path.

Tests: the traversal test flips from pinning the post-ack shape to pinning the pre-ack reject (reject ack, no terminate, nothing in-flight or queued), and a new test pins the post-ack re-check by making the resolver fail only on its second call.

**Related issue or feature (if applicable):**

- fixes #2333

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
