### PR TITLE
Carve deprecated and renamed keys out of the pass-through rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -745,7 +745,11 @@ against legacy behaviour before assuming the simpler version suffices.
   `esphome.board`, renamed fields like `wifi.use_address`); refusing the
   write strands the user. Validate *our* outputs (`generate_device_yaml`,
   `generate_minimal_stub_yaml`, `dashboard_import.import_config`, clone's
-  leaf rewrites) but pass user-supplied content through unchanged. PR
+  leaf rewrites) but pass user-supplied content through unchanged —
+  except keys esphome has deprecated or renamed: when an editor write
+  already touches a block spelled with a legacy key the catalog marks
+  as renamed, respell that block to canonical in the same edit rather
+  than preserving the dead spelling. PR
   #412 reverses #405's overzealous validation on `create_device`'s
   `file_content` branch and pins the legacy-config acceptance contract.
   The next compile / install surfaces real schema errors with line


### PR DESCRIPTION
# What does this implement/fix?

Adds the carve-out to the pass-user-content-through-unchanged rule: keys esphome has deprecated or renamed are the exception. When an editor write already touches a block spelled with a legacy key the catalog marks as renamed, the writer respells that block to canonical in the same edit instead of preserving the dead spelling. Companion to #2415, which implements the behavior for `api: services:`.

**Related issue or feature (if applicable):**

- related to #2396

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
