### PR TITLE
Drop the adopt state seed and key mdns claims on the device-named PTR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -656,11 +656,11 @@ against legacy behaviour before assuming the simpler version suffices.
     live anchor PTR — a gate `refresh_mdns`'s drawer re-resolves share
     via `apply_resolved_addresses`. The importable adopt path
     (`devices/importable.py`) seeds no state — it applies the
-    factory broadcast's cached IP, probes the esphomelib service
-    (a same-name adopt claims mdns off the cache hit), and wakes a
-    targeted ping; a rename-during-adopt has no PTR under the
-    chosen name, so the sweep arbitrates until the flashed
-    firmware announces and mdns takes over. There is
+    factory broadcast's cached IP and probes the esphomelib
+    service (a same-name adopt claims mdns off the cache hit); a
+    rename-during-adopt has no PTR under the chosen name, so the
+    sweep arbitrates until the flashed firmware announces and
+    mdns takes over. There is
     deliberately **no** sweep re-claim of mdns ownership off SRV/A
     resolves (the #1999 resolve-first sweep manufactured un-demotable
     PTR-less claims): a PTR-lost device stays ONLINE via ping, and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -644,20 +644,21 @@ against legacy behaviour before assuming the simpler version suffices.
     PTR; a `Removed` of the winner re-opens the election on the next
     read, and both browser `Removed` branches defer to the surviving
     sibling anchor — withdrawal happens only when no anchor remains.
-    Every claim path enforces the invariant: a cache hit claims only
-    behind a live PTR (`cache_apply_or_resolve`), `_apply_service_info`
-    skips the ONLINE claim for a PTR-less wire answer (a `probe_device`
-    resolve applies its data, takes no ownership — no `Removed` could
-    ever withdraw it; in an ICMP-unavailable deployment no arbiter
+    Every claim path enforces the invariant: a cache hit claims
+    only behind a live PTR (`cache_apply_or_resolve`),
+    `_apply_service_info` claims only behind the live PTR of the
+    *device-named* service — the one whose `Removed` maps back to the
+    device — so a PTR-less wire answer and a cross-name resolve (the
+    adopt probe riding the factory service) apply their data but take
+    no ownership (in an ICMP-unavailable deployment no arbiter
     replaces the skipped claim, so such a device waits for its
-    announce), and the active resolve claims only behind the live
-    anchor PTR — a gate `refresh_mdns`'s drawer re-resolves share via
-    `apply_resolved_addresses`. One PTR-less carve-out remains, with a
-    known latch tracked for a fix: the importable adopt seed
-    (`devices/importable.py`), a UX seed under the chosen YAML name
-    while the device still broadcasts under its factory name; the
-    post-flash announce replaces it, but a renamed adopt that never
-    flashes is un-withdrawable (#2389). There is
+    announce), and the non-API active resolve claims only behind the
+    live anchor PTR — a gate `refresh_mdns`'s drawer re-resolves share
+    via `apply_resolved_addresses`. The importable adopt seed
+    (`devices/importable.py`) rides the `ping` source — a
+    rename-during-adopt has no PTR under the chosen name, so the
+    sweep arbitrates until the flashed firmware announces and mdns
+    takes over. There is
     deliberately **no** sweep re-claim of mdns ownership off SRV/A
     resolves (the #1999 resolve-first sweep manufactured un-demotable
     PTR-less claims): a PTR-lost device stays ONLINE via ping, and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -654,11 +654,13 @@ against legacy behaviour before assuming the simpler version suffices.
     replaces the skipped claim, so such a device waits for its
     announce), and the non-API active resolve claims only behind the
     live anchor PTR — a gate `refresh_mdns`'s drawer re-resolves share
-    via `apply_resolved_addresses`. The importable adopt seed
-    (`devices/importable.py`) rides the `ping` source — a
-    rename-during-adopt has no PTR under the chosen name, so the
-    sweep arbitrates until the flashed firmware announces and mdns
-    takes over. There is
+    via `apply_resolved_addresses`. The importable adopt path
+    (`devices/importable.py`) seeds no state — it applies the
+    factory broadcast's cached IP, probes the esphomelib service
+    (a same-name adopt claims mdns off the cache hit), and wakes a
+    targeted ping; a rename-during-adopt has no PTR under the
+    chosen name, so the sweep arbitrates until the flashed
+    firmware announces and mdns takes over. There is
     deliberately **no** sweep re-claim of mdns ownership off SRV/A
     resolves (the #1999 resolve-first sweep manufactured un-demotable
     PTR-less claims): a PTR-lost device stays ONLINE via ping, and the

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -540,9 +540,9 @@ class MdnsSource:
         # decides — no permanent latch. The claim rides the live PTR of
         # the *device-named* service — the one whose ``Removed`` maps
         # back to *device_name*: a PTR-less wire answer and a cross-name
-        # resolve (the adopt probe riding the factory service, #2389)
-        # apply their data below but take no ownership.
-        if self._cached_ptr(f"{device_name}.{info.type}", info.type) is not None:
+        # resolve (the adopt probe riding the factory service) apply
+        # their data below but take no ownership.
+        if self._has_live_ptr(device_name, info.type):
             monitor.apply(device_name, DeviceState.ONLINE, "mdns", claim=True)
         # Pass the full announced address set (IPv4 first, then
         # scoped IPv6 — link-local entries keep the ``%scope``

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -537,11 +537,12 @@ class MdnsSource:
         # the active-resolve path: a resolved service is liveness evidence
         # on its own (already claimed even when addressless), and the
         # browser's ``Removed`` lifecycle withdraws the claim so ping
-        # decides — no permanent latch. The claim rides a live PTR: a
-        # PTR-less wire answer (a ``probe_device`` resolve) applies its
-        # data below but takes no ownership, since no ``Removed`` could
-        # ever withdraw it.
-        if self._cached_ptr(info.name, info.type) is not None:
+        # decides — no permanent latch. The claim rides the live PTR of
+        # the *device-named* service — the one whose ``Removed`` maps
+        # back to *device_name*: a PTR-less wire answer and a cross-name
+        # resolve (the adopt probe riding the factory service, #2389)
+        # apply their data below but take no ownership.
+        if self._cached_ptr(f"{device_name}.{info.type}", info.type) is not None:
             monitor.apply(device_name, DeviceState.ONLINE, "mdns", claim=True)
         # Pass the full announced address set (IPv4 first, then
         # scoped IPv6 — link-local entries keep the ``%scope``

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -231,17 +231,24 @@ class MdnsSource:
         if self._zeroconf is None:
             return None
         cache = self._zeroconf.zeroconf.cache
-        # Decode TXT per service, esphomelib first — one freshest-of-both
-        # pick could surface web_server's contentless TXT over the
-        # identity TXT on an api+web_server device.
-        txt_dns_records: list[DNSRecord] = []
+        # Decode TXT per service, live esphomelib first — one
+        # freshest-of-both pick could surface web_server's contentless
+        # TXT over the identity TXT on an api+web_server device, while
+        # an expired esphomelib TXT (a device recompiled without
+        # ``api:``) must not shadow a live http identity TXT.
+        now_ms = current_time_millis()
+        txt_by_service: dict[str, list[DNSRecord]] = {}
         records: list[DNSRecord] = [*self._get_address_records(name)]
         for service_type in (_ESPHOME_SERVICE_TYPE, _HTTP_SERVICE_TYPE):
             service_name = f"{name}.{service_type}"
             txts = list(cache.get_all_by_details(service_name, _TYPE_TXT, _CLASS_IN))
-            txt_dns_records = txt_dns_records or txts
+            txt_by_service[service_type] = txts
             records.extend(cache.get_all_by_details(service_name, _TYPE_SRV, _CLASS_IN))
             records.extend(txts)
+        esphomelib_txts = txt_by_service[_ESPHOME_SERVICE_TYPE]
+        if not any(txt.get_remaining_ttl(now_ms) for txt in esphomelib_txts):
+            esphomelib_txts = []
+        txt_dns_records = esphomelib_txts or txt_by_service[_HTTP_SERVICE_TYPE]
         # The expiry countdown rides the ownership anchor.
         ptr = self._anchor_ptr(name)
         if ptr is not None:

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -246,7 +246,7 @@ class MdnsSource:
             records.extend(cache.get_all_by_details(service_name, _TYPE_SRV, _CLASS_IN))
             records.extend(txts)
         esphomelib_txts = txt_by_service[_ESPHOME_SERVICE_TYPE]
-        if not any(txt.get_remaining_ttl(now_ms) for txt in esphomelib_txts):
+        if all(txt.is_expired(now_ms) for txt in esphomelib_txts):
             esphomelib_txts = []
         txt_dns_records = esphomelib_txts or txt_by_service[_HTTP_SERVICE_TYPE]
         # The expiry countdown rides the ownership anchor.
@@ -259,7 +259,6 @@ class MdnsSource:
         # wants the truthful "last seen" age even when the cached
         # record has aged past its TTL. (The PTR lookup alone is
         # live-only; zeroconf's alias API filters expired entries.)
-        now_ms = current_time_millis()
         latest = max(records, key=attrgetter("created"))
         # ``DNSRecord.created`` is millis; ``get_remaining_ttl``
         # already returns seconds (impl divides by 1000.0). Don't

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -231,11 +231,13 @@ class MdnsSource:
         if self._zeroconf is None:
             return None
         cache = self._zeroconf.zeroconf.cache
-        # Decode TXT per service, live esphomelib first — one
+        # Decode TXT per service: live esphomelib wins (one
         # freshest-of-both pick could surface web_server's contentless
-        # TXT over the identity TXT on an api+web_server device, while
-        # an expired esphomelib TXT (a device recompiled without
-        # ``api:``) must not shadow a live http identity TXT.
+        # TXT over the identity TXT on an api+web_server device), then
+        # a live http TXT (an expired esphomelib TXT — a device
+        # recompiled without ``api:`` — must not shadow it), then the
+        # aged records, so the panel keeps the last-known identity the
+        # unfiltered ``records`` below deliberately preserve.
         now_ms = current_time_millis()
         txt_by_service: dict[str, list[DNSRecord]] = {}
         records: list[DNSRecord] = [*self._get_address_records(name)]
@@ -246,9 +248,10 @@ class MdnsSource:
             records.extend(cache.get_all_by_details(service_name, _TYPE_SRV, _CLASS_IN))
             records.extend(txts)
         esphomelib_txts = txt_by_service[_ESPHOME_SERVICE_TYPE]
-        if all(txt.is_expired(now_ms) for txt in esphomelib_txts):
-            esphomelib_txts = []
-        txt_dns_records = esphomelib_txts or txt_by_service[_HTTP_SERVICE_TYPE]
+        http_txts = txt_by_service[_HTTP_SERVICE_TYPE]
+        live_esphomelib = [r for r in esphomelib_txts if not r.is_expired(now_ms)]
+        live_http = [r for r in http_txts if not r.is_expired(now_ms)]
+        txt_dns_records = live_esphomelib or live_http or esphomelib_txts or http_txts
         # The expiry countdown rides the ownership anchor.
         ptr = self._anchor_ptr(name)
         if ptr is not None:
@@ -550,6 +553,12 @@ class MdnsSource:
         # their data below but take no ownership.
         if self._has_live_ptr(device_name, info.type):
             monitor.apply(device_name, DeviceState.ONLINE, "mdns", claim=True)
+        else:
+            _LOGGER.debug(
+                "mDNS resolve of %s (%s) applied data only (no live device-named PTR)",
+                device_name,
+                info.name,
+            )
         # Pass the full announced address set (IPv4 first, then
         # scoped IPv6 — link-local entries keep the ``%scope``
         # suffix). ``apply_ip_addresses`` picks the IPv4 primary

--- a/esphome_device_builder/controllers/_device_state_monitor/shared.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/shared.py
@@ -8,6 +8,7 @@ sources are reached through ``state`` and the monitor's public
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import TYPE_CHECKING
 
 from ...helpers.hostname import is_local_hostname
@@ -16,6 +17,8 @@ from ...models import Device, DeviceState, ReachabilitySource
 
 if TYPE_CHECKING:
     from .controller import DeviceStateMonitor
+
+_LOGGER = logging.getLogger(__name__)
 
 
 # Source-precedence ledger. An observation can only override the
@@ -110,6 +113,8 @@ def apply_resolved_addresses(
     # liveness stays with ping.
     if monitor.mdns.has_live_anchor_ptr(name):
         monitor.apply(name, DeviceState.ONLINE, "mdns", claim=True)
+    else:
+        _LOGGER.debug("mDNS resolve for %s applied addresses only (no live anchor PTR)", name)
     monitor.apply_ip_addresses(name, usable)
 
 

--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -153,9 +153,9 @@ async def import_device(
     # rather than blinking through OFFLINE for ~10s waiting on
     # the next ping sweep. Seeded under ``ping`` — for a
     # rename-during-adopt no PTR exists under *name*, so an mdns
-    # claim would have no ``Removed`` to withdraw it (#2389); the
-    # sweep keeps arbitrating until the flashed firmware announces
-    # and mdns takes over. Probe esphomelib too so version /
+    # claim would have no ``Removed`` to withdraw it; the sweep
+    # keeps arbitrating until the flashed firmware announces and
+    # mdns takes over. Probe esphomelib too so version /
     # config_hash / api_encryption land alongside the IP.
     controller._state_monitor.apply(name, DeviceState.ONLINE, "ping")
     cached = controller._state_monitor.mdns.get_cached_addresses(f"{mdns_name}.local")

--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -157,11 +157,13 @@ async def import_device(
     cached = controller._state_monitor.mdns.get_cached_addresses(f"{mdns_name}.local")
     if cached:
         controller._state_monitor.apply_ip_addresses(name, cached)
-    # Both broadcast names are known here: the adoption YAML pins
-    # ``name`` with the mac suffix off, so the device broadcasts
-    # under it only after its first flash — until then the factory
-    # firmware broadcasts ``mdns_name``. Probe that service and
-    # apply against ``name``.
+    # Normally ``name`` IS the live broadcast — adopt imports the
+    # device under its MAC-suffixed factory name and bakes the
+    # suffix into the literal name (``name_add_mac_suffix: false``),
+    # so the mdns name matches immediately. Only a name edited in
+    # the adopt dialog diverges: the factory service then carries
+    # the device's data until the first flash bakes in the new
+    # name, so probe by ``mdns_name`` and apply against ``name``.
     controller._state_monitor.mdns.probe_device(name, service_name=mdns_name)
     controller._state_monitor.probe_device_ping(name)
     return {"configuration": configuration}

--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -17,7 +17,6 @@ from ...helpers.json import JSONDecodeError, dumps_indent, loads
 from ...helpers.lazy_module import async_import_module
 from ...models import (
     AdoptableDevice,
-    DeviceState,
     ErrorCode,
     EventType,
     ImportableDeviceAddedData,
@@ -148,16 +147,13 @@ async def import_device(
         controller._on_importable_removed(cached_name)
     mdns_name = cached_names[0] if cached_names else name
 
-    # Skip-the-wait state seed; the device was advertising on
-    # mDNS milliseconds ago, so pin ONLINE + the cached IP now
-    # rather than blinking through OFFLINE for ~10s waiting on
-    # the next ping sweep. Seeded under ``ping`` — for a
-    # rename-during-adopt no PTR exists under *name*, so an mdns
-    # claim would have no ``Removed`` to withdraw it (#2389); the
-    # sweep keeps arbitrating until the flashed firmware announces
-    # and mdns takes over. Probe esphomelib too so version /
-    # config_hash / api_encryption land alongside the IP.
-    controller._state_monitor.apply(name, DeviceState.ONLINE, "ping")
+    # No state seed — the real sources decide. The device was
+    # advertising on mDNS milliseconds ago, so a same-name adopt
+    # claims ONLINE via the esphomelib probe's cache hit in this
+    # same call; a rename-during-adopt has no PTR under *name* (an
+    # mdns claim would have no ``Removed`` to withdraw it, #2389),
+    # so the woken sweep pings the cached IP applied below for a
+    # real verdict within seconds.
     cached = controller._state_monitor.mdns.get_cached_addresses(f"{mdns_name}.local")
     if cached:
         controller._state_monitor.apply_ip_addresses(name, cached)
@@ -167,6 +163,7 @@ async def import_device(
     # only knows the YAML name, which has no broadcast yet for
     # the rename-during-adopt case.
     controller._state_monitor.mdns.probe_device(name, service_name=mdns_name)
+    controller._state_monitor.probe_device_ping(name)
     return {"configuration": configuration}
 
 

--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -157,11 +157,11 @@ async def import_device(
     cached = controller._state_monitor.mdns.get_cached_addresses(f"{mdns_name}.local")
     if cached:
         controller._state_monitor.apply_ip_addresses(name, cached)
-    # Look up the service by ``mdns_name`` (factory firmware is
-    # still broadcasting under that) but apply against the
-    # chosen ``name``. The scan-change handler probes too but
-    # only knows the YAML name, which has no broadcast yet for
-    # the rename-during-adopt case.
+    # Both broadcast names are known here: the adoption YAML pins
+    # ``name`` with the mac suffix off, so the device broadcasts
+    # under it only after its first flash — until then the factory
+    # firmware broadcasts ``mdns_name``. Probe that service and
+    # apply against ``name``.
     controller._state_monitor.mdns.probe_device(name, service_name=mdns_name)
     controller._state_monitor.probe_device_ping(name)
     return {"configuration": configuration}

--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -151,9 +151,13 @@ async def import_device(
     # Skip-the-wait state seed; the device was advertising on
     # mDNS milliseconds ago, so pin ONLINE + the cached IP now
     # rather than blinking through OFFLINE for ~10s waiting on
-    # the next ping sweep. Probe esphomelib too so version /
+    # the next ping sweep. Seeded under ``ping`` — for a
+    # rename-during-adopt no PTR exists under *name*, so an mdns
+    # claim would have no ``Removed`` to withdraw it (#2389); the
+    # sweep keeps arbitrating until the flashed firmware announces
+    # and mdns takes over. Probe esphomelib too so version /
     # config_hash / api_encryption land alongside the IP.
-    controller._state_monitor.apply(name, DeviceState.ONLINE, "mdns", claim=True)
+    controller._state_monitor.apply(name, DeviceState.ONLINE, "ping")
     cached = controller._state_monitor.mdns.get_cached_addresses(f"{mdns_name}.local")
     if cached:
         controller._state_monitor.apply_ip_addresses(name, cached)

--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -153,9 +153,9 @@ async def import_device(
     # rather than blinking through OFFLINE for ~10s waiting on
     # the next ping sweep. Seeded under ``ping`` — for a
     # rename-during-adopt no PTR exists under *name*, so an mdns
-    # claim would have no ``Removed`` to withdraw it; the sweep
-    # keeps arbitrating until the flashed firmware announces and
-    # mdns takes over. Probe esphomelib too so version /
+    # claim would have no ``Removed`` to withdraw it (#2389); the
+    # sweep keeps arbitrating until the flashed firmware announces
+    # and mdns takes over. Probe esphomelib too so version /
     # config_hash / api_encryption land alongside the IP.
     controller._state_monitor.apply(name, DeviceState.ONLINE, "ping")
     cached = controller._state_monitor.mdns.get_cached_addresses(f"{mdns_name}.local")

--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -147,13 +147,12 @@ async def import_device(
         controller._on_importable_removed(cached_name)
     mdns_name = cached_names[0] if cached_names else name
 
-    # No state seed — the real sources decide. The device was
-    # advertising on mDNS milliseconds ago, so a same-name adopt
-    # claims ONLINE via the esphomelib probe's cache hit in this
-    # same call; a rename-during-adopt has no PTR under *name* (an
-    # mdns claim would have no ``Removed`` to withdraw it, #2389),
-    # so the woken sweep pings the cached IP applied below for a
-    # real verdict within seconds.
+    # No state seed — the real sources decide. Discovery is
+    # mDNS-based, so a same-name adopt claims ONLINE via the
+    # esphomelib probe's cache hit in this same call; a
+    # rename-during-adopt has no PTR under *name* (an mdns claim
+    # would have no ``Removed`` to withdraw it, #2389), so the
+    # regular sweep pings the cached IP applied below.
     cached = controller._state_monitor.mdns.get_cached_addresses(f"{mdns_name}.local")
     if cached:
         controller._state_monitor.apply_ip_addresses(name, cached)
@@ -165,7 +164,6 @@ async def import_device(
     # the device's data until the first flash bakes in the new
     # name, so probe by ``mdns_name`` and apply against ``name``.
     controller._state_monitor.mdns.probe_device(name, service_name=mdns_name)
-    controller._state_monitor.probe_device_ping(name)
     return {"configuration": configuration}
 
 

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -558,15 +558,7 @@ async def test_import_device_seeds_online_state_from_zeroconf_cache(
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """A freshly-adopted device should land ONLINE without waiting for ping.
-
-    The device was advertising on mDNS milliseconds ago — that's how
-    it ended up on the discovery banner — so we already know it's
-    reachable. ``import_device`` claims ONLINE via the state monitor
-    (``mdns`` priority + ``claim=True`` so a later ping observation
-    can't clobber it) and pulls the cached IP out of zeroconf so the
-    new card has an address right away.
-    """
+    """A freshly-adopted device lands ONLINE under ``ping`` with the cached IP, no mdns claim."""
     ctrl = make_controller(tmp_path)
     _seed_import_state(ctrl)
     ctrl._state_monitor = RecordingStateMonitor(
@@ -586,6 +578,41 @@ async def test_import_device_seeds_online_state_from_zeroconf_cache(
         ("get_cached_addresses", "kitchen.local"),
         ("apply_ip_addresses", "kitchen", ["192.168.1.42"]),
         ("probe_device", "kitchen", "kitchen"),
+    ]
+
+
+async def test_import_device_rename_seeds_ping_with_the_factory_broadcast(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A rename-during-adopt seeds under ``ping`` off the factory name's cache."""
+    ctrl = make_controller(tmp_path)
+    _seed_import_state(ctrl)
+    ctrl.state.import_result["apollo-plt-1-983300"] = AdoptableDevice(
+        name="apollo-plt-1-983300",
+        friendly_name="Apollo PLT-1",
+        package_import_url="github://apollo/plt-1.yaml",
+        project_name="apollo.plt-1",
+        project_version="26.3.2.1",
+        network="wifi",
+        ignored=False,
+    )
+    ctrl._state_monitor = RecordingStateMonitor(
+        cached_addresses={"apollo-plt-1-983300.local": ["192.168.1.77"]}
+    )
+
+    await ctrl.import_device(
+        name="kitchen",
+        project_name="apollo.plt-1",
+        package_import_url="github://apollo/plt-1.yaml",
+    )
+
+    assert ctrl._state_monitor.calls == [
+        ("apply", "kitchen", DeviceState.ONLINE, "ping", False),
+        ("get_cached_addresses", "apollo-plt-1-983300.local"),
+        ("apply_ip_addresses", "kitchen", ["192.168.1.77"]),
+        ("probe_device", "kitchen", "apollo-plt-1-983300"),
     ]
 
 

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -20,7 +20,7 @@ import pytest
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.controllers.editor import ValidatorUnavailableError
 from esphome_device_builder.helpers.api import CommandError
-from esphome_device_builder.models import AdoptableDevice, DeviceState, ErrorCode, EventType
+from esphome_device_builder.models import AdoptableDevice, ErrorCode, EventType
 
 from .conftest import (
     CaptureDevicesEventsFactory,
@@ -553,12 +553,12 @@ async def test_import_device_returns_even_when_post_scan_fails(
     assert result == {"configuration": "kitchen.yaml"}
 
 
-async def test_import_device_seeds_online_state_from_zeroconf_cache(
+async def test_import_device_applies_cached_ip_and_probes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """A freshly-adopted device lands ONLINE under ``ping`` with the cached IP, no mdns claim."""
+    """Adopt applies the cached IP and probes; no fabricated state, the real sources decide."""
     ctrl = make_controller(tmp_path)
     _seed_import_state(ctrl)
     ctrl._state_monitor = RecordingStateMonitor(
@@ -571,13 +571,11 @@ async def test_import_device_seeds_online_state_from_zeroconf_cache(
         package_import_url="github://x",
     )
 
-    # Full call sequence — includes the post-apply probe_device the
-    # previous MagicMock-based assertion silently let through.
     assert ctrl._state_monitor.calls == [
-        ("apply", "kitchen", DeviceState.ONLINE, "ping", False),
         ("get_cached_addresses", "kitchen.local"),
         ("apply_ip_addresses", "kitchen", ["192.168.1.42"]),
         ("probe_device", "kitchen", "kitchen"),
+        ("probe_device_ping", "kitchen"),
     ]
 
 
@@ -585,7 +583,7 @@ async def test_import_device_rename_seeds_ping_with_the_factory_broadcast(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """A rename-during-adopt seeds under ``ping`` off the factory name's cache."""
+    """A rename-during-adopt applies the factory name's cached IP and wakes ping to arbitrate."""
     ctrl = make_controller(tmp_path)
     _seed_import_state(ctrl)
     ctrl.state.import_result["apollo-plt-1-983300"] = AdoptableDevice(
@@ -608,10 +606,10 @@ async def test_import_device_rename_seeds_ping_with_the_factory_broadcast(
     )
 
     assert ctrl._state_monitor.calls == [
-        ("apply", "kitchen", DeviceState.ONLINE, "ping", False),
         ("get_cached_addresses", "apollo-plt-1-983300.local"),
         ("apply_ip_addresses", "kitchen", ["192.168.1.77"]),
         ("probe_device", "kitchen", "apollo-plt-1-983300"),
+        ("probe_device_ping", "kitchen"),
     ]
 
 
@@ -620,7 +618,7 @@ async def test_import_device_skips_apply_ip_when_zeroconf_cache_misses(
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """No cached IP → state still flips ONLINE, just no apply_ip call."""
+    """No cached IP → probes still run, just no apply_ip call."""
     ctrl = make_controller(tmp_path)
     _seed_import_state(ctrl)
     ctrl._state_monitor = RecordingStateMonitor()  # no cached addresses
@@ -632,9 +630,9 @@ async def test_import_device_skips_apply_ip_when_zeroconf_cache_misses(
     )
 
     assert ctrl._state_monitor.calls == [
-        ("apply", "kitchen", DeviceState.ONLINE, "ping", False),
         ("get_cached_addresses", "kitchen.local"),
         ("probe_device", "kitchen", "kitchen"),
+        ("probe_device_ping", "kitchen"),
     ]
 
 

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -583,7 +583,6 @@ async def test_import_device_seeds_online_state_from_zeroconf_cache(
 
 async def test_import_device_rename_seeds_ping_with_the_factory_broadcast(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
 ) -> None:
     """A rename-during-adopt seeds under ``ping`` off the factory name's cache."""

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -582,7 +582,7 @@ async def test_import_device_seeds_online_state_from_zeroconf_cache(
     # Full call sequence — includes the post-apply probe_device the
     # previous MagicMock-based assertion silently let through.
     assert ctrl._state_monitor.calls == [
-        ("apply", "kitchen", DeviceState.ONLINE, "mdns", True),
+        ("apply", "kitchen", DeviceState.ONLINE, "ping", False),
         ("get_cached_addresses", "kitchen.local"),
         ("apply_ip_addresses", "kitchen", ["192.168.1.42"]),
         ("probe_device", "kitchen", "kitchen"),
@@ -606,7 +606,7 @@ async def test_import_device_skips_apply_ip_when_zeroconf_cache_misses(
     )
 
     assert ctrl._state_monitor.calls == [
-        ("apply", "kitchen", DeviceState.ONLINE, "mdns", True),
+        ("apply", "kitchen", DeviceState.ONLINE, "ping", False),
         ("get_cached_addresses", "kitchen.local"),
         ("probe_device", "kitchen", "kitchen"),
     ]

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -578,11 +578,11 @@ async def test_import_device_applies_cached_ip_and_probes(
     ]
 
 
-async def test_import_device_rename_seeds_ping_with_the_factory_broadcast(
+async def test_import_device_rename_applies_the_factory_cached_ip_and_probes(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """A rename-during-adopt applies the factory name's cached IP and wakes ping to arbitrate."""
+    """The factory name drives the cache lookup and probe; the chosen name receives the apply."""
     ctrl = make_controller(tmp_path)
     _seed_import_state(ctrl)
     ctrl.state.import_result["apollo-plt-1-983300"] = AdoptableDevice(

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -575,7 +575,6 @@ async def test_import_device_applies_cached_ip_and_probes(
         ("get_cached_addresses", "kitchen.local"),
         ("apply_ip_addresses", "kitchen", ["192.168.1.42"]),
         ("probe_device", "kitchen", "kitchen"),
-        ("probe_device_ping", "kitchen"),
     ]
 
 
@@ -609,7 +608,6 @@ async def test_import_device_rename_seeds_ping_with_the_factory_broadcast(
         ("get_cached_addresses", "apollo-plt-1-983300.local"),
         ("apply_ip_addresses", "kitchen", ["192.168.1.77"]),
         ("probe_device", "kitchen", "apollo-plt-1-983300"),
-        ("probe_device_ping", "kitchen"),
     ]
 
 
@@ -632,7 +630,6 @@ async def test_import_device_skips_apply_ip_when_zeroconf_cache_misses(
     assert ctrl._state_monitor.calls == [
         ("get_cached_addresses", "kitchen.local"),
         ("probe_device", "kitchen", "kitchen"),
-        ("probe_device_ping", "kitchen"),
     ]
 
 

--- a/tests/test_mdns_ownership.py
+++ b/tests/test_mdns_ownership.py
@@ -81,6 +81,13 @@ def _prime_removed(monitor: Any) -> None:
     monitor.ping.wake = MagicMock()
 
 
+def _stub_no_live_ptrs(monitor: Any) -> None:
+    """Wire a zeroconf whose cache holds no live PTR for any service type."""
+    zc = MagicMock()
+    zc.zeroconf.cache.current_entry_with_name_and_alias.return_value = None
+    monitor.mdns._zeroconf = zc
+
+
 async def test_removed_marks_unknown_and_wakes_the_ping_sweep() -> None:
     """A ``Removed`` drops to UNKNOWN, releases every ledger, and nudges the ICMP sweep."""
     device = make_online_api_device()
@@ -406,6 +413,7 @@ async def test_http_removed_withdraws_a_non_api_bucket() -> None:
     monitor, _callbacks = make_state_monitor_with_callbacks([device])
     monitor.state.state_source["kitchen"] = ReachabilitySource.MDNS
     _prime_removed(monitor)
+    _stub_no_live_ptrs(monitor)
 
     _dispatch_http_removed(monitor)
 
@@ -440,6 +448,7 @@ async def test_http_removed_withdraws_when_yaml_gained_api_but_firmware_lacks_it
     monitor, _callbacks = make_state_monitor_with_callbacks([device])
     monitor.state.state_source["kitchen"] = ReachabilitySource.MDNS
     _prime_removed(monitor)
+    _stub_no_live_ptrs(monitor)
 
     _dispatch_http_removed(monitor)
 
@@ -509,6 +518,7 @@ async def test_http_removed_leaves_an_mqtt_owned_name_alone() -> None:
     monitor, callbacks = make_state_monitor_with_callbacks([device])
     monitor.state.state_source["kitchen"] = ReachabilitySource.MQTT
     _prime_removed(monitor)
+    _stub_no_live_ptrs(monitor)
 
     _dispatch_http_removed(monitor)
 

--- a/tests/test_mdns_ownership.py
+++ b/tests/test_mdns_ownership.py
@@ -536,3 +536,29 @@ def test_anchor_ptr_elects_esphomelib_first_then_http() -> None:
         lookup.side_effect = lambda type_, _alias, _live=live: _live.get(type_)
         assert monitor.mdns._anchor_ptr("kitchen") is winner, live
         assert monitor.mdns.has_live_anchor_ptr("kitchen") is (winner is not None), live
+
+
+async def test_cross_name_resolve_applies_data_but_takes_no_ownership(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The adopt probe rides the factory service; its PTR can't anchor the chosen name."""
+    device = make_online_api_device(state=DeviceState.UNKNOWN)
+    monitor, _callbacks = make_state_monitor_with_callbacks([device])
+    info = stub_async_service_info(monkeypatch, resolved=True)
+    info.name = "factory-name._esphomelib._tcp.local."
+    info.type = "_esphomelib._tcp.local."
+    zc = MagicMock()
+    # The factory service's PTR is live; the chosen name's is not.
+    zc.zeroconf.cache.current_entry_with_name_and_alias.side_effect = lambda _type, alias: (
+        MagicMock() if alias.startswith("factory-name.") else None
+    )
+    monitor.mdns._zeroconf = zc
+
+    verdict = await monitor.mdns.resolve_then(
+        MagicMock(), info, "kitchen", monitor.mdns._apply_service_info
+    )
+
+    assert verdict is True
+    assert device.runtime_state.state == DeviceState.UNKNOWN
+    assert "kitchen" not in monitor.state.state_source
+    assert device.runtime_state.deployed_version == "2026.7.0"

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -806,6 +806,38 @@ def test_get_mdns_cache_info_prefers_the_esphomelib_txt_over_a_fresher_http_txt(
         zc.close()
 
 
+def test_get_mdns_cache_info_expired_esphomelib_txt_yields_to_a_live_http_txt() -> None:
+    """A dead esphomelib TXT (device recompiled without api) can't shadow live http identity."""
+    zc = Zeroconf(interfaces=["127.0.0.1"])
+    try:
+        expired_esphomelib_txt = DNSText(
+            name="kitchen._esphomelib._tcp.local.",
+            type_=_TYPE_TXT,
+            class_=_CLASS_IN,
+            ttl=120,
+            text=bytes([len(b"version=2025.4.0")]) + b"version=2025.4.0",
+            created=current_time_millis() - 500_000,
+        )
+        live_http_txt = DNSText(
+            name="kitchen._http._tcp.local.",
+            type_=_TYPE_TXT,
+            class_=_CLASS_IN,
+            ttl=4500,
+            text=bytes([len(b"version=2026.7.2")]) + b"version=2026.7.2",
+            created=current_time_millis() - 2_000,
+        )
+        zc.cache.async_add_records([expired_esphomelib_txt, live_http_txt])
+
+        monitor = _make_monitor([_make_device()], None)
+        monitor.mdns._zeroconf = MagicMock(zeroconf=zc)
+
+        info = monitor.mdns.get_mdns_cache_info("kitchen")
+        assert info is not None
+        assert info.txt_records == {"version": "2026.7.2"}
+    finally:
+        zc.close()
+
+
 def test_get_mdns_cache_info_sorts_txt_records_for_wire_stability() -> None:
     """
     Identical TXT content in any input order produces the same dict.

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -806,6 +806,38 @@ def test_get_mdns_cache_info_prefers_the_esphomelib_txt_over_a_fresher_http_txt(
         zc.close()
 
 
+def test_get_mdns_cache_info_keeps_the_aged_esphomelib_txt_when_nothing_is_live() -> None:
+    """With every TXT expired the panel keeps last-known identity instead of going empty."""
+    zc = Zeroconf(interfaces=["127.0.0.1"])
+    try:
+        expired_esphomelib_txt = DNSText(
+            name="kitchen._esphomelib._tcp.local.",
+            type_=_TYPE_TXT,
+            class_=_CLASS_IN,
+            ttl=120,
+            text=bytes([len(b"version=2025.4.0")]) + b"version=2025.4.0",
+            created=current_time_millis() - 500_000,
+        )
+        expired_http_txt = DNSText(
+            name="kitchen._http._tcp.local.",
+            type_=_TYPE_TXT,
+            class_=_CLASS_IN,
+            ttl=120,
+            text=bytes([len(b"path=/")]) + b"path=/",
+            created=current_time_millis() - 400_000,
+        )
+        zc.cache.async_add_records([expired_esphomelib_txt, expired_http_txt])
+
+        monitor = _make_monitor([_make_device()], None)
+        monitor.mdns._zeroconf = MagicMock(zeroconf=zc)
+
+        info = monitor.mdns.get_mdns_cache_info("kitchen")
+        assert info is not None
+        assert info.txt_records == {"version": "2025.4.0"}
+    finally:
+        zc.close()
+
+
 def test_get_mdns_cache_info_expired_esphomelib_txt_yields_to_a_live_http_txt() -> None:
     """A dead esphomelib TXT (device recompiled without api) can't shadow live http identity."""
     zc = Zeroconf(interfaces=["127.0.0.1"])


### PR DESCRIPTION
# What does this implement/fix?

Close the last PTR-less mdns claim, following #2393 (now rebased onto its merge). Adopting an importable device under a different name than its factory broadcast seeded an mdns ONLINE claim under the chosen name; no PTR exists for that name, so no `Removed` could ever withdraw it, and a renamed adopt that never flashed sat ONLINE indefinitely.

Two changes:

- The adopt path seeds no state at all — the real sources decide. Discovery is mDNS-based, so the device was broadcasting milliseconds ago: a same-name adopt claims ONLINE via the esphomelib probe's synchronous cache hit in the same call, and a rename-during-adopt (whose chosen name has no PTR) gets the factory broadcast's cached IP applied and is arbitrated by the regular ping sweep instead of holding a fabricated ONLINE. The drawer never shows a ping that didn't run.
- `_apply_service_info`'s claim gate now keys on the **device-named** service's PTR — the one whose `Removed` maps back to the device — instead of the resolved service's. The post-adopt probe rides the factory service (whose PTR is live), and under the old gate that cross-name resolve would have re-created the un-withdrawable claim; it now applies its data (version / config_hash / IP, the probe's purpose) and takes no ownership. For every other caller the resolved service and the device name agree, so nothing else changes.

With this, no PTR-less mdns claim path remains, and the CLAUDE.md invariant bullet drops its last carve-out.

Also carries the accepted review follow-ups from #2393's final round (maintainer's call moved them here rather than blocking that merge): the drawer's TXT panel picks live esphomelib TXT first, then live `_http._tcp` identity TXT, then the aged records (so a device recompiled without `api:` doesn't show a dead version forever, and an all-expired cache keeps last-known identity instead of emptying the panel); debug logs when a successful resolve is denied the mdns claim for lack of a live PTR (both gated claim sites); and the three http-withdrawal tests now stub the PTR lookup explicitly instead of riding `_zeroconf is None`. The proxy-served-PTR deferral edge case was reviewed and deliberately deferred (#2406).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2389

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
