### PR TITLE
Preserve curated locked flags when re-importing board manifests

### DIFF
--- a/script/_board_import.py
+++ b/script/_board_import.py
@@ -407,9 +407,11 @@ def emit_manifest(record: dict[str, Any], *, boards_dir: Path) -> Path | None:
     emitted manifest and the ownership check can't disagree. Skips with a
     warning when the target already holds a manifest this source doesn't
     own — a hand-curated board (no ``source.type``) or another import
-    source's output. Images are referenced as upstream URLs in the
-    manifest itself; any pre-existing local ``images/`` subdir from older
-    syncs is removed so the wheel doesn't carry stale mirrors.
+    source's output. Curated ``locked`` flags on featured-component
+    fields carry across re-imports; values still come from upstream.
+    Images are referenced as upstream URLs in the manifest itself; any
+    pre-existing local ``images/`` subdir from older syncs is removed so
+    the wheel doesn't carry stale mirrors.
     """
     source_type = record["source"]["type"]
     target_dir = boards_dir / record["id"]
@@ -426,6 +428,8 @@ def emit_manifest(record: dict[str, Any], *, boards_dir: Path) -> Path | None:
         )
         return None
     target_dir.mkdir(parents=True, exist_ok=True)
+
+    record = _carry_curated_locks(prior, record)
 
     # Carry a hand-curated ``full_config`` opt-out/opt-in across re-imports —
     # the importer never sets it (imports derive ``full_config`` from
@@ -446,6 +450,76 @@ def emit_manifest(record: dict[str, Any], *, boards_dir: Path) -> Path | None:
 
     manifest_path.write_text(dump_manifest(record), encoding="utf-8")
     return target_dir
+
+
+def _carry_curated_locks(prior: dict[str, Any] | None, record: dict[str, Any]) -> dict[str, Any]:
+    """
+    Re-lock featured-component fields the prior manifest locked.
+
+    Matched by entry ``id`` + field name; values come from the fresh
+    record. Returns a rebuilt record; never mutates the input.
+    """
+    prior_featured = prior.get("featured_components") if prior is not None else None
+    new_featured = record.get("featured_components")
+    if not isinstance(prior_featured, list) or not isinstance(new_featured, list):
+        return record
+
+    prior_locks = _collect_locked_fields(prior_featured)
+    rebuilt_featured: list[Any] = []
+    featured_changed = False
+    for entry in new_featured:
+        locked_keys = prior_locks.get(entry.get("id", "")) if isinstance(entry, dict) else None
+        rebuilt_entry, changed = _relock_entry(entry, locked_keys)
+        featured_changed = featured_changed or changed
+        rebuilt_featured.append(rebuilt_entry)
+
+    if not featured_changed:
+        return record
+    return {
+        key: rebuilt_featured if key == "featured_components" else value
+        for key, value in record.items()
+    }
+
+
+def _collect_locked_fields(featured: list[Any]) -> dict[str, set[str]]:
+    """Map each featured entry's ``id`` to its ``locked: true`` field names."""
+    out: dict[str, set[str]] = {}
+    for entry in featured:
+        if not isinstance(entry, dict) or not isinstance(entry.get("fields"), dict):
+            continue
+        locked = {
+            fkey
+            for fkey, fval in entry["fields"].items()
+            if isinstance(fval, dict) and fval.get("locked") is True
+        }
+        if locked and isinstance(entry.get("id"), str):
+            out[entry["id"]] = locked
+    return out
+
+
+def _relock_entry(entry: Any, locked_keys: set[str] | None) -> tuple[Any, bool]:
+    """Return *entry* with every field in *locked_keys* locked, plus a changed flag."""
+    fields = entry.get("fields") if isinstance(entry, dict) else None
+    if not locked_keys or not isinstance(fields, dict):
+        return entry, False
+    rebuilt_fields: dict[str, Any] = {}
+    changed = False
+    for fkey, fval in fields.items():
+        preset, preset_changed = _lock_preset(fval) if fkey in locked_keys else (fval, False)
+        changed = changed or preset_changed
+        rebuilt_fields[fkey] = preset
+    if not changed:
+        return entry, False
+    return {**entry, "fields": rebuilt_fields}, True
+
+
+def _lock_preset(fval: Any) -> tuple[Any, bool]:
+    """Return the ``locked: true`` form of a field preset, plus a changed flag."""
+    if isinstance(fval, dict):
+        if fval.get("locked"):
+            return fval, False
+        return {**fval, "locked": True}, True
+    return {"value": fval, "locked": True}, True
 
 
 def prune_removed(active_remote_ids: set[str], *, source_type: str, boards_dir: Path) -> list[str]:

--- a/script/_board_import.py
+++ b/script/_board_import.py
@@ -452,12 +452,41 @@ def emit_manifest(record: dict[str, Any], *, boards_dir: Path) -> Path | None:
     return target_dir
 
 
+def prune_removed(active_remote_ids: set[str], *, source_type: str, boards_dir: Path) -> list[str]:
+    """Delete boards/<id>/ for any manifest this source owns that's no longer upstream."""
+    removed: list[str] = []
+    if not boards_dir.is_dir():
+        return removed
+    for child in sorted(boards_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        manifest = child / "manifest.yaml"
+        if not manifest.is_file():
+            continue
+        is_imported, remote_id = is_imported_manifest(manifest, source_type=source_type)
+        if not is_imported:
+            continue
+        if remote_id and remote_id in active_remote_ids:
+            continue
+        shutil.rmtree(child)
+        removed.append(child.name)
+    return removed
+
+
+def load_components_index() -> dict[str, dict[str, Any]]:
+    """Join the slim component index with each per-id body, keyed by component id."""
+    if not _COMPONENTS_INDEX_JSON.is_file():
+        raise SystemExit(
+            f"{_COMPONENTS_INDEX_JSON} not found — run script/sync_components.py first."
+        )
+    return load_component_catalog(_COMPONENTS_INDEX_JSON, _COMPONENTS_BODIES_DIR)
+
+
 def _carry_curated_locks(prior: dict[str, Any] | None, record: dict[str, Any]) -> dict[str, Any]:
     """
-    Re-lock featured-component fields the prior manifest locked.
+    Re-lock fields the prior manifest locked, keyed by entry ``id`` + field name.
 
-    Matched by entry ``id`` + field name; values come from the fresh
-    record. Returns a rebuilt record; never mutates the input.
+    Values come from the fresh record; the record is rebuilt, never mutated.
     """
     prior_featured = prior.get("featured_components") if prior is not None else None
     new_featured = record.get("featured_components")
@@ -516,37 +545,7 @@ def _relock_entry(entry: Any, locked_keys: set[str] | None) -> tuple[Any, bool]:
 def _lock_preset(fval: Any) -> tuple[Any, bool]:
     """Return the ``locked: true`` form of a field preset, plus a changed flag."""
     if isinstance(fval, dict):
-        if fval.get("locked"):
+        if fval.get("locked") is True:
             return fval, False
         return {**fval, "locked": True}, True
     return {"value": fval, "locked": True}, True
-
-
-def prune_removed(active_remote_ids: set[str], *, source_type: str, boards_dir: Path) -> list[str]:
-    """Delete boards/<id>/ for any manifest this source owns that's no longer upstream."""
-    removed: list[str] = []
-    if not boards_dir.is_dir():
-        return removed
-    for child in sorted(boards_dir.iterdir()):
-        if not child.is_dir():
-            continue
-        manifest = child / "manifest.yaml"
-        if not manifest.is_file():
-            continue
-        is_imported, remote_id = is_imported_manifest(manifest, source_type=source_type)
-        if not is_imported:
-            continue
-        if remote_id and remote_id in active_remote_ids:
-            continue
-        shutil.rmtree(child)
-        removed.append(child.name)
-    return removed
-
-
-def load_components_index() -> dict[str, dict[str, Any]]:
-    """Join the slim component index with each per-id body, keyed by component id."""
-    if not _COMPONENTS_INDEX_JSON.is_file():
-        raise SystemExit(
-            f"{_COMPONENTS_INDEX_JSON} not found — run script/sync_components.py first."
-        )
-    return load_component_catalog(_COMPONENTS_INDEX_JSON, _COMPONENTS_BODIES_DIR)

--- a/script/_board_import.py
+++ b/script/_board_import.py
@@ -407,7 +407,7 @@ def emit_manifest(record: dict[str, Any], *, boards_dir: Path) -> Path | None:
     emitted manifest and the ownership check can't disagree. Skips with a
     warning when the target already holds a manifest this source doesn't
     own — a hand-curated board (no ``source.type``) or another import
-    source's output. Curated ``locked`` flags on featured-component
+    source's output. Prior ``locked`` flags on featured-component
     fields carry across re-imports; values still come from upstream.
     Images are referenced as upstream URLs in the manifest itself; any
     pre-existing local ``images/`` subdir from older syncs is removed so
@@ -487,6 +487,7 @@ def _carry_curated_locks(prior: dict[str, Any] | None, record: dict[str, Any]) -
     Re-lock fields the prior manifest locked, keyed by entry ``id`` + field name.
 
     Values come from the fresh record; the record is rebuilt, never mutated.
+    A prior lock with no matching entry or field is dropped with a warning.
     """
     prior_featured = prior.get("featured_components") if prior is not None else None
     new_featured = record.get("featured_components")
@@ -494,20 +495,16 @@ def _carry_curated_locks(prior: dict[str, Any] | None, record: dict[str, Any]) -
         return record
 
     prior_locks = _collect_locked_fields(prior_featured)
-    rebuilt_featured: list[Any] = []
-    featured_changed = False
-    for entry in new_featured:
-        locked_keys = prior_locks.get(entry.get("id", "")) if isinstance(entry, dict) else None
-        rebuilt_entry, changed = _relock_entry(entry, locked_keys)
-        featured_changed = featured_changed or changed
-        rebuilt_featured.append(rebuilt_entry)
-
-    if not featured_changed:
+    if not prior_locks:
         return record
-    return {
-        key: rebuilt_featured if key == "featured_components" else value
-        for key, value in record.items()
-    }
+    _warn_unmatched_locks(record["id"], prior_locks, new_featured)
+    rebuilt = [
+        _relock_entry(
+            entry, prior_locks.get(entry.get("id", "")) if isinstance(entry, dict) else None
+        )
+        for entry in new_featured
+    ]
+    return {**record, "featured_components": rebuilt}
 
 
 def _collect_locked_fields(featured: list[Any]) -> dict[str, set[str]]:
@@ -526,26 +523,46 @@ def _collect_locked_fields(featured: list[Any]) -> dict[str, set[str]]:
     return out
 
 
-def _relock_entry(entry: Any, locked_keys: set[str] | None) -> tuple[Any, bool]:
-    """Return *entry* with every field in *locked_keys* locked, plus a changed flag."""
+def _warn_unmatched_locks(
+    board_id: str, prior_locks: dict[str, set[str]], new_featured: list[Any]
+) -> None:
+    """Warn for every prior locked field the re-import can't re-apply."""
+    fields_by_id = {
+        entry["id"]: entry.get("fields")
+        for entry in new_featured
+        if isinstance(entry, dict) and isinstance(entry.get("id"), str)
+    }
+    for entry_id, fkeys in sorted(prior_locks.items()):
+        fields = fields_by_id.get(entry_id)
+        present = fields.keys() if isinstance(fields, dict) else ()
+        for fkey in sorted(fkeys - set(present)):
+            _LOGGER.warning(
+                "%s: locked preset %s.%s from the prior manifest has no match in the "
+                "re-import; lock dropped",
+                board_id,
+                entry_id,
+                fkey,
+            )
+
+
+def _relock_entry(entry: Any, locked_keys: set[str] | None) -> Any:
+    """Return *entry* with every field in *locked_keys* locked."""
     fields = entry.get("fields") if isinstance(entry, dict) else None
     if not locked_keys or not isinstance(fields, dict):
-        return entry, False
-    rebuilt_fields: dict[str, Any] = {}
-    changed = False
-    for fkey, fval in fields.items():
-        preset, preset_changed = _lock_preset(fval) if fkey in locked_keys else (fval, False)
-        changed = changed or preset_changed
-        rebuilt_fields[fkey] = preset
-    if not changed:
-        return entry, False
-    return {**entry, "fields": rebuilt_fields}, True
+        return entry
+    return {
+        **entry,
+        "fields": {
+            fkey: _lock_preset(fval) if fkey in locked_keys else fval
+            for fkey, fval in fields.items()
+        },
+    }
 
 
-def _lock_preset(fval: Any) -> tuple[Any, bool]:
-    """Return the ``locked: true`` form of a field preset, plus a changed flag."""
+def _lock_preset(fval: Any) -> Any:
+    """Return the ``locked: true`` form of a field preset."""
     if isinstance(fval, dict):
         if fval.get("locked") is True:
-            return fval, False
-        return {**fval, "locked": True}, True
-    return {"value": fval, "locked": True}, True
+            return fval
+        return {**fval, "locked": True}
+    return {"value": fval, "locked": True}

--- a/tests/test_board_import.py
+++ b/tests/test_board_import.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import yaml
 
 from script._board_import import (
     emit_manifest,
@@ -78,6 +79,56 @@ def test_emit_manifest_preserves_full_config_override(tmp_path: Path) -> None:
     assert "full_config: false" in text
     # Re-inserted right after the esphome block, keeping key order stable.
     assert text.index("esphome:") < text.index("full_config: false") < text.index("source:")
+
+
+def test_emit_manifest_preserves_curated_locks(tmp_path: Path) -> None:
+    path = _write_manifest(tmp_path, "some_board", "source-a")
+    path.write_text(
+        path.read_text(encoding="utf-8")
+        + (
+            "featured_components:\n"
+            "- id: strip_1\n"
+            "  component_id: light.esp32_rmt_led_strip\n"
+            "  fields:\n"
+            "    chipset:\n"
+            "      value: ws2812\n"
+            "      locked: true\n"
+            "    num_leds:\n"
+            "      value: 4\n"
+            "      locked: true\n"
+            "    pin:\n"
+            "      value: 32\n"
+            "      locked: true\n"
+        ),
+        encoding="utf-8",
+    )
+    fresh_fields = {
+        "chipset": "ws2812",
+        "num_leds": 5,
+        "pin": {"value": 32, "locked": True},
+        "rgb_order": "GRB",
+    }
+    record = {
+        **_RECORD,
+        "featured_components": [
+            {
+                "id": "strip_1",
+                "component_id": "light.esp32_rmt_led_strip",
+                "fields": fresh_fields,
+            },
+            {"id": "other", "component_id": "psram", "fields": {"mode": "octal"}},
+        ],
+    }
+    assert emit_manifest(record, boards_dir=tmp_path) is not None
+    emitted = yaml.safe_load(path.read_text(encoding="utf-8"))
+    strip, other = emitted["featured_components"]
+    assert strip["fields"]["chipset"] == {"value": "ws2812", "locked": True}
+    assert strip["fields"]["num_leds"] == {"value": 5, "locked": True}
+    assert strip["fields"]["pin"] == {"value": 32, "locked": True}
+    assert strip["fields"]["rgb_order"] == "GRB"
+    assert other["fields"] == {"mode": "octal"}
+    assert fresh_fields["chipset"] == "ws2812"
+    assert fresh_fields["num_leds"] == 5
 
 
 def test_prune_removed_only_touches_own_source_type(tmp_path: Path) -> None:

--- a/tests/test_board_import.py
+++ b/tests/test_board_import.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -127,8 +128,47 @@ def test_emit_manifest_preserves_curated_locks(tmp_path: Path) -> None:
     assert strip["fields"]["pin"] == {"value": 32, "locked": True}
     assert strip["fields"]["rgb_order"] == "GRB"
     assert other["fields"] == {"mode": "octal"}
-    assert fresh_fields["chipset"] == "ws2812"
     assert fresh_fields["num_leds"] == 5
+    assert fresh_fields["pin"] == {"value": 32, "locked": True}
+
+
+def test_emit_manifest_warns_when_prior_lock_has_no_match(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    path = _write_manifest(tmp_path, "some_board", "source-a")
+    path.write_text(
+        path.read_text(encoding="utf-8")
+        + (
+            "featured_components:\n"
+            "- id: strip_gone\n"
+            "  component_id: light.esp32_rmt_led_strip\n"
+            "  fields:\n"
+            "    chipset:\n"
+            "      value: ws2812\n"
+            "      locked: true\n"
+            "- id: strip_1\n"
+            "  component_id: light.esp32_rmt_led_strip\n"
+            "  fields:\n"
+            "    num_leds:\n"
+            "      value: 4\n"
+            "      locked: true\n"
+        ),
+        encoding="utf-8",
+    )
+    record = {
+        **_RECORD,
+        "featured_components": [
+            {"id": "strip_1", "component_id": "light.esp32_rmt_led_strip", "fields": {"pin": 32}},
+        ],
+    }
+    with caplog.at_level(logging.WARNING):
+        assert emit_manifest(record, boards_dir=tmp_path) is not None
+    assert "strip_gone.chipset" in caplog.text
+    assert "strip_1.num_leds" in caplog.text
+    emitted = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert emitted["featured_components"] == [
+        {"id": "strip_1", "component_id": "light.esp32_rmt_led_strip", "fields": {"pin": 32}},
+    ]
 
 
 def test_prune_removed_only_touches_own_source_type(tmp_path: Path) -> None:


### PR DESCRIPTION
# What does this implement/fix?

The weekly device catalog sync regenerates imported manifests from upstream, which drops any curation applied on top of them; the pending sync PR #2353 reverts the locked flags #2296 put on fixed LED params (chipset, num_leds, rgb_order, data_rate) across 10 imported boards. The extraction heuristics can't reproduce that curation, since it was judged per entry (soldered onboard LEDs locked, user attached strip terminals left soft).

Teach the shared emit path to carry curated locked flags across re-imports, next to the existing full_config carry; a field the prior manifest locked stays locked, while its value still comes from upstream. A prior lock that no longer matches any entry or field logs a warning, so curation loss shows up in the sync log instead of vanishing silently. Applies to both the esphome-devices and bluetooth-proxies syncs.

Verified end to end: regenerating KinCony-KC868-Uair with the real sync now produces only the upstream_revision bump, keeping all six curated locks; regenerating KinCony-AIO (deliberately soft) stays soft.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

