### PR TITLE
Pass OTA address-cache args when loaded_integrations is still unknown

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -350,8 +350,13 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         # build that doesn't read them is harmless. Devices loading
         # neither (e.g. MQTT-only configs) flash via paths that don't
         # take a host/port at all, so the cache args are noise there.
+        # An empty list is *unknown*, not known-no-OTA: it means the
+        # StorageJSON hasn't been read yet (never compiled, or the
+        # post-compile refresh is a spawned task the dependent upload
+        # can outrun), so pass the args rather than dropping them on
+        # the device's very first flash.
         loaded = device.loaded_integrations
-        if "api" not in loaded and "web_server" not in loaded:
+        if loaded and "api" not in loaded and "web_server" not in loaded:
             return []
         return _build_address_cache_args(device, self._state_monitor)
 

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -334,8 +334,9 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         """
         Return ``--mdns/--dns-address-cache`` CLI args for *configuration*.
 
-        Empty list when the device is unknown, has no OTA-capable
-        integration loaded, or has no cached IP available.
+        Empty list when the device is unknown, known to load no
+        OTA-capable integration, or has no cached IP available; an
+        empty ``loaded_integrations`` counts as unknown, not no-OTA.
         """
         # Keyed on the YAML filename; the esphome name can differ from the stem.
         device = self.get_by_configuration(configuration)
@@ -350,11 +351,9 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         # build that doesn't read them is harmless. Devices loading
         # neither (e.g. MQTT-only configs) flash via paths that don't
         # take a host/port at all, so the cache args are noise there.
-        # An empty list is *unknown*, not known-no-OTA: it means the
-        # StorageJSON hasn't been read yet (never compiled, or the
-        # post-compile refresh is a spawned task the dependent upload
-        # can outrun), so pass the args rather than dropping them on
-        # the device's very first flash.
+        # An empty list is *unknown*, not known-no-OTA — StorageJSON
+        # not read yet (never compiled, or the post-compile refresh
+        # lost the race to the dependent upload) — so pass the args.
         loaded = device.loaded_integrations
         if loaded and "api" not in loaded and "web_server" not in loaded:
             return []

--- a/tests/controllers/firmware/test_address_cache.py
+++ b/tests/controllers/firmware/test_address_cache.py
@@ -210,12 +210,7 @@ def test_get_address_cache_args_skipped_for_neither_api_nor_web_server() -> None
 
 
 def test_get_address_cache_args_passes_cache_for_unknown_integrations() -> None:
-    """Empty ``loaded_integrations`` is unknown, not known-no-OTA — pass the args.
-
-    A never-compiled device (fresh adopt) reads its integrations from
-    a StorageJSON that doesn't exist yet, and the post-compile refresh
-    is a spawned task the dependent upload can outrun.
-    """
+    """Empty ``loaded_integrations`` is unknown, not known-no-OTA — the args still pass."""
     controller = _devices_controller_with(_device(loaded_integrations=[]))
 
     args = controller.get_address_cache_args("kitchen.yaml")

--- a/tests/controllers/firmware/test_address_cache.py
+++ b/tests/controllers/firmware/test_address_cache.py
@@ -209,6 +209,20 @@ def test_get_address_cache_args_skipped_for_neither_api_nor_web_server() -> None
     assert args == []
 
 
+def test_get_address_cache_args_passes_cache_for_unknown_integrations() -> None:
+    """Empty ``loaded_integrations`` is unknown, not known-no-OTA — pass the args.
+
+    A never-compiled device (fresh adopt) reads its integrations from
+    a StorageJSON that doesn't exist yet, and the post-compile refresh
+    is a spawned task the dependent upload can outrun.
+    """
+    controller = _devices_controller_with(_device(loaded_integrations=[]))
+
+    args = controller.get_address_cache_args("kitchen.yaml")
+
+    assert args == ["--mdns-address-cache", "kitchen.local=192.168.1.50"]
+
+
 def test_get_address_cache_args_unknown_configuration_returns_empty() -> None:
     """Unknown filename → empty list, no exception.
 


### PR DESCRIPTION
# What does this implement/fix?

`get_address_cache_args` treated an empty `loaded_integrations` the same as a config known to load neither `api` nor `web_server`, and returned no OTA address-cache args. But an empty list is *unknown*, not known-no-OTA: `loaded_integrations` comes only from StorageJSON, which doesn't exist for a never-compiled device, and the post-compile refresh that fills it is a spawned background task with executor hops. The install chain releases the dependent UPLOAD synchronously inside the compile's `JOB_COMPLETED` fire (`release_dependents`), so the very first upload of a freshly adopted device routinely builds its command before the refresh lands and gets no `--mdns-address-cache` args at all.

For a same-name adopt that only costs a redundant live resolve, but for a renamed adopt (hole 3 of #2412) the new hostname isn't broadcast yet, so the dropped cache args turn the first install into a resolution failure that a bare retry then passes.

The gate now skips only when `loaded_integrations` is non-empty and lacks both OTA-capable integrations. Passing the args to a build that doesn't read them is harmless (the existing comment already states this); the regression test pins that an empty list with a known address still yields the cache args.

Part of #2412 (the cache-args race); the adopt-then-rename flow lands separately in the frontend.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder/issues/2412

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#1533

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
