### PR TITLE
Pin the delegate-wrapper peel inventory against the live tree

### DIFF
--- a/tests/test_sync_components_delegate_peel.py
+++ b/tests/test_sync_components_delegate_peel.py
@@ -1,0 +1,98 @@
+"""Sweep pinning every live delegate-wrapper peel to its intended schema."""
+
+from __future__ import annotations
+
+import importlib
+import json
+
+import esphome.config_validation as cv
+import pytest
+
+from script.sync_components import (  # type: ignore[import-not-found]
+    _OUTPUT_BODIES_DIR,
+    _delegated_schema,
+    _get_esphome_loader,
+    _unwrap_schema_to_dict,
+)
+
+# Every wrapper the delegate probe fires on across the installed tree
+# (components, platforms, and automation registries), mapped to the
+# module-level schema it must peel to.
+_DELEGATE_WRAPPERS = [
+    ("esphome.components.api", "_encryption_schema", "ENCRYPTION_SCHEMA"),
+    ("esphome.components.climate", "visual_temperature_step", "VISUAL_TEMPERATURE_STEP_SCHEMA"),
+    ("esphome.components.deep_sleep", "validate_wakeup_pin", "WAKEUP_PIN_SCHEMA"),
+    ("esphome.components.mapping", "map_schema", "BASE_SCHEMA"),
+    ("esphome.components.micro_wake_word", "_maybe_empty_vad_schema", "VAD_MODEL_SCHEMA"),
+    ("esphome.components.nrf52", "_dfu_schema", "_DFU_SCHEMA"),
+    ("esphome.components.uart", "maybe_empty_debug", "DEBUG_SCHEMA"),
+    ("esphome.components.wifi", "_fast_connect_schema", "FAST_CONNECT_SCHEMA"),
+    ("esphome.components.wifi", "wifi_network_ap", "WIFI_NETWORK_AP"),
+    ("esphome.core.config", "validate_area_config", "AREA_SCHEMA"),
+]
+
+# The subset of delegate sites the shipped catalog nests; every shipped
+# nested key must come from the delegated schema.
+_NESTED_SITES = [
+    ("api", ("encryption",), "esphome.components.api", "ENCRYPTION_SCHEMA"),
+    ("mapping", (), "esphome.components.mapping", "BASE_SCHEMA"),
+    ("uart", ("debug",), "esphome.components.uart", "DEBUG_SCHEMA"),
+    ("wifi", ("ap",), "esphome.components.wifi", "WIFI_NETWORK_AP"),
+]
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _primed_core() -> None:
+    """Prime esphome's CORE so component modules import cleanly."""
+    assert _get_esphome_loader() is not None
+
+
+def _schema_keys(module_name: str, schema_name: str) -> set[str]:
+    module = importlib.import_module(module_name)
+    schema_dict = _unwrap_schema_to_dict(getattr(module, schema_name))
+    assert schema_dict is not None
+    return {str(getattr(key, "schema", key)) for key in schema_dict}
+
+
+@pytest.mark.parametrize(
+    ("module_name", "wrapper", "schema_name"),
+    [pytest.param(*row, id=f"{row[0].rsplit('.', 1)[-1]}.{row[1]}") for row in _DELEGATE_WRAPPERS],
+)
+def test_live_delegate_peel_resolves_its_intended_schema(
+    module_name: str, wrapper: str, schema_name: str
+) -> None:
+    """The peel returns exactly the module schema the wrapper delegates to."""
+    module = importlib.import_module(module_name)
+    assert _delegated_schema(getattr(module, wrapper)) is getattr(module, schema_name)
+
+
+@pytest.mark.parametrize(
+    ("component", "entry_path", "module_name", "schema_name"),
+    [pytest.param(*row, id=f"{row[0]}.{'.'.join(row[1]) or '<root>'}") for row in _NESTED_SITES],
+)
+def test_shipped_nested_keys_come_from_the_delegated_schema(
+    component: str, entry_path: tuple[str, ...], module_name: str, schema_name: str
+) -> None:
+    """Every shipped nested key at a delegate site exists in the delegated schema."""
+    body = json.loads((_OUTPUT_BODIES_DIR / f"{component}.json").read_text(encoding="utf-8"))
+    entries = body["config_entries"]
+    for key in entry_path:
+        entries = next(e for e in entries if e["key"] == key).get("config_entries") or []
+    shipped = {e["key"] for e in entries}
+    assert shipped
+    assert shipped <= _schema_keys(module_name, schema_name)
+
+
+def test_all_wrapped_delegate_is_not_peeled() -> None:
+    """A wrapper referencing a module-level ``cv.All`` delegate is not peeled."""
+    namespace = {
+        "WRAPPED": cv.All(cv.Schema({cv.Optional("x"): cv.boolean}), lambda value: value),
+    }
+    exec("def wrapper(value):\n    return WRAPPED(value)", namespace)  # noqa: S102
+    assert _delegated_schema(namespace["wrapper"]) is None
+
+
+def test_schema_builder_config_schema_is_not_peeled() -> None:
+    """gsl3670's dynamic CONFIG_SCHEMA builder does not peel to its embedded firmware schema."""
+    touchscreen = importlib.import_module("esphome.components.gsl3670.touchscreen")
+    assert _delegated_schema(touchscreen._config_schema) is None


### PR DESCRIPTION
# What does this implement/fix?

The audit #2372 asked for, with the outcome the data supports: pins instead of a broadened peel.

An instrumented run over the installed tree (every component and platform manifest plus the automation registries, 166 distinct probed callables) shows the delegate probe fires on ten wrappers, and each one resolves to exactly the module schema the wrapper delegates to; the automation registries produce zero firings. The issue's suggested `cv.All(cv.Schema({...}), validator)` broadening was implemented and measured before being discarded: it adds exactly one firing in the whole tree, and that one is a false positive, gsl3670's dynamic `CONFIG_SCHEMA` builder whose module level `FIRMWARE_SCHEMA` is embedded as a sub key value rather than delegated to, so the peel would have treated `{url, sha256, file}` as the platform's top level shape. Zero true positives against one wrong peel settles the question for the current tree.

The new sweep pins what the audit established: each of the ten firings resolves to its intended schema by identity, the four sites the shipped catalog nests (api encryption, mapping's root, uart debug, wifi ap) draw every shipped nested key from the delegated schema, a synthetic `cv.All` delegate stays unpeeled, and gsl3670's builder stays unpeeled. A future upstream refactor that shifts what the sole schema heuristic grabs, or a rebroadening attempt, now has to face these directly.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2372

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
