### PR TITLE
Map name_add_mac_suffix mDNS broadcasts to catalog names

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -29,6 +29,7 @@ from functools import partial
 from typing import Any, Protocol
 
 from ...helpers.async_ import create_eager_task, drain_tasks, log_task_exit
+from ...helpers.hostname import mac_suffix_from_address, split_mac_suffix_broadcast
 from ...helpers.ip import drop_unspecified_addresses, is_unspecified_address
 from ...helpers.subscriber_presence import SubscriberPresence
 from ...models import (
@@ -657,5 +658,37 @@ class DeviceStateMonitor(TaskControllerBase):
     # ------------------------------------------------------------------
 
     def _find_device_by_name(self, name: str) -> Device | None:
+        """
+        Return a configured device for *name*.
+
+        Accepts either the YAML ``esphome.name`` or a live mDNS
+        broadcast shaped as ``{name}-{mac_suffix}`` when
+        ``name_add_mac_suffix`` is enabled.
+        """
         bucket = self._get_devices_by_name(name)
-        return bucket[0] if bucket else None
+        if bucket:
+            return bucket[0]
+
+        parsed = split_mac_suffix_broadcast(name)
+        if parsed is None:
+            return None
+        base_name, suffix = parsed
+        bucket = self._get_devices_by_name(base_name)
+        if not bucket:
+            return None
+
+        if len(bucket) == 1:
+            device = bucket[0]
+            if device.mac_address:
+                expected = mac_suffix_from_address(device.mac_address)
+                if expected and expected != suffix:
+                    return None
+            return device
+
+        matches = [
+            candidate
+            for candidate in bucket
+            if candidate.mac_address
+            and mac_suffix_from_address(candidate.mac_address) == suffix
+        ]
+        return matches[0] if len(matches) == 1 else None

--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -688,7 +688,6 @@ class DeviceStateMonitor(TaskControllerBase):
         matches = [
             candidate
             for candidate in bucket
-            if candidate.mac_address
-            and mac_suffix_from_address(candidate.mac_address) == suffix
+            if candidate.mac_address and mac_suffix_from_address(candidate.mac_address) == suffix
         ]
         return matches[0] if len(matches) == 1 else None

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -476,16 +476,17 @@ class MdnsSource:
         # ``AsyncServiceBrowser`` dispatches handlers on the
         # asyncio loop, so call apply methods directly.
         monitor = self._monitor
-        device_name = device_name_from_service(name)
-        _LOGGER.debug("mDNS: %s %s (raw: %s)", state_change, device_name, name)
+        broadcast_name = device_name_from_service(name)
+        _LOGGER.debug("mDNS: %s %s (raw: %s)", state_change, broadcast_name, name)
 
         # Short-circuit unconfigured devices so we don't spawn
         # ServiceInfo lookups for unrelated ESPHome nodes on the LAN.
-        if monitor._find_device_by_name(device_name) is None:
+        device = monitor._find_device_by_name(broadcast_name)
+        if device is None:
             return
 
         if state_change == ServiceStateChange.Removed:
-            self._on_service_removed(name, device_name, sibling_type=_HTTP_SERVICE_TYPE)
+            self._on_service_removed(name, device.name, sibling_type=_HTTP_SERVICE_TYPE)
             return
 
         # Don't claim ONLINE off a bare PTR — only once the service
@@ -495,7 +496,7 @@ class MdnsSource:
         # a stale PTR for a long-gone device); claiming here latched
         # it ONLINE forever with no IP, locking out the ICMP sweep.
         info = AsyncServiceInfo(service_type, name)
-        self.cache_apply_or_resolve(zeroconf, info, device_name)
+        self.cache_apply_or_resolve(zeroconf, info, device.name)
 
     def _on_browser_event(
         self, zeroconf: Any, service_type: str, name: str, state_change: ServiceStateChange
@@ -522,7 +523,7 @@ class MdnsSource:
         # withdraw only when no anchor remains. A goodbye burst byes
         # both services in one packet, so a sleeper's first Removed
         # already sees the sibling PTR evicted.
-        if self._has_live_ptr(device_name, sibling_type):
+        if self._has_live_ptr(device_name_from_service(name), sibling_type):
             return
         # A goodbye withdraws only the PTR (firmware never byes SRV/A,
         # which stay cached for their full TTLs), so a verify-resolve
@@ -550,8 +551,10 @@ class MdnsSource:
         # the *device-named* service — the one whose ``Removed`` maps
         # back to *device_name*: a PTR-less wire answer and a cross-name
         # resolve (the adopt probe riding the factory service) apply
-        # their data below but take no ownership.
-        if self._has_live_ptr(device_name, info.type):
+        # their data below but take no ownership. ``name_add_mac_suffix``
+        # is the exception: the PTR lives under the suffixed broadcast
+        # label, but it still anchors the matched YAML name.
+        if self._ptr_anchors_device(device_name, info):
             monitor.apply(device_name, DeviceState.ONLINE, "mdns", claim=True)
         else:
             _LOGGER.debug(
@@ -618,13 +621,13 @@ class MdnsSource:
         MQTT / ping paths.
         """
         monitor = self._monitor
-        device_name = device_name_from_service(name)
+        device = monitor._find_device_by_name(device_name_from_service(name))
         # Look at the whole name bucket, not just bucket[0]: sibling
         # YAMLs can share an ``esphome.name`` (a config + a ``foo (1)``
         # copy). An all-API bucket skips only the identity path below;
         # a ``Removed`` is evidence-gated instead (an api+web_server
         # bucket publishes both PTRs).
-        bucket = monitor._get_devices_by_name(device_name)
+        bucket = monitor._get_devices_by_name(device.name) if device is not None else []
         if not bucket:
             return
         if state_change == ServiceStateChange.Removed:
@@ -634,12 +637,12 @@ class MdnsSource:
             # compiled-without-api device whose YAML gained ``api:``
             # must still withdraw. ``source_withdrawn`` itself no-ops
             # for a name mdns doesn't own.
-            self._on_service_removed(name, device_name, sibling_type=_ESPHOME_SERVICE_TYPE)
+            self._on_service_removed(name, device.name, sibling_type=_ESPHOME_SERVICE_TYPE)
             return
-        if all(device.api_enabled for device in bucket):
+        if all(d.api_enabled for d in bucket):
             return
         info = AsyncServiceInfo(service_type, name)
-        self.cache_apply_or_resolve(zeroconf, info, device_name, self._apply_http_txt)
+        self.cache_apply_or_resolve(zeroconf, info, device.name, self._apply_http_txt)
 
     def _apply_http_txt(self, device_name: str, info: AsyncServiceInfo) -> None:
         """
@@ -669,6 +672,27 @@ class MdnsSource:
         return self._cached_ptr(f"{device_name}.{_ESPHOME_SERVICE_TYPE}") or self._cached_ptr(
             f"{device_name}.{_HTTP_SERVICE_TYPE}", _HTTP_SERVICE_TYPE
         )
+
+    def _ptr_anchors_device(self, device_name: str, info: AsyncServiceInfo) -> bool:
+        """
+        Report whether a live PTR on *info* can anchor *device_name*'s claim.
+
+        Normally the PTR must sit under *device_name* itself. When
+        ``name_add_mac_suffix`` is on, the wire PTR is under the
+        suffixed broadcast label while apply still keys to the YAML
+        name — allow that only when the broadcast resolves to the
+        same configured device. A cross-name adopt probe (factory
+        service, user-chosen name) must not claim.
+        """
+        if self._has_live_ptr(device_name, info.type):
+            return True
+        broadcast_name = device_name_from_service(info.name)
+        if broadcast_name == device_name:
+            return False
+        if not self._has_live_ptr(broadcast_name, info.type):
+            return False
+        device = self._monitor._find_device_by_name(broadcast_name)
+        return device is not None and device.name == device_name
 
     def _has_live_ptr(self, device_name: str, service_type: str) -> bool:
         """Whether the cache holds an unexpired *service_type* PTR for *device_name*."""

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -217,14 +217,19 @@ class PingSource(SweepSource):
         """Resolve *device.address* through the DNS cache and ICMP it."""
         monitor = self._monitor
         async with self.icmp_concurrency:
-            addresses = await monitor.state.dns_cache.async_resolve(device.address)
-            if not addresses and is_local_hostname(device.address):
-                # System resolver couldn't resolve the ``.local`` (no nss-mdns
-                # in most container images). Fall back to zeroconf's own mDNS
-                # cache, kept fresh by the ``AsyncServiceBrowser``, rather than
-                # giving up — but ping still decides liveness, so a stale or
-                # reflected entry demotes instead of latching ONLINE (#1776).
-                addresses = monitor.mdns.get_cached_addresses(device.address)
+            addresses: list[str] = []
+            for hostname in shared.local_hostnames_for_device(device):
+                resolved = await monitor.state.dns_cache.async_resolve(hostname)
+                if not resolved and is_local_hostname(hostname):
+                    # System resolver couldn't resolve the ``.local`` (no nss-mdns
+                    # in most container images). Fall back to zeroconf's own mDNS
+                    # cache, kept fresh by the ``AsyncServiceBrowser``, rather than
+                    # giving up — but ping still decides liveness, so a stale or
+                    # reflected entry demotes instead of latching ONLINE (#1776).
+                    resolved = monitor.mdns.get_cached_addresses(hostname) or []
+                if resolved:
+                    addresses = resolved
+                    break
             if not addresses:
                 # mDNS-less devices: the ``.local`` won't resolve but a
                 # prior MQTT/DNS observation left a usable IP. Ping that so

--- a/esphome_device_builder/controllers/_device_state_monitor/shared.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/shared.py
@@ -11,7 +11,11 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
-from ...helpers.hostname import is_local_hostname
+from ...helpers.hostname import (
+    broadcast_hostname_with_mac_suffix,
+    default_mdns_address,
+    is_local_hostname,
+)
 from ...helpers.ip import drop_unspecified_addresses
 from ...models import Device, DeviceState, ReachabilitySource
 
@@ -41,6 +45,18 @@ _MDNS_HOSTNAME_RESOLVE_TIMEOUT = 3.0
 # inside a single ICMP timeout window. One bound for every ICMP
 # consumer (ping sweep, reviver pre-filter).
 ICMP_BATCH_SIZE = 24
+
+
+def local_hostnames_for_device(device: Device) -> list[str]:
+    """Return ``device.address`` plus the ``name_add_mac_suffix`` hostname when known."""
+    hostnames = [device.address] if device.address else []
+    if device.mac_address:
+        suffixed = default_mdns_address(
+            broadcast_hostname_with_mac_suffix(device.name, device.mac_address)
+        )
+        if suffixed not in hostnames:
+            hostnames.append(suffixed)
+    return hostnames
 
 
 def should_ping(monitor: DeviceStateMonitor, device: Device) -> bool:
@@ -85,7 +101,10 @@ def sweep_has_no_target(monitor: DeviceStateMonitor, device: Device) -> bool:
         return True
     if not monitor.state.dns_cache.has_cached_failure(address):
         return False
-    return not (is_local_hostname(address) and monitor.mdns.get_cached_addresses(address))
+    for hostname in local_hostnames_for_device(device):
+        if is_local_hostname(hostname) and monitor.mdns.get_cached_addresses(hostname):
+            return False
+    return True
 
 
 def apply_resolved_addresses(

--- a/esphome_device_builder/helpers/hostname.py
+++ b/esphome_device_builder/helpers/hostname.py
@@ -2,10 +2,50 @@
 
 from __future__ import annotations
 
+import re
+
+# ``name_add_mac_suffix: true`` appends ``-<last-3-mac-bytes-hex>`` to
+# the configured ``esphome.name`` on the wire. Six lowercase hex digits
+# is unambiguous with ESPHome's hostname rules (base names can't end in
+# a bare 6-hex MAC suffix unless the user typed it literally).
+_MAC_SUFFIX_BROADCAST_RE = re.compile(r"^(.+)-([0-9a-f]{6})$")
+_MAC_SEPARATORS = str.maketrans("", "", ":-.")
+
 
 def default_mdns_address(name: str) -> str:
     """Return the mDNS address ESPHome derives from a device *name* by default."""
     return f"{name}.local"
+
+
+def mac_suffix_from_address(mac: str) -> str:
+    """Return ESPHome's ``name_add_mac_suffix`` tail (last 3 MAC bytes, lowercase hex)."""
+    stripped = mac.translate(_MAC_SEPARATORS).lower()
+    if len(stripped) != 12:
+        return ""
+    try:
+        int(stripped, 16)
+    except ValueError:
+        return ""
+    return stripped[-6:]
+
+
+def broadcast_hostname_with_mac_suffix(base_name: str, mac: str) -> str:
+    """Return the mDNS hostname ESPHome publishes when ``name_add_mac_suffix`` is on."""
+    suffix = mac_suffix_from_address(mac)
+    return f"{base_name}-{suffix}" if suffix else base_name
+
+
+def split_mac_suffix_broadcast(broadcast_name: str) -> tuple[str, str] | None:
+    """
+    Split a suffixed broadcast hostname into ``(base_name, mac_suffix)``.
+
+    Returns ``None`` when *broadcast_name* doesn't match the
+    ``name_add_mac_suffix`` shape.
+    """
+    match = _MAC_SUFFIX_BROADCAST_RE.match(broadcast_name.lower())
+    if match is None:
+        return None
+    return match.group(1), match.group(2)
 
 
 def normalize_hostname(hostname: str) -> str:

--- a/tests/test_mdns_name_match.py
+++ b/tests/test_mdns_name_match.py
@@ -188,6 +188,50 @@ async def test_handler_short_circuits_unknown_device(monkeypatch: pytest.MonkeyP
     assert not any(c[0] == "on_state_change" for c in callbacks.calls)
 
 
+async def test_handler_marks_mac_suffix_broadcast_online(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``name_add_mac_suffix`` broadcasts ``{name}-{mac}`` but YAML keeps the base name.
+
+    Pre-fix the handler looked up the broadcast label verbatim, found
+    no configured entry for ``example-node-aabbcc``, and the device
+    stayed Unknown/OFFLINE until a ping sweep against the wrong
+    ``example-node.local`` hostname failed.
+    """
+    devices = [_device("example-node")]
+    monitor, callbacks = make_state_monitor_with_callbacks(devices)
+
+    handler = await _capture_handler(monitor, monkeypatch)
+    handler(
+        MagicMock(),
+        "_esphomelib._tcp.local.",
+        "example-node-aabbcc._esphomelib._tcp.local.",
+        ServiceStateChange.Added,
+    )
+
+    assert (
+        "on_state_change",
+        "example-node",
+        DeviceState.ONLINE,
+        "mdns",
+    ) in callbacks.calls
+
+
+async def test_handler_short_circuits_unknown_mac_suffix_broadcast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A suffixed broadcast with no matching configured base name is ignored."""
+    monitor, callbacks = make_state_monitor_with_callbacks([_device("other-device")])
+
+    handler = await _capture_handler(monitor, monkeypatch)
+    handler(
+        MagicMock(),
+        "_esphomelib._tcp.local.",
+        "example-node-aabbcc._esphomelib._tcp.local.",
+        ServiceStateChange.Added,
+    )
+
+    assert not any(c[0] == "on_state_change" for c in callbacks.calls)
+
+
 async def test_mdns_takes_ownership_after_ping_set_online(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
> **Note:** I'm not proposing this as *the* fix — it's a patch that resolved the offline-badge behaviour I hit in my setup. Happy for maintainers to take a different approach; see the linked issue for context and evidence.

Related to #2480.

## Summary

- Add helpers to parse ESPHome's `name_add_mac_suffix` broadcast shape (`{base}-{6hex}`)
- Map suffixed `_esphomelib._tcp` announcements to the configured catalog name via `_find_device_for_mdns_broadcast()`
- Apply reachability against the catalog name; gate ONLINE on PTRs under the broadcast name
- Extend the ping sweep to try `{name}-{mac_suffix}.local` when the base `.local` address does not resolve
- Add regression tests in `test_mdns_name_match.py`

## Test plan

- [x] `pytest tests/test_mdns_name_match.py` (10 passed)
- [x] Hot-patched on a live HA add-on (`host_network: true`); device went `unknown → online (via mdns)` instead of `offline (via ping)`