### PR TITLE
Substitute the platform's own bounds in the range shed

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -2613,8 +2613,8 @@ def build_component_entry(
         # Platform build: drop hub-derived signals that bleed onto a
         # platform field this domain redefines (e.g. the modbus_controller
         # item ``address``). Hub builds keep them.
-        bleed = (introspection.get("field_range_bleed_keys") or {}).get(domain, set())
-        field_ranges = {k: v for k, v in field_ranges.items() if k not in bleed}
+        bleed = (introspection.get("field_range_bleed_keys") or {}).get(domain, {})
+        field_ranges = _shed_range_bleed(field_ranges, bleed)
         refined_bleed = (introspection.get("refined_bleed_keys") or {}).get(domain, {})
         refined_types = _shed_refined_bleed(refined_types, refined_bleed)
     # Refined types first: the range gate reads the entry's final type,
@@ -4749,15 +4749,17 @@ def _upgrade_stamp_only_refinements(
 def _collect_bleed_keys(
     manifest: Any,
     platform_manifests_by_domain: list[tuple[str, Any]],
-) -> tuple[dict[str, set[tuple[str, ...]]], dict[str, dict[tuple[str, ...], RefinedType | None]]]:
+) -> tuple[
+    dict[str, dict[tuple[str, ...], tuple[int | float, int | float] | None]],
+    dict[str, dict[tuple[str, ...], RefinedType | None]],
+]:
     """Per-domain hub signals a platform schema redefines, for platform builds to shed.
 
-    Ranges shed when the platform redefines the key unbounded; refined
-    types shed when the platform's own refinement differs (the
+    Both signals shed when the platform's own value differs (the
     modbus_controller hub's ``cv.hex_uint8_t`` ``address`` vs the platform
     item's plain ``cv.positive_int``), each shed path mapping to the
-    platform's own refinement (``None`` when it has none) so the build
-    substitutes rather than dropping. Keyed per platform domain, not
+    platform's own range / refinement (``None`` when it has none) so the
+    build substitutes rather than dropping. Keyed per platform domain, not
     aggregated: one platform's redefinition must not spare a sibling
     platform from the shed. Hub builds keep every signal. Covers
     hub-to-platform bleed only; a sibling platform's contribution rides
@@ -4765,12 +4767,16 @@ def _collect_bleed_keys(
     """
     hub_ranges = _collect_field_ranges(manifest)
     hub_refined = _collect_refined_types(manifest)
-    range_bleed: dict[str, set[tuple[str, ...]]] = {}
+    range_bleed: dict[str, dict[tuple[str, ...], tuple[int | float, int | float] | None]] = {}
     refined_bleed: dict[str, dict[tuple[str, ...], RefinedType | None]] = {}
     for domain, platform_manifest in platform_manifests_by_domain:
         keys = _platform_field_keys([platform_manifest])
-        bounded = set(_collect_field_ranges(platform_manifest))
-        bled = {path for path in hub_ranges if path in keys and path not in bounded}
+        platform_ranges = _collect_field_ranges(platform_manifest)
+        bled = {
+            path: platform_ranges.get(path)
+            for path in hub_ranges
+            if path in keys and platform_ranges.get(path) != hub_ranges[path]
+        }
         if bled:
             range_bleed[domain] = bled
         # Refined types walk list items, so the key set must too or the
@@ -4785,6 +4791,16 @@ def _collect_bleed_keys(
         if refined_bled:
             refined_bleed[domain] = refined_bled
     return range_bleed, refined_bleed
+
+
+def _shed_range_bleed(
+    field_ranges: dict[tuple[str, ...], tuple[int | float, int | float]],
+    range_bleed: dict[tuple[str, ...], tuple[int | float, int | float] | None],
+) -> dict[tuple[str, ...], tuple[int | float, int | float]]:
+    """Drop shed hub ranges, substituting the platform's own where it has one."""
+    return {k: v for k, v in field_ranges.items() if k not in range_bleed} | {
+        k: v for k, v in range_bleed.items() if v is not None
+    }
 
 
 def _shed_refined_bleed(

--- a/tests/test_sync_components_field_ranges.py
+++ b/tests/test_sync_components_field_ranges.py
@@ -43,10 +43,12 @@ from script.sync_components import (  # type: ignore[import-not-found]
     _MACHINE_DERIVED_RANGE_FIELDS,
     _apply_field_ranges,
     _collect_automation_field_ranges,
+    _collect_bleed_keys,
     _collect_field_ranges,
     _field_ranges_in_schema,
     _numeric_range_bounds,
     _platform_field_keys,
+    _shed_range_bleed,
     _walk_entries,
     introspect_component,
 )
@@ -362,18 +364,32 @@ def test_per_domain_bleed_does_not_aggregate_across_platforms() -> None:
     sibling domain bounds the same key.
     """
     hub = _FakeManifest({cv.Optional("address"): cv.hex_uint8_t})
-    bounded = _FakeManifest({cv.Optional("address"): cv.All(cv.int_, cv.Range(min=5, max=48))})
+    bounded = _FakeManifest({cv.Optional("address"): cv.All(cv.int_, cv.Range(min=0, max=255))})
     unbounded = _FakeManifest({cv.Optional("address"): cv.positive_int})
-    hub_ranges = _collect_field_ranges(hub)
-    bleed: dict[str, set] = {}
-    for domain, pm in (("a", bounded), ("b", unbounded)):
-        keys = _platform_field_keys([pm])
-        pbounded = set(_collect_field_ranges(pm))
-        bled = {p for p in hub_ranges if p in keys and p not in pbounded}
-        if bled:
-            bleed[domain] = bled
-    assert ("address",) not in bleed.get("a", set())  # a bounds it -> keep
-    assert ("address",) in bleed.get("b", set())  # b unbounded -> shed
+    bleed, _refined = _collect_bleed_keys(hub, [("a", bounded), ("b", unbounded)])
+    assert ("address",) not in bleed.get("a", {})  # a bounds it identically -> keep
+    assert ("address",) in bleed.get("b", {})  # b unbounded -> shed
+
+
+def test_divergent_platform_bound_is_shed_with_substitute() -> None:
+    """A shed path the platform bounds differently maps to the platform's own bounds."""
+    hub = _FakeManifest({cv.Optional("address"): cv.hex_uint8_t})
+    divergent = _FakeManifest({cv.Optional("address"): cv.All(cv.int_, cv.Range(min=5, max=48))})
+    unbounded = _FakeManifest({cv.Optional("address"): cv.positive_int})
+    bleed, _refined = _collect_bleed_keys(hub, [("a", divergent), ("b", unbounded)])
+    assert bleed["a"][("address",)] == (5, 48)
+    assert bleed["b"][("address",)] is None
+
+
+def test_shed_range_bleed_substitutes_and_drops() -> None:
+    """The shed keeps unshed paths, substitutes platform bounds, drops the rest."""
+    field_ranges = {
+        ("kept",): (0, 255),
+        ("substituted",): (0, 255),
+        ("dropped",): (0, 255),
+    }
+    shed = _shed_range_bleed(field_ranges, {("substituted",): (5, 48), ("dropped",): None})
+    assert shed == {("kept",): (0, 255), ("substituted",): (5, 48)}
 
 
 def test_no_platform_component_has_no_range_bleed() -> None:


### PR DESCRIPTION
# What does this implement/fix?

The range analog of the refined type substitution. `_collect_bleed_keys` now maps each shed range path to the platform's own bounds instead of collecting a bare path set, sheds when the platform bounds the key differently rather than only when unbounded, and the new `_shed_range_bleed` substitutes those bounds on the platform build the same way `_shed_refined_bleed` already does for refinements. An audit of the installed tree found zero divergent bound pairs today, so the shipped catalog is unchanged; this is forward correctness for the first upstream schema that diverges. New tests pin the divergent substitution, the unbounded drop, and the identical bounds keep; the per domain aggregation test now exercises `_collect_bleed_keys` itself.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2427

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
