### PR TITLE
Ask for the device YAML config in the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -90,6 +90,19 @@ body:
       required: true
 
   - type: textarea
+    id: config
+    attributes:
+      label: Device YAML config
+      description: |
+        The YAML config of the affected device, with secrets redacted
+        (Wi-Fi credentials, API encryption key, OTA password). Prefer the
+        whole file; trim only if it's huge. If this report isn't about a
+        specific device, write "not device specific".
+      render: yaml
+    validations:
+      required: true
+
+  - type: textarea
     id: logs
     attributes:
       label: Relevant logs / errors
@@ -103,5 +116,5 @@ body:
     attributes:
       label: Anything else?
       description: |
-        Screenshots, related YAML config, board picked, anything else
-        that might help us reproduce.
+        Screenshots, board picked, anything else that might help us
+        reproduce.


### PR DESCRIPTION
# What does this implement/fix?

The bug report form now asks for the affected device's YAML config in its own field, rendered as yaml, with a note to redact secrets first; the esphome/esphome template already does this and it saves a lot of guessing about whether a fix matched the reporter's setup. The field is required so it can't be silently skipped, but reporters can write "not device specific" when the issue isn't tied to a device. The field id is `config` so a later PR can pre-fill it from the dashboard UI.

**Related issue or feature (if applicable):**

- https://github.com/esphome/device-builder/issues/2479 (an example report we could only guess at without the config)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
