### PR TITLE
Add a name_add_mac_suffix flag to Device

### DIFF
--- a/esphome_device_builder/helpers/device_yaml/_loading.py
+++ b/esphome_device_builder/helpers/device_yaml/_loading.py
@@ -32,6 +32,7 @@ from ._parsing import (
     extract_ota_partition_access,
     get_api_encryption_block,
     has_top_level_block,
+    name_add_mac_suffix_enabled,
     parse_esphome_meta,
     yaml_has_api_encryption,
     yaml_has_top_level_block,
@@ -332,6 +333,7 @@ def load_device_from_storage(
         # mqtt for dashboard discovery" the way ``"api"`` does.
         uses_mqtt=has_top_level_block(resolved_config, yaml_content, "mqtt"),
         uses_deep_sleep=has_top_level_block(resolved_config, yaml_content, "deep_sleep"),
+        name_add_mac_suffix=name_add_mac_suffix_enabled(resolved_config, yaml_content),
         api_enabled=api_enabled,
         api_encrypted=api_encrypted,
         mac_address=mac_address,

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -217,10 +217,11 @@ _TRUTHY_BOOL_STRINGS = frozenset({"true", "yes", "on", "enable"})
 _RAW_NAME_ADD_MAC_SUFFIX_RE = re.compile(
     # Truthy ``name_add_mac_suffix:`` indented under ``esphome:``. The
     # body alternatives are exclusive so the engine can't backtrack
-    # exponentially on newline runs.
-    r"^esphome:[^\n]*\n(?:[ \t][^\n]*\n|\n)*"
-    rf"[ \t]+name_add_mac_suffix:[ \t]*(?:{'|'.join(sorted(_TRUTHY_BOOL_STRINGS))})\b",
-    re.MULTILINE | re.IGNORECASE,
+    # exponentially on newline runs; case-folding is scoped to the value
+    # (YAML keys are case-sensitive), and the value may be quoted.
+    r"^esphome:[^\n]*\n(?:[ \t][^\n]*\n|#[^\n]*\n|\n)*"
+    rf"""[ \t]+name_add_mac_suffix:[ \t]*["']?(?i:{"|".join(sorted(_TRUTHY_BOOL_STRINGS))})\b""",
+    re.MULTILINE,
 )
 
 

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -211,6 +211,51 @@ def yaml_has_api_encryption(yaml_content: str) -> bool:
     return bool(_RAW_API_ENCRYPTION_RE.search(yaml_content))
 
 
+# esphome's ``cv.boolean`` truthy spellings.
+_TRUTHY_BOOL_STRINGS = frozenset({"true", "yes", "on", "enable"})
+
+_RAW_NAME_ADD_MAC_SUFFIX_RE = re.compile(
+    # Truthy ``name_add_mac_suffix:`` indented under ``esphome:``. The
+    # body alternatives are exclusive so the engine can't backtrack
+    # exponentially on newline runs.
+    r"^esphome:[^\n]*\n(?:[ \t][^\n]*\n|\n)*"
+    rf"[ \t]+name_add_mac_suffix:[ \t]*(?:{'|'.join(sorted(_TRUTHY_BOOL_STRINGS))})\b",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+
+def yaml_has_name_add_mac_suffix(yaml_content: str) -> bool:
+    """Heuristic: True when raw YAML sets a truthy ``esphome: name_add_mac_suffix:``."""
+    return bool(_RAW_NAME_ADD_MAC_SUFFIX_RE.search(yaml_content))
+
+
+def config_name_add_mac_suffix(config: dict | None) -> bool:
+    """Return True when the resolved ``esphome:`` block sets a truthy ``name_add_mac_suffix``."""
+    if not isinstance(config, dict):
+        return False
+    block = config.get("esphome")
+    if not isinstance(block, dict):
+        return False
+    value = block.get("name_add_mac_suffix")
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in _TRUTHY_BOOL_STRINGS
+    return False
+
+
+def name_add_mac_suffix_enabled(resolved_config: dict | None, yaml_content: str) -> bool:
+    """
+    Detect a truthy ``esphome.name_add_mac_suffix``: resolved config wins, raw text fills in.
+
+    The raw-text fallback applies only when resolution failed, keeping
+    the flag stable mid-edit.
+    """
+    if resolved_config is not None:
+        return config_name_add_mac_suffix(resolved_config)
+    return yaml_has_name_add_mac_suffix(yaml_content)
+
+
 def config_has_top_level_block(config: dict | None, key: str) -> bool:
     """Return True when *config* (a resolved device YAML) defines top-level *key*.
 

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -248,8 +248,7 @@ def name_add_mac_suffix_enabled(resolved_config: dict | None, yaml_content: str)
     """
     Detect a truthy ``esphome.name_add_mac_suffix``: resolved config wins, raw text fills in.
 
-    The raw-text fallback applies only when resolution failed, keeping
-    the flag stable mid-edit.
+    The raw-text fallback applies only when resolution failed.
     """
     if resolved_config is not None:
         return config_name_add_mac_suffix(resolved_config)

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -149,6 +149,10 @@ class Device(DashboardModel):
     update_available: bool = False  # True if compiled with older ESPHome version
     uses_mqtt: bool = False  # True if the YAML declares a top-level mqtt: block
     uses_deep_sleep: bool = False  # True if the YAML declares a top-level deep_sleep: block
+    # True when the esphome: block sets a truthy name_add_mac_suffix —
+    # the suffixed broadcast never matches this config, so status
+    # tracking is unavailable.
+    name_add_mac_suffix: bool = False
     # Native API surface flags — drive the lock-icon indicator in
     # the device list. Both fields are computed in
     # ``helpers.device_yaml.load_device_from_storage`` as the

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -149,9 +149,7 @@ class Device(DashboardModel):
     update_available: bool = False  # True if compiled with older ESPHome version
     uses_mqtt: bool = False  # True if the YAML declares a top-level mqtt: block
     uses_deep_sleep: bool = False  # True if the YAML declares a top-level deep_sleep: block
-    # True when the esphome: block sets a truthy name_add_mac_suffix —
-    # the suffixed broadcast never matches this config, so status
-    # tracking is unavailable.
+    # Truthy esphome.name_add_mac_suffix; status tracking is unavailable for such configs.
     name_add_mac_suffix: bool = False
     # Native API surface flags — drive the lock-icon indicator in
     # the device list. Both fields are computed in

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -46,6 +46,7 @@ from esphome_device_builder.helpers.device_yaml._parsing import (
     extract_logger_interface,
     extract_ota_partition_access,
     resolve_esp32_variant,
+    yaml_has_name_add_mac_suffix,
 )
 from esphome_device_builder.models import (
     BoardCatalogEntry,
@@ -1117,6 +1118,52 @@ def test_load_device_from_storage_detects_deep_sleep(tmp_path: Path) -> None:
     awake = tmp_path / "awake.yaml"
     awake.write_text("esphome:\n  name: awake\napi:\n", encoding="utf-8")
     assert load_device_from_storage(awake).uses_deep_sleep is False
+
+
+def test_load_device_from_storage_detects_name_add_mac_suffix(tmp_path: Path) -> None:
+    """A truthy ``esphome.name_add_mac_suffix`` sets the flag; false or absent clears it."""
+    suffixed = tmp_path / "suffixed.yaml"
+    suffixed.write_text("esphome:\n  name: kit\n  name_add_mac_suffix: true\n", encoding="utf-8")
+    assert load_device_from_storage(suffixed).name_add_mac_suffix is True
+
+    adopted = tmp_path / "adopted.yaml"
+    adopted.write_text(
+        "esphome:\n  name: kit-aabbcc\n  name_add_mac_suffix: false\n", encoding="utf-8"
+    )
+    assert load_device_from_storage(adopted).name_add_mac_suffix is False
+
+    plain = tmp_path / "plain.yaml"
+    plain.write_text("esphome:\n  name: plain\n", encoding="utf-8")
+    assert load_device_from_storage(plain).name_add_mac_suffix is False
+
+
+def test_load_device_name_add_mac_suffix_survives_invalid_draft(tmp_path: Path) -> None:
+    """The raw-text fallback keeps the flag set when the draft doesn't parse."""
+    draft = tmp_path / "draft.yaml"
+    draft.write_text(
+        "esphome:\n  name: kit\n  name_add_mac_suffix: yes\nwifi: [broken\n", encoding="utf-8"
+    )
+    assert load_device_from_storage(draft).name_add_mac_suffix is True
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        pytest.param("esphome:\n  name: a\n  name_add_mac_suffix: true\n", True, id="true"),
+        pytest.param("esphome:\n  name: a\n  name_add_mac_suffix: On\n", True, id="on"),
+        pytest.param("esphome:\n\n  name_add_mac_suffix: yes\n", True, id="blank_line"),
+        pytest.param("esphome:\n  name_add_mac_suffix: false\n", False, id="false"),
+        pytest.param(
+            "esphome:\n  name: a\nweb_server:\n  name_add_mac_suffix: true\n",
+            False,
+            id="other_block",
+        ),
+        pytest.param("esphome:\n  name: a\n", False, id="absent"),
+    ],
+)
+def test_yaml_has_name_add_mac_suffix(content: str, expected: bool) -> None:
+    """The raw scan matches truthy values under ``esphome:`` only."""
+    assert yaml_has_name_add_mac_suffix(content) is expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -1137,6 +1137,10 @@ def test_load_device_from_storage_detects_name_add_mac_suffix(tmp_path: Path) ->
     plain.write_text("esphome:\n  name: plain\n", encoding="utf-8")
     assert load_device_from_storage(plain).name_add_mac_suffix is False
 
+    quoted = tmp_path / "quoted.yaml"
+    quoted.write_text('esphome:\n  name: kit\n  name_add_mac_suffix: "enable"\n', encoding="utf-8")
+    assert load_device_from_storage(quoted).name_add_mac_suffix is True
+
 
 def test_load_device_name_add_mac_suffix_survives_invalid_draft(tmp_path: Path) -> None:
     """The raw-text fallback keeps the flag set when the draft doesn't parse."""
@@ -1162,6 +1166,13 @@ def test_load_device_name_add_mac_suffix_survives_invalid_draft(tmp_path: Path) 
         pytest.param("esphome:\n  name: a\n", False, id="absent"),
         pytest.param("esphome:\n  name_add_mac_suffix: enabled\n", False, id="enabled_not_truthy"),
         pytest.param("esphome:\n  name_add_mac_suffix: 1\n", False, id="numeric_not_truthy"),
+        pytest.param('esphome:\n  name_add_mac_suffix: "true"\n', True, id="quoted_value"),
+        pytest.param("esphome:\n  Name_Add_Mac_Suffix: true\n", False, id="cased_key"),
+        pytest.param(
+            "esphome:\n  name: a\n# note\n  name_add_mac_suffix: true\n",
+            True,
+            id="column0_comment",
+        ),
     ],
 )
 def test_yaml_has_name_add_mac_suffix(content: str, expected: bool) -> None:

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -1160,6 +1160,8 @@ def test_load_device_name_add_mac_suffix_survives_invalid_draft(tmp_path: Path) 
             id="other_block",
         ),
         pytest.param("esphome:\n  name: a\n", False, id="absent"),
+        pytest.param("esphome:\n  name_add_mac_suffix: enabled\n", False, id="enabled_not_truthy"),
+        pytest.param("esphome:\n  name_add_mac_suffix: 1\n", False, id="numeric_not_truthy"),
     ],
 )
 def test_yaml_has_name_add_mac_suffix(content: str, expected: bool) -> None:
@@ -1177,6 +1179,7 @@ def test_yaml_has_name_add_mac_suffix(content: str, expected: bool) -> None:
         pytest.param({"esphome": {"name_add_mac_suffix": "enable"}}, True, id="str_enable"),
         pytest.param({"esphome": {"name_add_mac_suffix": "disable"}}, False, id="str_disable"),
         pytest.param({"esphome": {"name_add_mac_suffix": 1}}, False, id="non_bool_scalar"),
+        pytest.param({"esphome": {"name_add_mac_suffix": "enabled"}}, False, id="str_enabled"),
         pytest.param({"esphome": {}}, False, id="absent"),
     ],
 )

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -41,6 +41,7 @@ from esphome_device_builder.helpers.device_yaml import (
 )
 from esphome_device_builder.helpers.device_yaml._parsing import (
     _is_valid_esphome_name,
+    config_name_add_mac_suffix,
     device_ap_label,
     extract_logger_baud_rate,
     extract_logger_interface,
@@ -1164,6 +1165,24 @@ def test_load_device_name_add_mac_suffix_survives_invalid_draft(tmp_path: Path) 
 def test_yaml_has_name_add_mac_suffix(content: str, expected: bool) -> None:
     """The raw scan matches truthy values under ``esphome:`` only."""
     assert yaml_has_name_add_mac_suffix(content) is expected
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        pytest.param(None, False, id="no_config"),
+        pytest.param({"esphome": "kit"}, False, id="block_not_dict"),
+        pytest.param({"esphome": {"name_add_mac_suffix": True}}, True, id="bool_true"),
+        pytest.param({"esphome": {"name_add_mac_suffix": False}}, False, id="bool_false"),
+        pytest.param({"esphome": {"name_add_mac_suffix": "enable"}}, True, id="str_enable"),
+        pytest.param({"esphome": {"name_add_mac_suffix": "disable"}}, False, id="str_disable"),
+        pytest.param({"esphome": {"name_add_mac_suffix": 1}}, False, id="non_bool_scalar"),
+        pytest.param({"esphome": {}}, False, id="absent"),
+    ],
+)
+def test_config_name_add_mac_suffix(config: dict | None, expected: bool) -> None:
+    """Resolved-config detection accepts bools and ``cv.boolean`` truthy strings."""
+    assert config_name_add_mac_suffix(config) is expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this implement/fix?

Adds a `name_add_mac_suffix` flag to `Device`, computed like the neighboring YAML derived flags; the resolved config wins, and a raw text scan of the `esphome:` block keeps the flag stable while an unparsable draft is being edited. Only truthy values set it, so adopted configs with an explicit `false` stay clear. The companion frontend change will use it to warn in the editor and on the device card that status tracking is unavailable while the option is set.

**Related issue or feature (if applicable):**

- https://github.com/esphome/device-builder/issues/2480

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#1592

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

