### PR TITLE
Scope extends cycles per ref and substitute shed refinements

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -2613,8 +2613,8 @@ def build_component_entry(
         # item ``address``). Hub builds keep them.
         bleed = (introspection.get("field_range_bleed_keys") or {}).get(domain, set())
         field_ranges = {k: v for k, v in field_ranges.items() if k not in bleed}
-        refined_bleed = (introspection.get("refined_bleed_keys") or {}).get(domain, set())
-        refined_types = {k: v for k, v in refined_types.items() if k not in refined_bleed}
+        refined_bleed = (introspection.get("refined_bleed_keys") or {}).get(domain, {})
+        refined_types = _shed_refined_bleed(refined_types, refined_bleed)
     # Refined types first: the range gate reads the entry's final type,
     # and a field promoted to float_with_unit must keep its bounds.
     _apply_refined_types(config_entries, refined_types)
@@ -2806,13 +2806,15 @@ def _promote_template_controls(component_id: str, entries: list[dict]) -> None:
 
 def _merge_extends_config_vars(
     schema_node: dict, schema_dir: Path, _seen_refs: frozenset[str] = frozenset()
-) -> tuple[dict[str, Any], frozenset[str]]:
+) -> tuple[dict[str, Any], dict[str, str]]:
     """
     Deep-merge a schema node's ``extends`` ancestry with its local config_vars.
 
-    Returns the merged fields plus the keys drawn exclusively from the
-    ancestry, so the caller can scope cycle-breaking to the inherited
-    subtree; a locally-overridden key counts as local.
+    Returns the merged fields plus a map from each key drawn exclusively
+    from the ancestry to the ref it resolved through, so the caller can
+    scope cycle-breaking per ref; a locally-overridden key counts as
+    local. A key several refs provide is attributed to the last, matching
+    the merge's last-wins resolution.
 
     Per-field, not whole-field: a partial override like ``{"default": "x"}``
     keeps the base's inherited ``type`` / enum / docs. Values are usually field
@@ -2824,10 +2826,13 @@ def _merge_extends_config_vars(
     """
     config_vars = dict(schema_node.get("config_vars") or {})
     extended: dict[str, dict] = {}
+    origin_ref: dict[str, str] = {}
     for ref in schema_node.get("extends") or []:
         if ref in _seen_refs:
             continue
-        extended.update(_resolve_extends(ref, schema_dir))
+        resolved = _resolve_extends(ref, schema_dir)
+        extended.update(resolved)
+        origin_ref.update(dict.fromkeys(resolved, ref))
     merged: dict[str, Any] = {}
     for key in {*extended, *config_vars}:
         base = extended.get(key)
@@ -2836,7 +2841,7 @@ def _merge_extends_config_vars(
             merged[key] = {**base, **local}
         else:
             merged[key] = local if local is not None else base or {}
-    return merged, frozenset(set(extended) - set(config_vars))
+    return merged, {key: ref for key, ref in origin_ref.items() if key not in config_vars}
 
 
 def _convert_config_vars(
@@ -2852,12 +2857,7 @@ def _convert_config_vars(
     ``_seen_refs`` is threaded to break self-referential ``extends`` cycles; see
     :func:`_merge_extends_config_vars`.
     """
-    merged, inherited_keys = _merge_extends_config_vars(schema_node, schema_dir, _seen_refs)
-    # A ref is a cycle only within its own expansion subtree: inherited
-    # fields carry it as seen, a *local* field re-extending the same ref
-    # is legitimate reuse (combination's kalman ``std_dev`` re-extends
-    # the sensor schema its platform root also extends).
-    seen_refs = _seen_refs | frozenset(schema_node.get("extends") or [])
+    merged, inherited_ref = _merge_extends_config_vars(schema_node, schema_dir, _seen_refs)
 
     out: list[dict] = []
     for key, raw in merged.items():
@@ -2880,12 +2880,19 @@ def _convert_config_vars(
         # keys (docs, help link) survive (font.file).
         recovered = _RAW_NODE_OVERRIDES.get((component_id, key))
         field_raw = {**(raw or {}), **recovered} if recovered is not None else (raw or {})
+        # A ref is a cycle only within its own expansion subtree: an
+        # inherited field carries just the ref it resolved through, so a
+        # sibling ref on the same node stays expandable beneath it and a
+        # *local* field re-extending the same ref is legitimate reuse
+        # (combination's kalman ``std_dev`` re-extends the sensor schema
+        # its platform root also extends).
+        ref = inherited_ref.get(key)
         entry = _convert_field(
             key,
             field_raw,
             schema_dir,
             top_level=bool(component_id),
-            _seen_refs=seen_refs if key in inherited_keys else _seen_refs,
+            _seen_refs=_seen_refs if ref is None else _seen_refs | {ref},
         )
         if entry is None:
             continue
@@ -4750,13 +4757,15 @@ def _upgrade_stamp_only_refinements(
 def _collect_bleed_keys(
     manifest: Any,
     platform_manifests_by_domain: list[tuple[str, Any]],
-) -> tuple[dict[str, set[tuple[str, ...]]], dict[str, set[tuple[str, ...]]]]:
+) -> tuple[dict[str, set[tuple[str, ...]]], dict[str, dict[tuple[str, ...], RefinedType | None]]]:
     """Per-domain hub signals a platform schema redefines, for platform builds to shed.
 
     Ranges shed when the platform redefines the key unbounded; refined
     types shed when the platform's own refinement differs (the
     modbus_controller hub's ``cv.hex_uint8_t`` ``address`` vs the platform
-    item's plain ``cv.positive_int``). Keyed per platform domain, not
+    item's plain ``cv.positive_int``), each shed path mapping to the
+    platform's own refinement (``None`` when it has none) so the build
+    substitutes rather than dropping. Keyed per platform domain, not
     aggregated: one platform's redefinition must not spare a sibling
     platform from the shed. Hub builds keep every signal. Covers
     hub-to-platform bleed only; a sibling platform's contribution rides
@@ -4765,7 +4774,7 @@ def _collect_bleed_keys(
     hub_ranges = _collect_field_ranges(manifest)
     hub_refined = _collect_refined_types(manifest)
     range_bleed: dict[str, set[tuple[str, ...]]] = {}
-    refined_bleed: dict[str, set[tuple[str, ...]]] = {}
+    refined_bleed: dict[str, dict[tuple[str, ...], RefinedType | None]] = {}
     for domain, platform_manifest in platform_manifests_by_domain:
         keys = _platform_field_keys([platform_manifest])
         bounded = set(_collect_field_ranges(platform_manifest))
@@ -4777,13 +4786,23 @@ def _collect_bleed_keys(
         list_keys = _platform_field_keys([platform_manifest], descend_list_items=True)
         platform_refined = _collect_refined_types(platform_manifest)
         refined_bled = {
-            path
+            path: platform_refined.get(path)
             for path in hub_refined
             if path in list_keys and platform_refined.get(path) != hub_refined[path]
         }
         if refined_bled:
             refined_bleed[domain] = refined_bled
     return range_bleed, refined_bleed
+
+
+def _shed_refined_bleed(
+    refined_types: dict[tuple[str, ...], RefinedType],
+    refined_bleed: dict[tuple[str, ...], RefinedType | None],
+) -> dict[tuple[str, ...], RefinedType]:
+    """Drop shed hub refinements, substituting the platform's own where it has one."""
+    return {k: v for k, v in refined_types.items() if k not in refined_bleed} | {
+        k: v for k, v in refined_bleed.items() if v is not None
+    }
 
 
 def introspect_component(component_id: str) -> dict[str, Any]:

--- a/tests/test_sync_components_extends_cycle.py
+++ b/tests/test_sync_components_extends_cycle.py
@@ -47,7 +47,43 @@ def test_merge_extends_skips_seen_refs() -> None:
         node, Path("/nonexistent"), frozenset({"CYCLE"})
     )
     assert set(merged) == {"local"}
-    assert inherited == frozenset()
+    assert inherited == {}
+
+
+def test_merge_extends_attributes_inherited_keys_per_ref(monkeypatch) -> None:
+    """Each inherited key maps to its own ref; a multi-ref key takes the merge-winning last one."""
+
+    def fake_resolve(ref: str, schema_dir: Path) -> dict:
+        return {
+            "A": {"a_field": {"key": "Optional"}, "shared": {"key": "Optional"}},
+            "B": {"b_field": {"key": "Optional"}, "shared": {"key": "Required"}},
+        }.get(ref, {})
+
+    monkeypatch.setattr(sync_components, "_resolve_extends", fake_resolve)
+
+    node = {"extends": ["A", "B"], "config_vars": {"a_field": {"key": "Required"}}}
+    merged, inherited = sync_components._merge_extends_config_vars(node, Path("/nonexistent"))
+
+    assert merged["shared"] == {"key": "Required"}
+    assert inherited == {"b_field": "B", "shared": "B"}
+
+
+def test_sibling_ref_stays_expandable_under_an_inherited_field(monkeypatch) -> None:
+    """A field inherited from one ref may nest-extend a sibling ref listed on the same node."""
+
+    def fake_resolve(ref: str, schema_dir: Path) -> dict:
+        if ref == "A":
+            return {"child": {"key": "Optional", "type": "schema", "schema": {"extends": ["B"]}}}
+        if ref == "B":
+            return {"leaf": {"key": "Optional", "type": "string"}}
+        return {}
+
+    monkeypatch.setattr(sync_components, "_resolve_extends", fake_resolve)
+
+    entries = sync_components._convert_config_vars({"extends": ["A", "B"]}, Path("/nonexistent"))
+
+    child = next(e for e in entries if e["key"] == "child")
+    assert [e["key"] for e in child["config_entries"]] == ["leaf"]
 
 
 def test_get_esphome_loader_primes_core_target_platform(monkeypatch) -> None:

--- a/tests/test_sync_components_hex_display.py
+++ b/tests/test_sync_components_hex_display.py
@@ -222,7 +222,11 @@ def test_hub_refinement_bleed_is_shed_for_platform_builds() -> None:
     from script.sync_components import introspect_component  # noqa: PLC0415
 
     introspection = introspect_component("modbus_controller")
-    assert ("address",) in introspection.get("refined_bleed_keys", {}).get("sensor", set())
+    shed = introspection.get("refined_bleed_keys", {}).get("sensor", {})
+    assert ("address",) in shed
+    # The platform item's ``cv.positive_int`` carries no refinement of its
+    # own, so the shed drops the hub's hex outright.
+    assert shed[("address",)] is None
 
 
 def test_shipped_catalog_modbus_platform_address_stays_decimal() -> None:
@@ -291,4 +295,31 @@ def test_bleed_guard_sees_list_item_paths() -> None:
         )
     )
     _range_bleed, refined_bleed = _collect_bleed_keys(hub, [("sensor", platform)])
-    assert ("items", "addr") in refined_bleed.get("sensor", set())
+    assert ("items", "addr") in refined_bleed.get("sensor", {})
+
+
+def test_shed_path_substitutes_the_platforms_own_refinement() -> None:
+    """A shed path where the platform refines differently maps to the platform's refinement."""
+    from script.sync_components import _collect_bleed_keys  # noqa: PLC0415
+
+    hub = SimpleNamespace(config_schema=cv.Schema({cv.Optional("threshold"): cv.hex_int}))
+    platform = SimpleNamespace(config_schema=cv.Schema({cv.Optional("threshold"): cv.frequency}))
+    _range_bleed, refined_bleed = _collect_bleed_keys(hub, [("sensor", platform)])
+    substitute = refined_bleed["sensor"][("threshold",)]
+    assert substitute is not None
+    assert substitute.type == "float_with_unit"
+
+
+def test_shed_refined_bleed_substitutes_and_drops() -> None:
+    """The shed keeps unshed paths, substitutes typed platform refinements, drops the rest."""
+    from script.sync_components import _shed_refined_bleed  # noqa: PLC0415
+
+    hub_hex = RefinedType("integer", display_format="hex")
+    platform_own = RefinedType("float_with_unit", unit_options=["Hz"])
+    refined_types = {
+        ("kept",): hub_hex,
+        ("substituted",): hub_hex,
+        ("dropped",): hub_hex,
+    }
+    shed = _shed_refined_bleed(refined_types, {("substituted",): platform_own, ("dropped",): None})
+    assert shed == {("kept",): hub_hex, ("substituted",): platform_own}


### PR DESCRIPTION
# What does this implement/fix?

Two forward correctness fixes from the #2391 and #2402 reviews, done together because both refine how per domain signals are scoped.

The extends cycle guard was per node: every inherited key carried all of its node's refs as seen, so a field inherited from one ref could not nest extend a sibling ref listed on the same node. `_merge_extends_config_vars` now attributes each inherited key to the ref it resolved through (last wins for a key several refs provide, matching the merge), and the converter passes only that ref as seen for the key; self referential cycles stay guarded exactly as before.

The refined type bleed shed subtracted the hub's refinement for a platform build but never substituted the platform's own: keep first merging meant a path both sides refine differently ended up with no refinement at all. `_collect_bleed_keys` now maps each shed path to the platform's own refinement (`None` when it has none), and `_shed_refined_bleed` substitutes typed entries while still dropping the unrefined ones, so the modbus_controller item `address` keeps its current no refinement outcome while a future typed divergence lands the platform's own type.

Zero shipped impact: a full regen after both changes is byte identical, matching the issues' expectation that no catalog pair diverges today. New pins cover per ref attribution, sibling ref expansion under an inherited field, the substitution map, and the shed helper.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2394
- fixes https://github.com/esphome/device-builder/issues/2403

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
