### PR TITLE
Floor automation enrichment in the catalog smoke

### DIFF
--- a/script/check_catalog.py
+++ b/script/check_catalog.py
@@ -27,6 +27,7 @@ Run locally:
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 from typing import Any
@@ -232,6 +233,7 @@ def main() -> int:  # noqa: C901
     failures.extend(_check_gating_floors(all_bodies))
     failures.extend(_check_no_field_bullet_descriptions(catalog))
     failures.extend(_check_boolean_options_exclusive(all_bodies))
+    failures.extend(_check_automation_enrichment_floor())
 
     if failures:
         print(f"FAIL: {len(failures)} catalog regression(s):")
@@ -309,6 +311,41 @@ _GATING_FLOORS: dict[str, int] = {
     "web_server": 2000,
     "zigbee": 1600,
 }
+
+# Catalog-wide floor on automation entries carrying live-introspection
+# enrichment (unit_options / display_format / range). A component import
+# silently failing mid-sweep de-refines its actions; wholesale loss
+# lands the count under the floor and reds the sync smoke. Sits well
+# below the live count (149 at introduction) so legitimate churn
+# passes; the band test keeps it calibrated from both sides.
+_AUTOMATION_ENRICHMENT_FLOOR = 100
+
+
+def _check_automation_enrichment_floor() -> list[str]:
+    """Fail when refinement-shaped automation enrichment falls below the floor."""
+    enriched = count_enriched_automation_entries()
+    if enriched >= _AUTOMATION_ENRICHMENT_FLOOR:
+        return []
+    return [
+        (
+            f"automation enrichment count {enriched} fell below floor "
+            f"{_AUTOMATION_ENRICHMENT_FLOOR} — a component import likely failed "
+            "mid-sweep, de-refining its actions"
+        )
+    ]
+
+
+def count_enriched_automation_entries() -> int:
+    """Count action / condition fields carrying refinement-shaped enrichment."""
+    base = Path(__file__).parent.parent / "esphome_device_builder" / "definitions" / "automations"
+    count = 0
+    for sub in ("actions", "conditions"):
+        for body_path in sorted((base / sub).glob("*.json")):
+            body = json.loads(body_path.read_text(encoding="utf-8"))
+            for entry in body.get("config_entries") or []:
+                if entry.get("unit_options") or entry.get("display_format") or entry.get("range"):
+                    count += 1
+    return count
 
 
 def _resolve_field(component: Any, path: str) -> Any:

--- a/tests/test_check_catalog_guards.py
+++ b/tests/test_check_catalog_guards.py
@@ -8,11 +8,14 @@ from typing import Any
 import pytest
 
 from esphome_device_builder.controllers.components import ComponentCatalog
+from script import check_catalog
 from script.check_catalog import (  # type: ignore[import-not-found]
+    _AUTOMATION_ENRICHMENT_FLOOR,
     _GATING_FLOORS,
     _check_boolean_options_exclusive,
     _check_gating_floors,
     _load_body_from_disk,
+    count_enriched_automation_entries,
 )
 
 pytestmark = pytest.mark.xdist_group("catalog")
@@ -119,3 +122,24 @@ def test_boolean_options_exclusive_reports_a_missing_body() -> None:
     assert _check_boolean_options_exclusive([("gone", None)]) == [
         "boolean/options check: missing body for gone"
     ]
+
+
+def test_automation_enrichment_floor_sits_in_a_sane_band() -> None:
+    """A floor typo (100 -> 10, or above live) fails here, not in the field."""
+    live = count_enriched_automation_entries()
+    assert live >= _AUTOMATION_ENRICHMENT_FLOOR, (
+        f"floor {_AUTOMATION_ENRICHMENT_FLOOR} above live count {live}: the sync smoke "
+        "would fire spuriously — lower it in script/check_catalog.py"
+    )
+    assert live // 4 <= _AUTOMATION_ENRICHMENT_FLOOR, (
+        f"floor {_AUTOMATION_ENRICHMENT_FLOOR} drifted far below live count {live} — "
+        "the catalog grew; bump it in script/check_catalog.py"
+    )
+
+
+def test_automation_enrichment_floor_reds_on_wholesale_loss(monkeypatch) -> None:
+    """A de-refined catalog fails the check with an actionable message."""
+    monkeypatch.setattr(check_catalog, "count_enriched_automation_entries", lambda: 3)
+    failures = check_catalog._check_automation_enrichment_floor()
+    assert len(failures) == 1
+    assert "import likely failed" in failures[0]


### PR DESCRIPTION
# What does this implement/fix?

The empty refinements guard was global, so one component whose import the sweep silently failed still shipped its actions de refined at exit 0. The fix is test coverage, not runtime machinery: `check_catalog.py` gains an automation enrichment floor, counting action and condition fields that carry refinement shaped enrichment (`unit_options`, `display_format`, `range`; 149 live today, floor 100) and failing the sync smoke with an actionable message when wholesale de refinement drops the count under it. The floor follows the `_GATING_FLOORS` pattern, including the band test that keeps it calibrated from both sides as the catalog grows, and a red path test pins the failure message. Single field losses on key components stay covered by the existing per field shipped pins.

The issue's second item, the redundant function local `SimpleNamespace` import, was already removed by a ruff pass in an earlier PR.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2382

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
