### PR TITLE
Surface name and id at the top of generated component blocks

### DIFF
--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -504,7 +504,7 @@ def _emit_field(key: str, value: Any, indent: str) -> list[str]:
 
 def _surface_identity_first(mapping: dict[str, Any]) -> dict[str, Any]:
     """Return *mapping* with ``name`` then ``id`` as the first keys when present."""
-    lead = {key: mapping[key] for key in ("name", "id") if key in mapping}
+    lead: dict[str, Any] = {key: mapping[key] for key in ("name", "id") if key in mapping}
     if not lead:
         return mapping
     return {**lead, **mapping}

--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -100,8 +100,8 @@ def generate_component_yaml(  # noqa: C901
     Nested values in ``fields`` (dicts as values) are emitted as
     indented YAML mappings — frontend submits the full structure as a
     single ``fields`` argument, no separate sub-entries dict needed.
-    ``id`` floats to the top of the block (and of entity sub-blocks)
-    regardless of the caller's field order.
+    ``name`` and ``id`` (in that order) surface to the top of the block
+    (and of entity sub-blocks) regardless of the caller's field order.
 
     Two kinds of identifier auto-fill happen here:
 
@@ -147,17 +147,17 @@ def generate_component_yaml(  # noqa: C901
         if not isinstance(sub, dict):
             continue
         sub_keys = {c.key for c in entry.config_entries}
-        # Build a fresh dict with id/name at the front so the emitted
-        # YAML reads naturally (humans put id/name first).
+        # Build a fresh dict with name/id at the front so the emitted
+        # YAML reads naturally (humans put name/id first).
         autofill: dict[str, Any] = {}
-        if "id" in sub_keys and not sub.get("id"):
-            autofill["id"] = f"{parent_id}_{entry.key}"
         if "name" in sub_keys and not sub.get("name"):
             autofill["name"] = entry.label or entry.key.replace("_", " ").title()
+        if "id" in sub_keys and not sub.get("id"):
+            autofill["id"] = f"{parent_id}_{entry.key}"
         autofill.update(sub)
-        fields[entry.key] = _surface_id_first(autofill)
+        fields[entry.key] = _surface_identity_first(autofill)
 
-    fields = _surface_id_first(fields)
+    fields = _surface_identity_first(fields)
 
     if domain is not None:
         lines = [f"{domain}:", f"{ESPHOME_YAML_INDENT}- platform: {unqualified}"]
@@ -502,11 +502,12 @@ def _emit_field(key: str, value: Any, indent: str) -> list[str]:
     return [f"{indent}{safe_key}: {_format_yaml_value(value)}"]
 
 
-def _surface_id_first(mapping: dict[str, Any]) -> dict[str, Any]:
-    """Return *mapping* with ``id`` as the first key when present."""
-    if "id" not in mapping:
+def _surface_identity_first(mapping: dict[str, Any]) -> dict[str, Any]:
+    """Return *mapping* with ``name`` then ``id`` as the first keys when present."""
+    lead = {key: mapping[key] for key in ("name", "id") if key in mapping}
+    if not lead:
         return mapping
-    return {"id": mapping["id"], **mapping}
+    return {**lead, **mapping}
 
 
 def _generate_id(component_id: str, name: str | None = None) -> str:

--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -100,6 +100,8 @@ def generate_component_yaml(  # noqa: C901
     Nested values in ``fields`` (dicts as values) are emitted as
     indented YAML mappings — frontend submits the full structure as a
     single ``fields`` argument, no separate sub-entries dict needed.
+    ``id`` floats to the top of the block (and of entity sub-blocks)
+    regardless of the caller's field order.
 
     Two kinds of identifier auto-fill happen here:
 
@@ -145,17 +147,17 @@ def generate_component_yaml(  # noqa: C901
         if not isinstance(sub, dict):
             continue
         sub_keys = {c.key for c in entry.config_entries}
-        if sub.get("name") and sub.get("id"):
-            continue
-        # Build a fresh dict with name/id at the front so the emitted
-        # YAML reads naturally (humans put name/id first).
+        # Build a fresh dict with id/name at the front so the emitted
+        # YAML reads naturally (humans put id/name first).
         autofill: dict[str, Any] = {}
-        if "name" in sub_keys and not sub.get("name"):
-            autofill["name"] = entry.label or entry.key.replace("_", " ").title()
         if "id" in sub_keys and not sub.get("id"):
             autofill["id"] = f"{parent_id}_{entry.key}"
+        if "name" in sub_keys and not sub.get("name"):
+            autofill["name"] = entry.label or entry.key.replace("_", " ").title()
         autofill.update(sub)
-        fields[entry.key] = autofill
+        fields[entry.key] = _surface_id_first(autofill)
+
+    fields = _surface_id_first(fields)
 
     if domain is not None:
         lines = [f"{domain}:", f"{ESPHOME_YAML_INDENT}- platform: {unqualified}"]
@@ -498,6 +500,13 @@ def _emit_field(key: str, value: Any, indent: str) -> list[str]:
         rendered = ", ".join(_format_flow_yaml_value(item) for item in value)
         return [f"{indent}{safe_key}: [{rendered}]"]
     return [f"{indent}{safe_key}: {_format_yaml_value(value)}"]
+
+
+def _surface_id_first(mapping: dict[str, Any]) -> dict[str, Any]:
+    """Return *mapping* with ``id`` as the first key when present."""
+    if "id" not in mapping:
+        return mapping
+    return {"id": mapping["id"], **mapping}
 
 
 def _generate_id(component_id: str, name: str | None = None) -> str:

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -946,11 +946,14 @@ async def test_generate_yaml_autofills_subentity_name_and_id(
     )
     # Top-level id auto-generated from the bare component stem and
     # surfaced right after the ``- platform:`` line.
-    assert yaml.splitlines()[2] == "    id: hlw8012"
+    lines = yaml.splitlines()
+    assert lines[2] == "    id: hlw8012"
     # Sub-entities get a default ``name`` (from the entry label) and a
     # ``<parent_id>_<key>`` id, prepended name-first ahead of user-supplied keys.
-    assert yaml.index("name: Current") < yaml.index("id: hlw8012_current")
-    assert yaml.index("name: Energy") < yaml.index("id: hlw8012_energy")
+    current = lines.index("      name: Current")
+    assert lines[current + 1] == "      id: hlw8012_current"
+    energy = lines.index("      name: Energy")
+    assert lines[energy + 1] == "      id: hlw8012_energy"
 
 
 async def test_generate_yaml_preserves_user_supplied_subentity_name(
@@ -967,12 +970,12 @@ async def test_generate_yaml_preserves_user_supplied_subentity_name(
             "current": {"name": "Plug Current", "id": "plug_amps"},
         },
     )
-    assert "name: Plug Current" in yaml
-    assert "id: plug_amps" in yaml
+    lines = yaml.splitlines()
     # A fully user-supplied sub-block still surfaces name then id first.
-    assert yaml.index("name: Plug Current") < yaml.index("id: plug_amps")
-    # And the auto-id prefix tracks the user's chosen parent id.
-    assert "id: plug" in yaml
+    current = lines.index("      name: Plug Current")
+    assert lines[current + 1] == "      id: plug_amps"
+    # And the user's chosen parent id surfaces right after ``- platform:``.
+    assert lines[2] == "    id: plug"
 
 
 async def test_generate_yaml_skips_autofill_for_non_entity_subblocks(

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -944,14 +944,13 @@ async def test_generate_yaml_autofills_subentity_name_and_id(
             "energy": {"device_class": "energy"},
         },
     )
-    # Top-level id auto-generated from the bare component stem.
-    assert "id: hlw8012" in yaml
-    # Sub-entities get a default ``name`` (from the entry label) and a
-    # ``<parent_id>_<key>`` id, prepended ahead of user-supplied keys.
-    assert "name: Current" in yaml
-    assert "id: hlw8012_current" in yaml
-    assert "name: Energy" in yaml
-    assert "id: hlw8012_energy" in yaml
+    # Top-level id auto-generated from the bare component stem and
+    # surfaced right after the ``- platform:`` line.
+    assert yaml.splitlines()[2] == "    id: hlw8012"
+    # Sub-entities get a ``<parent_id>_<key>`` id and a default ``name``
+    # (from the entry label), prepended id-first ahead of user-supplied keys.
+    assert yaml.index("id: hlw8012_current") < yaml.index("name: Current")
+    assert yaml.index("id: hlw8012_energy") < yaml.index("name: Energy")
 
 
 async def test_generate_yaml_preserves_user_supplied_subentity_name(
@@ -970,6 +969,8 @@ async def test_generate_yaml_preserves_user_supplied_subentity_name(
     )
     assert "name: Plug Current" in yaml
     assert "id: plug_amps" in yaml
+    # A fully user-supplied sub-block still surfaces its id first.
+    assert yaml.index("id: plug_amps") < yaml.index("name: Plug Current")
     # And the auto-id prefix tracks the user's chosen parent id.
     assert "id: plug" in yaml
 

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -947,10 +947,10 @@ async def test_generate_yaml_autofills_subentity_name_and_id(
     # Top-level id auto-generated from the bare component stem and
     # surfaced right after the ``- platform:`` line.
     assert yaml.splitlines()[2] == "    id: hlw8012"
-    # Sub-entities get a ``<parent_id>_<key>`` id and a default ``name``
-    # (from the entry label), prepended id-first ahead of user-supplied keys.
-    assert yaml.index("id: hlw8012_current") < yaml.index("name: Current")
-    assert yaml.index("id: hlw8012_energy") < yaml.index("name: Energy")
+    # Sub-entities get a default ``name`` (from the entry label) and a
+    # ``<parent_id>_<key>`` id, prepended name-first ahead of user-supplied keys.
+    assert yaml.index("name: Current") < yaml.index("id: hlw8012_current")
+    assert yaml.index("name: Energy") < yaml.index("id: hlw8012_energy")
 
 
 async def test_generate_yaml_preserves_user_supplied_subentity_name(
@@ -969,8 +969,8 @@ async def test_generate_yaml_preserves_user_supplied_subentity_name(
     )
     assert "name: Plug Current" in yaml
     assert "id: plug_amps" in yaml
-    # A fully user-supplied sub-block still surfaces its id first.
-    assert yaml.index("id: plug_amps") < yaml.index("name: Plug Current")
+    # A fully user-supplied sub-block still surfaces name then id first.
+    assert yaml.index("name: Plug Current") < yaml.index("id: plug_amps")
     # And the auto-id prefix tracks the user's chosen parent id.
     assert "id: plug" in yaml
 

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -60,7 +60,7 @@ from esphome_device_builder.helpers.yaml import (
     upsert_yaml_leaf_under_top_block,
     write_user_yaml,
 )
-from esphome_device_builder.helpers.yaml.component import _list_item_indent
+from esphome_device_builder.helpers.yaml.component import _first_defined_id, _list_item_indent
 from esphome_device_builder.helpers.yaml.scalar import (
     ESPHOME_YAML_INDENT,
     _plain_is_fast_safe,
@@ -1620,6 +1620,39 @@ def test_generate_component_yaml_singleton_emits_mapping_form() -> None:
     component = _component(component_id="wifi", category=ComponentCategory.MISC, multi_conf=False)
     out = generate_component_yaml(component, {"ssid": "home"})
     assert out == "wifi:\n  ssid: home"
+
+
+def test_generate_component_yaml_surfaces_id_after_platform() -> None:
+    """A trailing ``id`` in fields is emitted right after the ``- platform:`` line."""
+    component = _component(component_id="sensor.dht", category=ComponentCategory.SENSOR)
+    out = generate_component_yaml(component, {"pin": "GPIO4", "name": "Temp", "id": "temp_1"})
+    assert out.splitlines()[:4] == [
+        "sensor:",
+        "  - platform: dht",
+        "    id: temp_1",
+        "    pin: GPIO4",
+    ]
+
+
+def test_generate_component_yaml_surfaces_id_first_in_mapping_form() -> None:
+    """A trailing ``id`` in fields is emitted as the first mapping key."""
+    component = _component(component_id="myc", category=ComponentCategory.MISC)
+    out = generate_component_yaml(component, {"foo": 1, "id": "myc_1"})
+    assert out == "myc:\n  id: myc_1\n  foo: 1"
+
+
+def test_generate_component_yaml_surfaces_id_first_in_multi_conf_list_form() -> None:
+    """A trailing ``id`` in fields leads the ``- `` list item."""
+    component = _component(component_id="globals", category=ComponentCategory.MISC, multi_conf=True)
+    out = generate_component_yaml(component, {"type": "int", "id": "g1"})
+    assert out.startswith("globals:\n  - id: g1\n    type: int")
+
+
+def test_generate_component_yaml_first_defined_id_is_the_surfaced_parent_id() -> None:
+    """``_first_defined_id`` sees the entry-level id, not an earlier nested one."""
+    component = _component(component_id="sensor.hlw8012", category=ComponentCategory.SENSOR)
+    out = generate_component_yaml(component, {"current": {"id": "amps"}, "id": "plug"})
+    assert _first_defined_id(out) == "plug"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -1622,13 +1622,14 @@ def test_generate_component_yaml_singleton_emits_mapping_form() -> None:
     assert out == "wifi:\n  ssid: home"
 
 
-def test_generate_component_yaml_surfaces_id_after_platform() -> None:
-    """A trailing ``id`` in fields is emitted right after the ``- platform:`` line."""
+def test_generate_component_yaml_surfaces_name_and_id_after_platform() -> None:
+    """Trailing ``name``/``id`` fields are emitted right after the ``- platform:`` line."""
     component = _component(component_id="sensor.dht", category=ComponentCategory.SENSOR)
     out = generate_component_yaml(component, {"pin": "GPIO4", "name": "Temp", "id": "temp_1"})
-    assert out.splitlines()[:4] == [
+    assert out.splitlines() == [
         "sensor:",
         "  - platform: dht",
+        "    name: Temp",
         "    id: temp_1",
         "    pin: GPIO4",
     ]
@@ -2239,15 +2240,14 @@ def test_generate_component_yaml_id_falls_back_when_name_slug_is_empty() -> None
     component = _component(component_id="hlw8012", category=ComponentCategory.MISC)
     out = generate_component_yaml(component, {"id": "", "name": ":::"})
     # Auto-filled id is just the component stem — no trailing ``_``.
-    assert "  id: hlw8012\n" in out
-    assert "  id: hlw8012_\n" not in out
+    assert out.endswith("  id: hlw8012")
 
 
 def test_generate_component_yaml_id_dedups_leading_chip_stem() -> None:
     """A name already leading with the chip stem doesn't double it in the auto-id."""
     component = _component(component_id="hlw8012", category=ComponentCategory.MISC)
     out = generate_component_yaml(component, {"id": "", "name": "HLW8012 Power Monitor"})
-    assert "  id: hlw8012_power_monitor\n" in out
+    assert "  id: hlw8012_power_monitor" in out
     assert "hlw8012_hlw8012" not in out
 
 


### PR DESCRIPTION
# What does this implement/fix?

Generated component blocks now start with `name:` and `id:`, right after the `platform:` line, instead of leaving the id at the bottom. The order is always name, id, everything else; entity sub blocks get the same treatment, including fully user supplied ones. The reorder lives in `generate_component_yaml`, so both the add component flow and the create wizard board defaults pick it up.

**Related issue or feature (if applicable):**

- https://github.com/orgs/esphome/discussions/3789

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

