### PR TITLE
Locate flush-style api action lists

### DIFF
--- a/esphome_device_builder/controllers/automations/api_actions.py
+++ b/esphome_device_builder/controllers/automations/api_actions.py
@@ -16,9 +16,7 @@ from __future__ import annotations
 
 import re
 
-from ...helpers.api import CommandError
 from ...helpers.yaml.scan import child_block_end, is_list_item_line
-from ...models.api import ErrorCode
 from ...models.automations import YamlDiff
 
 #: Accepted spellings, canonical first — esphome's ``cv.rename_key``
@@ -172,9 +170,6 @@ def indent_for_list(rendered_item: str, item_indent: str) -> str:
     content, since YAML treats whitespace-only lines and fully
     empty lines differently inside a literal block.
     """
-    if len(item_indent) < 2:
-        msg = "api: block uses one-space indentation; re-indent it to edit actions"
-        raise CommandError(ErrorCode.INVALID_ARGS, msg)
     pad = " " * (len(item_indent) - 2)
     out_lines: list[str] = []
     for line in rendered_item.splitlines():
@@ -242,11 +237,7 @@ def render_append(
     item_indent: str,
     rendered: str,
 ) -> tuple[str, YamlDiff]:
-    """Append a new list item at the end of an existing ``api.actions:``.
-
-    *actions_end* comes pre-trimmed from :func:`locate_actions_list`, so
-    the line before it is never blank.
-    """
+    """Append a new list item at the pre-trimmed *actions_end* of ``api.actions:``."""
     item_text = indent_for_list(rendered, item_indent)
     insert_at = actions_end
     new_lines = [*lines[:insert_at], item_text, *lines[insert_at:]]

--- a/esphome_device_builder/controllers/automations/api_actions.py
+++ b/esphome_device_builder/controllers/automations/api_actions.py
@@ -81,12 +81,19 @@ def locate_actions_list(
     actions_end = api_end
     for idx in range(actions_start + 1, api_end):
         content = lines[idx].rstrip("\n\r")
-        if not content:
+        stripped = content.lstrip(" ")
+        if not stripped or stripped.startswith("#"):
             continue
-        leading = len(content) - len(content.lstrip(" "))
-        if leading <= len(child_indent):
+        leading = len(content) - len(stripped)
+        # A flush-style dash at the key's own indent is an item, not
+        # the next api child key — only shallower content or a
+        # same-indent non-dash line ends the list.
+        if leading < len(child_indent) or (
+            leading == len(child_indent) and not stripped.startswith("- ")
+        ):
             actions_end = idx
             break
+    actions_end = _trim_trailing_gap(lines, actions_start, actions_end)
     item_indent: str | None = None
     for idx in range(actions_start + 1, actions_end):
         raw = lines[idx].rstrip("\n\r")
@@ -308,6 +315,16 @@ def _item_spans(
     if start is not None:
         spans.append((start, actions_end))
     return spans
+
+
+def _trim_trailing_gap(lines: list[str], start: int, end: int) -> int:
+    """Pull *end* back over trailing blank and comment lines."""
+    while end - 1 > start:
+        stripped = lines[end - 1].strip()
+        if stripped and not stripped.startswith("#"):
+            break
+        end -= 1
+    return end
 
 
 def _find_block_key_line(

--- a/esphome_device_builder/controllers/automations/api_actions.py
+++ b/esphome_device_builder/controllers/automations/api_actions.py
@@ -16,6 +16,9 @@ from __future__ import annotations
 
 import re
 
+from ...helpers.api import CommandError
+from ...helpers.yaml.scan import child_block_end, is_list_item_line
+from ...models.api import ErrorCode
 from ...models.automations import YamlDiff
 
 #: Accepted spellings, canonical first — esphome's ``cv.rename_key``
@@ -78,27 +81,12 @@ def locate_actions_list(
     if found is None:
         return None
     actions_start, matched_key = found
-    actions_end = api_end
-    for idx in range(actions_start + 1, api_end):
-        content = lines[idx].rstrip("\n\r")
-        stripped = content.lstrip(" ")
-        if not stripped or stripped.startswith("#"):
-            continue
-        leading = len(content) - len(stripped)
-        # A flush-style dash at the key's own indent is an item, not
-        # the next api child key — only shallower content or a
-        # same-indent non-dash line ends the list.
-        if leading < len(child_indent) or (
-            leading == len(child_indent) and not stripped.startswith("- ")
-        ):
-            actions_end = idx
-            break
-    actions_end = _trim_trailing_gap(lines, actions_start, actions_end)
+    actions_end = child_block_end(lines, actions_start, api_end, child_indent)
     item_indent: str | None = None
     for idx in range(actions_start + 1, actions_end):
         raw = lines[idx].rstrip("\n\r")
         stripped = raw.lstrip(" ")
-        if stripped.startswith("- "):
+        if is_list_item_line(stripped):
             item_indent = raw[: len(raw) - len(stripped)]
             break
     if item_indent is None:
@@ -184,6 +172,9 @@ def indent_for_list(rendered_item: str, item_indent: str) -> str:
     content, since YAML treats whitespace-only lines and fully
     empty lines differently inside a literal block.
     """
+    if len(item_indent) < 2:
+        msg = "api: block uses one-space indentation; re-indent it to edit actions"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
     pad = " " * (len(item_indent) - 2)
     out_lines: list[str] = []
     for line in rendered_item.splitlines():
@@ -251,11 +242,13 @@ def render_append(
     item_indent: str,
     rendered: str,
 ) -> tuple[str, YamlDiff]:
-    """Append a new list item at the end of an existing ``api.actions:``."""
+    """Append a new list item at the end of an existing ``api.actions:``.
+
+    *actions_end* comes pre-trimmed from :func:`locate_actions_list`, so
+    the line before it is never blank.
+    """
     item_text = indent_for_list(rendered, item_indent)
     insert_at = actions_end
-    while insert_at > 0 and not lines[insert_at - 1].strip():
-        insert_at -= 1
     new_lines = [*lines[:insert_at], item_text, *lines[insert_at:]]
     new_text = "".join(new_lines)
     return new_text, YamlDiff(
@@ -308,23 +301,15 @@ def _item_spans(
     spans: list[tuple[int, int]] = []
     start: int | None = None
     for idx in range(actions_start + 1, actions_end):
-        if lines[idx].rstrip("\n\r").startswith(item_indent + "- "):
+        raw = lines[idx].rstrip("\n\r")
+        stripped = raw.lstrip(" ")
+        if raw[: len(raw) - len(stripped)] == item_indent and is_list_item_line(stripped):
             if start is not None:
                 spans.append((start, idx))
             start = idx
     if start is not None:
         spans.append((start, actions_end))
     return spans
-
-
-def _trim_trailing_gap(lines: list[str], start: int, end: int) -> int:
-    """Pull *end* back over trailing blank and comment lines."""
-    while end - 1 > start:
-        stripped = lines[end - 1].strip()
-        if stripped and not stripped.startswith("#"):
-            break
-        end -= 1
-    return end
 
 
 def _find_block_key_line(

--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -22,9 +22,9 @@ from ...helpers.api import CommandError
 from ...helpers.yaml import (
     SubEntityRef,
     YamlUpsertNotSupportedError,
-    _block_end,
     _indent_block,
     _splice_into_domain_block,
+    child_block_end,
     remove_inline_handler,
     remove_nested_handler,
     remove_subentity_handler,
@@ -564,7 +564,7 @@ def _upsert_under_top_key(
         text = lines[idx].rstrip("\n\r")
         if text == handler_re_prefix or text.startswith(handler_re_prefix + " "):
             handler_start = idx
-            handler_end = _block_end(lines, idx, end, indent)
+            handler_end = child_block_end(lines, idx, end, indent)
             break
     rendered_text = "\n".join(_indent_block(rendered_yaml, indent)) + "\n"
     if handler_start is not None and handler_end is not None:
@@ -674,7 +674,7 @@ def _delete_under_top_key(
     for idx in range(start + 1, end):
         text = lines[idx].rstrip("\n\r")
         if text == handler_prefix or text.startswith(handler_prefix + " "):
-            handler_end = _block_end(lines, idx, end, indent)
+            handler_end = child_block_end(lines, idx, end, indent)
             new_lines = [*lines[:idx], *lines[handler_end:]]
             return "".join(new_lines), YamlDiff(
                 fromLine=idx + 1,

--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -441,6 +441,9 @@ def _upsert_api_action(
     if actions_span is None:
         return api_actions.render_insert_actions_key(lines, api_span, rendered)
     actions_start, actions_end, item_indent, block_key = actions_span
+    if len(item_indent) < 2:
+        msg = "api: block indentation is too shallow; re-indent it to edit actions"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
     lines = _canonicalized_api_block(lines, actions_span)
     existing = api_actions.find_item(
         lines,

--- a/esphome_device_builder/controllers/migrations.py
+++ b/esphome_device_builder/controllers/migrations.py
@@ -16,13 +16,12 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-from ..helpers.yaml.scan import leading_ws
+from ..helpers.yaml.scan import child_block_end, leading_ws
 from ..models.automations import YamlDiff
 from .automations import api_actions
 from .automations.writing_layout import (
     _build_diff_for_append,
     _locate_singleton_block,
-    _trim_trailing_gap,
 )
 
 
@@ -191,13 +190,7 @@ def _child_block_span(
         content = lines[idx].rstrip("\n\r")
         if content != header and not content.startswith(header + " "):
             continue
-        stop = idx + 1
-        while stop < min(end, len(lines)):
-            deeper = lines[stop].rstrip("\n\r")
-            if deeper.strip() and len(leading_ws(deeper)) <= len(child_indent):
-                break
-            stop += 1
-        return idx, _trim_trailing_gap(lines, idx, stop)
+        return idx, child_block_end(lines, idx, min(end, len(lines)), child_indent)
     return None
 
 

--- a/esphome_device_builder/helpers/yaml/__init__.py
+++ b/esphome_device_builder/helpers/yaml/__init__.py
@@ -53,7 +53,6 @@ from .component import _splice_into_multi_conf_block as _splice_into_multi_conf_
 from .component import generate_component_yaml as generate_component_yaml
 from .component import merge_component_yaml as merge_component_yaml
 from .inline import SubEntityRef as SubEntityRef
-from .inline import _block_end as _block_end
 from .inline import _indent_block as _indent_block
 from .inline import remove_inline_handler as remove_inline_handler
 from .inline import remove_nested_handler as remove_nested_handler
@@ -73,6 +72,7 @@ from .scalar import _strip_yaml_quotes as _strip_yaml_quotes
 from .scalar import is_plain_literal_scalar as is_plain_literal_scalar
 from .scalar import read_yaml_scalar as read_yaml_scalar
 from .scalar import rewrite_yaml_scalar as rewrite_yaml_scalar
+from .scan import child_block_end as child_block_end
 from .substitution import is_retargetable_name as is_retargetable_name
 from .substitution import parse_substitution_ref as parse_substitution_ref
 from .substitution import rewrite_name_or_substitution as rewrite_name_or_substitution

--- a/esphome_device_builder/helpers/yaml/inline.py
+++ b/esphome_device_builder/helpers/yaml/inline.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from .scalar import ESPHOME_YAML_INDENT, YamlUpsertNotSupportedError, block_body_is_list
 from .scan import (
     block_end_index,
+    child_block_end,
     find_block_header,
     key_header_re,
     key_line_res,
@@ -290,7 +291,7 @@ def _locate_key_block(lines: list[str], frame: _SpanFrame, key: str) -> _SpanFra
 
 def _key_block_frame(lines: list[str], start: int, end_bound: int, outer_indent: str) -> _SpanFrame:
     """Frame for the block headed at *start*: bounds plus first-child indent."""
-    end = _block_end(lines, start, end_bound, outer_indent)
+    end = child_block_end(lines, start, end_bound, outer_indent)
     child = outer_indent + ESPHOME_YAML_INDENT
     for idx in range(start + 1, end):
         content = lines[idx].rstrip("\n\r")
@@ -298,17 +299,6 @@ def _key_block_frame(lines: list[str], start: int, end_bound: int, outer_indent:
             child = leading_ws(content)
             break
     return _SpanFrame(start, end, child)
-
-
-def _block_end(lines: list[str], start: int, end_bound: int, indent: str) -> int:
-    """First line index after *start* whose indent is <= len(*indent*); *end_bound* if none."""
-    for idx in range(start + 1, end_bound):
-        content = lines[idx].rstrip("\n\r")
-        if not content:
-            continue
-        if len(content) - len(content.lstrip(" ")) <= len(indent):
-            return idx
-    return end_bound
 
 
 def _apply_handler_upsert(
@@ -329,7 +319,7 @@ def _apply_handler_upsert(
     for idx in range(instance_start, instance_end):
         if handler_re.match(lines[idx].rstrip("\n\r")):
             handler_start = idx
-            handler_end = _block_end(lines, idx, instance_end, child_indent)
+            handler_end = child_block_end(lines, idx, instance_end, child_indent)
             break
 
     rendered_lines = _indent_block(rendered_yaml, child_indent)
@@ -410,7 +400,7 @@ def _locate_handler_range(
     handler_re = key_header_re(handler_key, indent=child_indent)
     for idx in range(instance_start, instance_end):
         if handler_re.match(lines[idx].rstrip("\n\r")):
-            return idx, _block_end(lines, idx, instance_end, child_indent)
+            return idx, child_block_end(lines, idx, instance_end, child_indent)
     return None
 
 

--- a/esphome_device_builder/helpers/yaml/inline.py
+++ b/esphome_device_builder/helpers/yaml/inline.py
@@ -295,7 +295,9 @@ def _key_block_frame(lines: list[str], start: int, end_bound: int, outer_indent:
     child = outer_indent + ESPHOME_YAML_INDENT
     for idx in range(start + 1, end):
         content = lines[idx].rstrip("\n\r")
-        if content:
+        stripped = content.lstrip(" ")
+        # A comment (possibly misaligned) is not the first child.
+        if stripped and not stripped.startswith("#"):
             child = leading_ws(content)
             break
     return _SpanFrame(start, end, child)

--- a/esphome_device_builder/helpers/yaml/scan.py
+++ b/esphome_device_builder/helpers/yaml/scan.py
@@ -37,6 +37,42 @@ def block_end_index(lines: list[str], start: int) -> int:
     return len(lines)
 
 
+def is_list_item_line(stripped: str) -> bool:
+    """Report whether a whitespace-stripped line opens a list item (``- foo`` or lone ``-``)."""
+    return stripped == "-" or stripped.startswith("- ")
+
+
+def child_block_end(lines: list[str], start: int, end_bound: int, indent: str) -> int:
+    """
+    End (exclusive) of the child block whose key line sits at *indent*.
+
+    A flush-style list item at the key's own indent continues the block;
+    blank and comment lines never end it. The end trims back over
+    trailing blanks and comments at or above the key's indent (they
+    belong to the gap before the next key); deeper trailing comments
+    stay inside the block.
+    """
+    end = end_bound
+    for idx in range(start + 1, end_bound):
+        content = lines[idx].rstrip("\n\r")
+        stripped = content.lstrip(" ")
+        if not stripped or stripped.startswith("#"):
+            continue
+        leading = len(content) - len(stripped)
+        if leading < len(indent) or (leading == len(indent) and not is_list_item_line(stripped)):
+            end = idx
+            break
+    while end - 1 > start:
+        content = lines[end - 1].rstrip("\n\r")
+        stripped = content.lstrip(" ")
+        if stripped and (
+            not stripped.startswith("#") or len(content) - len(stripped) > len(indent)
+        ):
+            break
+        end -= 1
+    return end
+
+
 def top_list_item_starts(lines: list[str], start: int, end: int) -> list[int]:
     """
     Line indexes of the canonical-indent ``- `` items in a block body.

--- a/esphome_device_builder/helpers/yaml/scan.py
+++ b/esphome_device_builder/helpers/yaml/scan.py
@@ -39,7 +39,7 @@ def block_end_index(lines: list[str], start: int) -> int:
 
 def is_list_item_line(stripped: str) -> bool:
     """Report whether a whitespace-stripped line opens a list item (``- foo`` or lone ``-``)."""
-    return stripped == "-" or stripped.startswith("- ")
+    return stripped.startswith("- ") or stripped.rstrip(" ") == "-"
 
 
 def child_block_end(lines: list[str], start: int, end_bound: int, indent: str) -> int:
@@ -87,7 +87,7 @@ def top_list_item_starts(lines: list[str], start: int, end: int) -> list[int]:
         stripped = raw.lstrip(" ")
         # A bare dash opens an item whose mapping starts on the next
         # line (the shape the nested-delete prune writes).
-        if not stripped.startswith("- ") and stripped.rstrip(" ") != "-":
+        if not is_list_item_line(stripped):
             continue
         prefix = raw[: len(raw) - len(stripped)]
         if item_indent is None:

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -1519,6 +1519,131 @@ def test_delete_api_action_refuses_inline_actions_list() -> None:
     assert err.value.code == ErrorCode.INVALID_ARGS
 
 
+_FLUSH_ACTIONS_YAML = (
+    "esphome:\n  name: x\n"
+    "api:\n  actions:\n"
+    "  - action: start_va\n"
+    "    then:\n      - logger.log: 'starting'\n"
+    "  - action: stop_va\n"
+    "    then:\n      - logger.log: 'stopping'\n"
+)
+
+
+def test_upsert_api_action_replaces_item_in_flush_dash_list() -> None:
+    """A flush-style list (dashes at the key's indent) edits in place."""
+    new_text, _diff = render_upsert(
+        _FLUSH_ACTIONS_YAML,
+        tree=AutomationTree(
+            trigger_id=None,
+            actions=[ActionNode(action_id="delay", params={"id": "2s"})],
+        ),
+        location=ApiActionLocation(action_name="start_va"),
+    )
+    assert new_text.count("actions:") == 1
+    assert new_text.count("- action: start_va") == 1
+    assert "delay: 2s" in new_text
+    assert "'starting'" not in new_text
+    assert "'stopping'" in new_text
+    parsed = parse_device_yaml(new_text)
+    api_names = [p.location.action_name for p in parsed if p.location.kind == "api_action"]
+    assert api_names == ["start_va", "stop_va"]
+
+
+def test_upsert_api_action_appends_at_flush_indent() -> None:
+    """A new item lands at the flush indent the existing items use."""
+    new_text, _diff = render_upsert(
+        _FLUSH_ACTIONS_YAML,
+        tree=AutomationTree(
+            trigger_id=None,
+            actions=[ActionNode(action_id="delay", params={"id": "1s"})],
+        ),
+        location=ApiActionLocation(action_name="pause_va"),
+    )
+    assert new_text.count("actions:") == 1
+    assert "\n  - action: pause_va\n" in new_text
+    parsed = parse_device_yaml(new_text)
+    api_names = [p.location.action_name for p in parsed if p.location.kind == "api_action"]
+    assert api_names == ["start_va", "stop_va", "pause_va"]
+
+
+def test_delete_api_action_from_flush_dash_list() -> None:
+    """Deleting one flush item keeps its sibling; deleting the last drops the key."""
+    new_text, diff = render_delete(
+        _FLUSH_ACTIONS_YAML,
+        location=ApiActionLocation(action_name="start_va"),
+    )
+    assert "start_va" not in new_text
+    assert "stop_va" in new_text
+    assert diff.replacement == ""
+    final_text, _diff = render_delete(
+        new_text,
+        location=ApiActionLocation(action_name="stop_va"),
+    )
+    assert "actions:" not in final_text
+    assert "api:" in final_text
+
+
+def test_upsert_api_action_canonicalizes_legacy_flush_services_block() -> None:
+    """A legacy flush-style ``services:`` block respells to canonical on write."""
+    text = (
+        "esphome:\n  name: x\n"
+        "api:\n  services:\n"
+        "  - service: start_va\n"
+        "    then:\n      - logger.log: 'starting'\n"
+    )
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id=None,
+            actions=[ActionNode(action_id="delay", params={"id": "1s"})],
+        ),
+        location=ApiActionLocation(action_name="start_va"),
+    )
+    assert "services:" not in new_text
+    assert "- service:" not in new_text
+    assert new_text.count("actions:") == 1
+    assert "\n  - action: start_va\n" in new_text
+
+
+def test_comment_between_flush_items_does_not_hide_the_rest() -> None:
+    """A comment at the key's indent inside a flush list doesn't end it."""
+    text = (
+        "esphome:\n  name: x\n"
+        "api:\n  actions:\n"
+        "  - action: start_va\n"
+        "    then:\n      - logger.log: 'starting'\n"
+        "  # stops the vacuum\n"
+        "  - action: stop_va\n"
+        "    then:\n      - logger.log: 'stopping'\n"
+    )
+    new_text, _diff = render_delete(
+        text,
+        location=ApiActionLocation(action_name="stop_va"),
+    )
+    assert "stop_va" not in new_text
+    assert "start_va" in new_text
+
+
+def test_delete_last_flush_item_keeps_trailing_banner_comment() -> None:
+    """A comment banner between the list and the next api key survives delete-last."""
+    text = (
+        "esphome:\n  name: x\n"
+        "api:\n  actions:\n"
+        "  - action: start_va\n"
+        "    then:\n      - logger.log: 'starting'\n"
+        "\n"
+        "  # transport security\n"
+        "  encryption:\n    key: 'aaaa'\n"
+    )
+    new_text, _diff = render_delete(
+        text,
+        location=ApiActionLocation(action_name="start_va"),
+    )
+    assert "actions:" not in new_text
+    assert "# transport security" in new_text
+    assert "encryption:" in new_text
+
+
 def test_upsert_api_action_appends_into_empty_actions_with_sibling_key() -> None:
     """``actions:`` with no items but a sibling key below gains its first item.
 

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -1735,6 +1735,56 @@ def test_component_action_field_replaces_flush_leaf_list() -> None:
     assert "close_action:" in final_text
 
 
+def test_device_on_flush_handler_round_trips() -> None:
+    """A flush-style ``on_boot:`` list under ``esphome:`` replaces and deletes wholly."""
+    text = (
+        "esphome:\n  name: x\n  on_boot:\n  - logger.log: hi\n  - delay: 2s\n  friendly_name: y\n"
+    )
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id="esphome.on_boot",
+            actions=[ActionNode(action_id="delay", params={"id": "1s"})],
+        ),
+        location=DeviceOnLocation(trigger="on_boot"),
+    )
+    assert new_text.count("on_boot:") == 1
+    assert "logger.log: hi" not in new_text
+    assert "delay: 1s" in new_text
+    assert "friendly_name: y" in new_text
+    final_text, _diff = render_delete(text, location=DeviceOnLocation(trigger="on_boot"))
+    assert "on_boot:" not in final_text
+    assert "logger.log: hi" not in final_text
+    assert "friendly_name: y" in final_text
+
+
+@pytest.mark.usefixtures("_sprinkler_paths")
+def test_nested_action_field_replaces_flush_leaf_list() -> None:
+    """A flush-style leaf list under a nested field path replaces and deletes wholly."""
+    text = (
+        "sprinkler:\n  - id: lawn\n    repeat_number:\n      id: lawn_repeat\n"
+        "      set_action:\n      - logger.log: repeat changed\n"
+        "    multiplier_number:\n      id: lawn_multiplier\n"
+    )
+    loc = ComponentActionFieldLocation(component_id="lawn", field="repeat_number.set_action")
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id=None,
+            actions=[ActionNode(action_id="delay", params={"id": "1s"})],
+        ),
+        location=loc,
+    )
+    assert new_text.count("set_action:") == 1
+    assert "repeat changed" not in new_text
+    assert "delay: 1s" in new_text
+    assert "lawn_multiplier" in new_text
+    final_text, _diff = render_delete(text, location=loc)
+    assert "set_action:" not in final_text
+    assert "repeat changed" not in final_text
+    assert "lawn_multiplier" in final_text
+
+
 def test_subentity_flush_handler_round_trips() -> None:
     """A flush-style handler list inside a sub-sensor block replaces and deletes wholly."""
     text = (

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -1785,6 +1785,33 @@ def test_nested_action_field_replaces_flush_leaf_list() -> None:
     assert "lawn_multiplier" in final_text
 
 
+@pytest.mark.usefixtures("_sprinkler_paths")
+def test_nested_descent_skips_a_misaligned_comment_child() -> None:
+    """A comment misaligned to the container key doesn't set the child indent."""
+    text = (
+        "sprinkler:\n  - id: lawn\n    repeat_number:\n"
+        "    # a note about the repeat number\n"
+        "      id: lawn_repeat\n"
+        "      set_action:\n        - logger.log: repeat changed\n"
+        "    multiplier_number:\n      id: lawn_multiplier\n"
+    )
+    loc = ComponentActionFieldLocation(component_id="lawn", field="repeat_number.set_action")
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id=None,
+            actions=[ActionNode(action_id="delay", params={"id": "1s"})],
+        ),
+        location=loc,
+    )
+    assert new_text.count("set_action:") == 1
+    assert "repeat changed" not in new_text
+    assert "# a note about the repeat number" in new_text
+    final_text, _diff = render_delete(text, location=loc)
+    assert "set_action:" not in final_text
+    assert "lawn_multiplier" in final_text
+
+
 def test_subentity_flush_handler_round_trips() -> None:
     """A flush-style handler list inside a sub-sensor block replaces and deletes wholly."""
     text = (

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -1644,6 +1644,132 @@ def test_delete_last_flush_item_keeps_trailing_banner_comment() -> None:
     assert "encryption:" in new_text
 
 
+def test_delete_last_flush_item_removes_item_scoped_comment() -> None:
+    """A comment indented inside the last item goes with it, not stranded under ``api:``."""
+    text = (
+        "api:\n  actions:\n"
+        "  - action: a\n"
+        "    then:\n      - logger.log: x\n"
+        "    # note about a\n"
+        "  encryption:\n    key: k\n"
+    )
+    new_text, _diff = render_delete(text, location=ApiActionLocation(action_name="a"))
+    assert "# note about a" not in new_text
+    assert "encryption:" in new_text
+
+
+def test_delete_last_flush_item_removes_block_scalar_tail() -> None:
+    """A ``#``-leading line inside a lambda block scalar is item content, not a comment."""
+    text = (
+        "api:\n  actions:\n"
+        "  - action: a\n"
+        "    then:\n"
+        "      - lambda: |-\n"
+        "          int n = 1;\n"
+        "          #define FOO 1\n"
+        "  encryption:\n    key: k\n"
+    )
+    new_text, _diff = render_delete(text, location=ApiActionLocation(action_name="a"))
+    assert "#define" not in new_text
+    assert "encryption:" in new_text
+
+
+def test_lone_dash_flush_item_round_trips() -> None:
+    """The lone-dash spelling (``-`` alone on its line) upserts in place and deletes."""
+    text = "api:\n  actions:\n  -\n    action: a\n    then:\n      - logger.log: x\n"
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id=None,
+            actions=[ActionNode(action_id="delay", params={"id": "1s"})],
+        ),
+        location=ApiActionLocation(action_name="a"),
+    )
+    assert new_text.count("action: a") == 1
+    assert "delay: 1s" in new_text
+    final_text, _diff = render_delete(text, location=ApiActionLocation(action_name="a"))
+    assert "action: a" not in final_text
+    assert "actions:" not in final_text
+
+
+def test_upsert_api_action_refuses_one_space_indent() -> None:
+    """A one-space ``api:`` child indent can't host the two-space item emit."""
+    text = "api:\n actions:\n - action: a\n   then:\n     - logger.log: x\n"
+    with pytest.raises(CommandError) as err:
+        render_upsert(
+            text,
+            tree=AutomationTree(
+                trigger_id=None,
+                actions=[ActionNode(action_id="delay", params={"id": "1s"})],
+            ),
+            location=ApiActionLocation(action_name="b"),
+        )
+    assert err.value.code == ErrorCode.INVALID_ARGS
+
+
+def test_component_action_field_replaces_flush_leaf_list() -> None:
+    """A flush-style action-field list replaces wholly instead of stacking a duplicate."""
+    text = (
+        "cover:\n  - platform: feedback\n    id: g\n"
+        "    open_action:\n"
+        "    - switch.turn_on: relay\n"
+        "    close_action:\n"
+        "    - switch.turn_off: relay\n"
+    )
+    loc = ComponentActionFieldLocation(component_id="g", field="open_action")
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id=None,
+            actions=[ActionNode(action_id="switch.toggle", params={"id": "relay"})],
+        ),
+        location=loc,
+    )
+    assert new_text.count("open_action:") == 1
+    assert "switch.toggle" in new_text
+    assert "switch.turn_on" not in new_text
+    assert "switch.turn_off" in new_text
+    final_text, _diff = render_delete(text, location=loc)
+    assert "open_action:" not in final_text
+    assert "switch.turn_on" not in final_text
+    assert "close_action:" in final_text
+
+
+def test_subentity_flush_handler_round_trips() -> None:
+    """A flush-style handler list inside a sub-sensor block replaces and deletes wholly."""
+    text = (
+        "esphome:\n  name: x\n"
+        "sensor:\n"
+        "  - platform: aht10\n"
+        "    id: aht20\n"
+        "    temperature:\n"
+        "      id: aht20_temperature\n"
+        "      on_value_range:\n"
+        "      - above: 10\n"
+        "        then:\n"
+        "          - light.toggle: led\n"
+        "    humidity:\n"
+        "      id: aht20_humidity\n"
+    )
+    loc = ComponentOnLocation(component_id="aht20_temperature", trigger="on_value_range")
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id="sensor.on_value_range",
+            trigger_params={"above": 42},
+            actions=[ActionNode(action_id="light.turn_on", params={"id": "led"})],
+        ),
+        location=loc,
+    )
+    assert new_text.count("on_value_range:") == 1
+    assert "above: 42" in new_text
+    assert "above: 10" not in new_text
+    assert "aht20_humidity" in new_text
+    final_text, _diff = render_delete(text, location=loc)
+    assert "on_value_range:" not in final_text
+    assert "aht20_humidity" in final_text
+
+
 def test_upsert_api_action_appends_into_empty_actions_with_sibling_key() -> None:
     """``actions:`` with no items but a sibling key below gains its first item.
 

--- a/tests/test_config_migrations.py
+++ b/tests/test_config_migrations.py
@@ -338,6 +338,15 @@ def test_ethernet_existing_clk_replaced_wholesale() -> None:
     assert "GPIO16" not in new_text
 
 
+def test_ethernet_existing_clk_with_comment_at_key_indent_replaced_wholesale() -> None:
+    """A comment at the ``clk:`` key's own indent doesn't split the replaced block."""
+    text = _ETHERNET_YAML + "  clk:\n  # a note\n    pin: GPIO17\n    mode: CLK_OUT\n"
+    new_text = _respell(text)
+    assert new_text.count("clk:") == 1
+    assert new_text.count("\n    pin:") == 1
+    assert "GPIO17" not in new_text
+
+
 @pytest.mark.parametrize("value", ["!secret clk", "EXTERNAL", "17"])
 def test_ethernet_undecodable_clk_mode_untouched(value: str) -> None:
     assert render_migrations(_ETHERNET_YAML.replace("GPIO0_IN", value)) is None

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -42,6 +42,7 @@ from esphome_device_builder.helpers.yaml import (
     _splice_into_domain_block,
     _splice_into_multi_conf_block,
     _strip_yaml_quotes,
+    child_block_end,
     fallback_ap_ssid,
     generate_api_encryption_key,
     generate_component_yaml,
@@ -2224,3 +2225,29 @@ def test_write_user_yaml_wraps_oserror_as_esphome_error(tmp_path: Path) -> None:
     """A failed write surfaces as ``EsphomeError``, matching ``esphome.helpers.write_file``."""
     with pytest.raises(EsphomeError, match="Could not write file"):
         write_user_yaml(tmp_path / "missing" / "x.yaml", "a: 1\n")
+
+
+def _cbe(text: str, start: int, indent: str) -> int:
+    lines = text.splitlines(keepends=True)
+    return child_block_end(lines, start, len(lines), indent)
+
+
+def test_child_block_end_flush_dash_continues_the_block() -> None:
+    text = "api:\n  actions:\n  - action: a\n    then: []\n  encryption:\n    key: k\n"
+    assert _cbe(text, 1, "  ") == 4
+
+
+def test_child_block_end_lone_dash_continues_the_block() -> None:
+    text = "api:\n  actions:\n  -\n    action: a\n  encryption:\n    key: k\n"
+    assert _cbe(text, 1, "  ") == 4
+
+
+def test_child_block_end_comment_inside_does_not_end_the_block() -> None:
+    text = "api:\n  actions:\n  - action: a\n  # note\n  - action: b\n  encryption:\n    key: k\n"
+    assert _cbe(text, 1, "  ") == 5
+
+
+def test_child_block_end_trims_shallow_banner_but_keeps_deep_comment() -> None:
+    text = "api:\n  actions:\n  - action: a\n    # for a\n\n  # banner\n  encryption:\n    key: k\n"
+    # The deep ``# for a`` stays inside; the blank + shallow banner trim off.
+    assert _cbe(text, 1, "  ") == 4


### PR DESCRIPTION
# What does this implement/fix?

A flush style api action list, dashes at the same column as the block key, is valid YAML that esphome compiles:

```yaml
api:
  actions:
  - action: start_va
    then:
      - logger.log: go
```

`locate_actions_list` ended the block at the first line whose indent was at or below the api child indent, which is the first flush dash itself, so the list read as empty. An upsert of an existing name then appended a duplicate four indent item and orphaned the flush items into bare list entries directly under `api:` (invalid YAML), and a delete of an existing item raised NOT_FOUND. Parsing was unaffected, so the manage list showed actions the editor could not edit or delete.

The same indent comparison lived in `helpers/yaml/inline.py:_block_end`, where the #2433 review found two more members of the class: a flush style leaf list under a component action field corrupted on flat upsert and delete, and a flush style container broke the sub entity descent. All the splice paths now share one boundary helper, `child_block_end` in `helpers/yaml/scan.py`, mirroring the frontend's `endsBlockAtIndent` rule: a flush dash line (including the lone dash spelling) continues the block, blank and comment lines never end it (a comment at the key's indent between flush items used to hide everything after it), and the end trims back over trailing blanks and shallow comment banners while a comment indented inside the last item stays with it. `locate_actions_list`, the inline handler upsert and remove, the sub entity locator, and the singleton handler splices all use it; `_item_spans` also accepts lone dash items so they round trip. A one space `api:` child indent, which the two space item emit cannot nest under, is refused with INVALID_ARGS instead of writing unparseable YAML.

Surfaced by the Kōan reviews on #2420 and #2433 as a pre existing gap; reproduced on main at e4e0959a. Top level lists (`script:` / `interval:`) and the frontend already handled flush style.

**Related issue or feature (if applicable):**

- related to #2396

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR:

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
