### PR TITLE
Collapse the doubled period in the validation-failure message

### DIFF
--- a/esphome_device_builder/controllers/devices/mutations_yaml.py
+++ b/esphome_device_builder/controllers/devices/mutations_yaml.py
@@ -197,12 +197,13 @@ async def validate_rewritten_yaml_or_raise(
             if on_failure is ErrorCode.INTERNAL_ERROR
             else ". Fix the errors in the editor and try again."
         )
+        body = "; ".join(shown) + suffix
+        # esphome messages often end with their own period; the tail
+        # brings the sentence break.
+        body = body.removesuffix(".")
         raise CommandError(
             on_failure,
-            f"Can't {action} — config doesn't validate: "
-            + "; ".join(shown)
-            + suffix
-            + message_tail,
+            f"Can't {action} — config doesn't validate: " + body + message_tail,
         )
     finally:
         if not succeeded and on_error_cleanup is not None:

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -346,6 +346,34 @@ async def test_import_device_rejects_when_imported_yaml_does_not_validate(
     assert ctrl._scanner.calls == []
 
 
+async def test_import_device_validation_message_collapses_the_period(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """An esphome error ending in a period doesn't double up against the tail."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    _seed_import_state(ctrl)
+    ctrl._db.editor.validate_yaml = AsyncMock(
+        return_value={
+            "yaml_errors": [],
+            "validation_errors": [
+                {"message": "gl-s10.yaml does not exist in repository."},
+            ],
+        }
+    )
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.import_device(
+            name="kitchen",
+            project_name="x",
+            package_import_url="github://x",
+        )
+
+    assert "repository. Fix the errors" in excinfo.value.message
+    assert ".." not in excinfo.value.message
+
+
 async def test_import_device_rolls_back_on_unicode_decode_error_from_read(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
# What does this implement/fix?

esphome's validation errors often carry their own trailing period ("gl-s10.yaml does not exist in repository."), and `_validate_rewritten_yaml_or_raise` appends a tail that starts with one, so the adopt dialog shows "…does not exist in repository.. Fix the errors in the editor and try again." The joined body now drops a single trailing period and lets the tail bring the sentence break; a test pins the collapsed join.

**Related issue or feature (if applicable):**

- cosmetic message fix, no linked issue

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
