### PR TITLE
Pin the art invariant through the resolver and the manifested catalog

### DIFF
--- a/tests/test_boards_json.py
+++ b/tests/test_boards_json.py
@@ -27,8 +27,8 @@ import orjson
 import pytest
 from esphome.components.esp32.boards import BOARDS as ESP32_BOARDS
 
-import esphome_device_builder
 from esphome_device_builder.definitions import (
+    _generic_image_url,
     build_board_catalog_from_manifests,
     load_board_body_from_disk,
     load_board_catalog,
@@ -774,9 +774,12 @@ def test_every_board_has_a_docs_url() -> None:
 
 
 def test_every_platform_has_generic_board_art() -> None:
-    """Each platform's ``_generic/<key>.svg`` art fallback exists."""
-    generic_dir = (
-        Path(esphome_device_builder.__file__).parent / "definitions" / "boards" / "_generic"
-    )
+    """Each platform resolves generic art through the loader's fallback."""
     for platform in Platform:
-        assert (generic_dir / f"{platform.value}.svg").is_file(), platform.value
+        assert _generic_image_url(platform.value, None), platform.value
+
+
+def test_every_manifested_board_carries_art() -> None:
+    """Every hand-curated board lands in the catalog with a non-empty ``images``."""
+    catalog = build_board_catalog_from_manifests(strict=True)
+    assert [b.id for b in catalog.boards if not b.images] == []


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #2465, taking the review round that landed as it merged. The art invariant now asserts through the loader (`_generic_image_url(platform.value, None)`), so a change to `_GENERIC_DIR`, the extension list, or the URL shape is caught, not just a missing file at a path the test reconstructs itself. A second test pins the user visible outcome: every manifested board lands in the catalog with a non empty `images`, the strictly stronger form the review verified holds exactly (the 12 RP2 boards were the only manifested boards without art during the regression).

**Related issue or feature (if applicable):**

- follow-up to the review on #2465

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR:

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
