### PR TITLE
Document name_add_mac_suffix status-tracking design scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -714,6 +714,20 @@ against legacy behaviour before assuming the simpler version suffices.
   proxies included); don't add detection or accommodations for
   fabricated records — close such issues pointing at the design-scope
   paragraph in docs/ARCHITECTURE.md "Discovery (mDNS)".
+
+  **`name_add_mac_suffix: true` configs are out of scope for status
+  tracking.** The option is a provisioning feature — one YAML flashed to
+  N units, each broadcasting `{name}-<last-3-MAC-bytes>` — and the adopt
+  flow bakes the suffix into the literal name and turns it off. A
+  `Device` row is 1:1 with a YAML file, so no row can represent the
+  fleet, and a suffixed broadcast can't be bound to a row safely: the
+  MAC is only learned through name-keyed paths that never fire for a
+  never-matched device, first-match binding promotes an arbitrary unit,
+  and a base-name fallback in `_find_device_by_name` also feeds the
+  already-configured exclusion in `_device_state_monitor/importable.py`,
+  hiding new factory units from the adopt list. Close such issues
+  pointing at the README section "Device status and
+  `name_add_mac_suffix`" (#2480; declined PR #2481).
 - **Persisted-IP revival is identity-gated** (`api_reviver.py`). A
   stuck-offline `api:` device whose `.local` won't resolve and whose RAM
   `ip_addresses` are gone (an mDNS `Removed` withdrawal, or a restart) gets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -717,7 +717,7 @@ against legacy behaviour before assuming the simpler version suffices.
 
   **`name_add_mac_suffix: true` configs are out of scope for status
   tracking.** The option is a provisioning feature — one YAML flashed to
-  N units, each broadcasting `{name}-<last-3-MAC-bytes>` — and the adopt
+  N units, each broadcasting `{name}-<last-6-MAC-digits>` — and the adopt
   flow bakes the suffix into the literal name and turns it off. A
   `Device` row is 1:1 with a YAML file, so no row can represent the
   fleet, and a suffixed broadcast can't be bound to a row safely: the

--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ automatic commits alongside yours, this toggle is for you.
 
 Configs that keep `name_add_mac_suffix: true` show as offline. The
 option is a provisioning feature: one YAML flashed to a whole batch of
-devices, each announcing itself as `<name>-<last-3-MAC-bytes>` so the
+devices, each announcing itself as `<name>-<last-6-MAC-digits>` so the
 units can be told apart out of the box. The dashboard tracks one device
 per YAML file, keyed on `esphome.name`, so a suffixed broadcast can't
 be safely linked back to a config — several units may be running the

--- a/README.md
+++ b/README.md
@@ -588,6 +588,27 @@ automatic commits alongside yours, this toggle is for you.
 > described above, will be closed with a pointer to this section.
 > Bug reports about the feature misbehaving are always welcome.
 
+## Device status and `name_add_mac_suffix`
+
+Configs that keep `name_add_mac_suffix: true` show as offline. The
+option is a provisioning feature: one YAML flashed to a whole batch of
+devices, each announcing itself as `<name>-<last-3-MAC-bytes>` so the
+units can be told apart out of the box. The dashboard tracks one device
+per YAML file, keyed on `esphome.name`, so a suffixed broadcast can't
+be safely linked back to a config — several units may be running the
+same YAML at once, and guessing promotes an arbitrary unit's address
+and version onto the card. Adopting the device is the supported path:
+the adopt flow bakes the suffixed name into `esphome.name` as a literal
+and turns the option off, which is the intended production state. If
+you manage the YAML by hand instead, give each device a unique literal
+name.
+
+> **Policy note.** Mapping suffixed broadcasts back to a base-named
+> config has been discussed and declined
+> ([issue #2480](https://github.com/esphome/device-builder/issues/2480)).
+> New issues asking for it will be closed with a pointer to this
+> section.
+
 ## Roadmap
 
 - ✅ Standalone backend with WS-first API, persistent compile queue, mDNS device discovery

--- a/README.md
+++ b/README.md
@@ -590,7 +590,8 @@ automatic commits alongside yours, this toggle is for you.
 
 ## Device status and `name_add_mac_suffix`
 
-Configs that keep `name_add_mac_suffix: true` show as offline. The
+Configs that keep `name_add_mac_suffix: true` are out of scope for
+status tracking; they show as offline or stay unknown. The
 option is a provisioning feature: one YAML flashed to a whole batch of
 devices, each announcing itself as `<name>-<last-6-MAC-digits>` so the
 units can be told apart out of the box. The dashboard tracks one device


### PR DESCRIPTION
# What does this implement/fix?

Documents that configs keeping `name_add_mac_suffix: true` are out of scope for status tracking; the option is a provisioning feature and the adopt flow bakes the suffix into the literal name and turns it off. The README gets a user-facing section with a policy note so future issues have something durable to point at, and CLAUDE.md gets the triage guidance next to the existing mDNS middlebox scope paragraph.

**Related issue or feature (if applicable):**

- https://github.com/esphome/device-builder/issues/2480

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
