### PR TITLE
Migrate the deprecated rp2040 platform key to rp2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,8 +408,11 @@ against legacy behaviour before assuming the simpler version suffices.
   unhandled. Current bespoke entries: the api `services`→`actions` /
   `service`→`action` pair (#2396) and the homeassistant action's
   `service`→`action` field under both registered ids; the fold also
-  carries the legacy `homeassistant.service` node id and the ethernet
-  `clk_mode`→`clk` conversion. The frontend's migrate nudge drives the
+  carries the legacy `homeassistant.service` node id, the ethernet
+  `clk_mode`→`clk` conversion, and the `_PLATFORM_KEY_RENAMES` table of
+  top-level platform block respells (`rp2040:`→`rp2:`; esphome component
+  ALIASES are invisible to the rename canary, so these are always
+  hand-added). The frontend's migrate nudge drives the
   one-click whole-file update; new migrations extend the artifact or
   add a rule function — never a new command.
 - **The long-lived process never imports `esphome.components.*`.**

--- a/esphome_device_builder/controllers/migrations.py
+++ b/esphome_device_builder/controllers/migrations.py
@@ -246,6 +246,34 @@ def _migrate_ethernet_clk(lines: list[str]) -> list[str]:
     return lines
 
 
+# Deprecated top-level platform block keys and their canonical spellings
+# (esphome component ALIASES, invisible to the cv.rename_key sync canary).
+# rp2040 -> rp2: renamed in esphome 2026.7, alias removed in 2027.7.
+_PLATFORM_KEY_RENAMES = (("rp2040", "rp2"),)
+
+
+def _migrate_platform_keys(lines: list[str]) -> list[str]:
+    """Respell deprecated top-level platform block keys to their canonical names."""
+    for legacy, canonical in _PLATFORM_KEY_RENAMES:
+        lines = _respell_top_level_key(lines, legacy, canonical)
+    return lines
+
+
+def _respell_top_level_key(lines: list[str], legacy: str, canonical: str) -> list[str]:
+    """
+    Rename the column-0 ``legacy:`` block key to ``canonical``, body untouched.
+
+    An existing ``canonical:`` block leaves the file alone — merging
+    two blocks is not the rule's job.
+    """
+    idx = find_block_header(lines, legacy)
+    if idx is None or find_block_header(lines, canonical) is not None:
+        return lines
+    out = list(lines)
+    out[idx] = canonical + lines[idx][len(legacy) :]
+    return out
+
+
 def _child_block_span(
     lines: list[str],
     start: int,
@@ -426,5 +454,6 @@ _RULES = (
     _canonicalize_api_actions,
     _canonicalize_action_nodes,
     _migrate_ethernet_clk,
+    _migrate_platform_keys,
     _apply_generated_renames,
 )

--- a/esphome_device_builder/controllers/migrations.py
+++ b/esphome_device_builder/controllers/migrations.py
@@ -246,34 +246,6 @@ def _migrate_ethernet_clk(lines: list[str]) -> list[str]:
     return lines
 
 
-# Deprecated top-level platform block keys and their canonical spellings
-# (esphome component ALIASES, invisible to the cv.rename_key sync canary).
-# rp2040 -> rp2: renamed in esphome 2026.7, alias removed in 2027.7.
-_PLATFORM_KEY_RENAMES = (("rp2040", "rp2"),)
-
-
-def _migrate_platform_keys(lines: list[str]) -> list[str]:
-    """Respell deprecated top-level platform block keys to their canonical names."""
-    for legacy, canonical in _PLATFORM_KEY_RENAMES:
-        lines = _respell_top_level_key(lines, legacy, canonical)
-    return lines
-
-
-def _respell_top_level_key(lines: list[str], legacy: str, canonical: str) -> list[str]:
-    """
-    Rename the column-0 ``legacy:`` block key to ``canonical``, body untouched.
-
-    An existing ``canonical:`` block leaves the file alone — merging
-    two blocks is not the rule's job.
-    """
-    idx = find_block_header(lines, legacy)
-    if idx is None or find_block_header(lines, canonical) is not None:
-        return lines
-    out = list(lines)
-    out[idx] = canonical + lines[idx][len(legacy) :]
-    return out
-
-
 def _child_block_span(
     lines: list[str],
     start: int,
@@ -289,6 +261,33 @@ def _child_block_span(
             continue
         return idx, child_block_end(lines, idx, min(end, len(lines)), child_indent)
     return None
+
+
+# Deprecated top-level platform block keys and their canonical spellings
+# (esphome component ALIASES, invisible to the cv.rename_key sync canary).
+# rp2040 -> rp2: renamed in esphome 2026.7, alias removed in 2027.7.
+_PLATFORM_KEY_RENAMES = (("rp2040", "rp2"),)
+
+
+def _migrate_platform_keys(lines: list[str]) -> list[str]:
+    """Respell deprecated top-level platform block keys to their canonical names."""
+    for legacy, canonical in _PLATFORM_KEY_RENAMES:
+        lines = _respell_top_level_key(lines, legacy, canonical)
+    return lines
+
+
+def _respell_top_level_key(lines: list[str], legacy: str, canonical: str) -> list[str]:
+    """
+    Rename the column-0 ``legacy:`` block header to ``canonical:``.
+
+    No-op when a ``canonical:`` block already exists.
+    """
+    idx = find_block_header(lines, legacy)
+    if idx is None or find_block_header(lines, canonical) is not None:
+        return lines
+    out = list(lines)
+    out[idx] = canonical + lines[idx][len(legacy) :]
+    return out
 
 
 def _block_scalar_mask(lines: list[str]) -> list[bool]:

--- a/tests/test_config_migrations.py
+++ b/tests/test_config_migrations.py
@@ -424,6 +424,52 @@ def test_block_scalar_indent_indicator_untouched() -> None:
     assert render_migrations(text) is None
 
 
+_RP2040_YAML = """esphome:
+  name: pico
+
+rp2040:  # target platform
+  board: rpipicow
+  framework:
+    platform_version: 1.2.0
+
+wifi:
+  ssid: foo
+"""
+
+
+def test_rp2040_platform_key_respelled_to_rp2() -> None:
+    new_text = _respell(_RP2040_YAML)
+    assert "rp2:  # target platform\n" in new_text
+    assert "rp2040" not in new_text
+    assert "  board: rpipicow\n" in new_text
+    assert "    platform_version: 1.2.0\n" in new_text
+    assert "wifi:\n  ssid: foo\n" in new_text
+
+
+def test_rp2040_absent_untouched() -> None:
+    assert render_migrations("esphome:\n  name: pico\n\nrp2:\n  board: rpipicow\n") is None
+
+
+def test_rp2040_beside_existing_rp2_untouched() -> None:
+    text = _RP2040_YAML + "\nrp2:\n  board: rpipico\n"
+    assert render_migrations(text) is None
+
+
+def test_rp2040_prefixed_components_untouched() -> None:
+    text = "rp2040:\n  board: rpipicow\n\noutput:\n  - platform: rp2040_pwm\n    pin: 1\n"
+    new_text = _respell(text)
+    assert new_text.startswith("rp2:\n")
+    assert "platform: rp2040_pwm" in new_text
+
+
+def test_rp2040_composes_with_other_rules() -> None:
+    text = "api:\n  services:\n    - service: hi\n      then: []\n\n" + _RP2040_YAML
+    new_text = _respell(text)
+    assert "  actions:\n" in new_text
+    assert "- action: hi\n" in new_text
+    assert "rp2:  # target platform\n" in new_text
+
+
 _VOC_RULE = MigrationRule(
     kind="platform_item_field", old="voc", new="voc_index", domain="sensor", platform="sgp4x"
 )


### PR DESCRIPTION
# What does this implement/fix?

Implements https://github.com/esphome/backlog/issues/156: the migrate nudge now offers renaming a deprecated `rp2040:` platform block to `rp2:` (esphome 2026.7 renamed the platform; the alias is removed in 2027.7).

The rule lands in the `editor/migrate_config` fold as a `_PLATFORM_KEY_RENAMES` table plus a generic `_respell_top_level_key` helper, so future top-level platform renames are one table row. It respells only the column-0 key token (inline comment and body untouched) and no-ops when a `rp2:` block already exists, since merging two blocks is not the rule's job. These renames ship as esphome component ALIASES, not `cv.rename_key`, so they are invisible to the sync's rename canary and always hand-added; CLAUDE.md's bespoke-entries note now says so.

The issue predates the dependency bump: it asked for a gate on installed esphome >= 2026.7.0, but `pyproject.toml` now floors `esphome>=2026.7.3`, so every supported install accepts `rp2:` and the rule is ungated like the others. Verified end to end against the venv's esphome 2026.7.3: the legacy spelling emits upstream's "rename it to 'rp2:'" deprecation warning, `render_migrations` produces a one line diff, and the migrated config validates cleanly with `esphome config`.

No frontend change needed; the existing config-migration nudge dry-runs `editor/migrate_config` and picks the rule up (frontend #1540 retired the section-level deprecation registry in favor of exactly this path). The catalog canonical-key flip stays separate (backlog #155).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/backlog/issues/156 (cross-repo, close manually on merge)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR:

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
