### PR TITLE
Add observed-state and config fields to the device status template

### DIFF
--- a/.github/ISSUE_TEMPLATE/device_status.yml
+++ b/.github/ISSUE_TEMPLATE/device_status.yml
@@ -82,6 +82,32 @@ body:
       required: true
 
   - type: textarea
+    id: observed
+    attributes:
+      label: Dashboard-observed state
+      description: |
+        Prefilled when you report from the dashboard's feedback dialog: the
+        device's state, reachability source, IP, versions, and installation.
+        Leave it as generated, or fill it in by hand from the device drawer.
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Device YAML config
+      description: |
+        The YAML config of the affected device, with secrets redacted
+        (Wi-Fi credentials, API encryption key, OTA password); prefilled
+        with known credentials masked when you report from the dashboard.
+        Prefer the whole file; trim only if it's huge. If this report isn't
+        about a specific device, write "not device specific".
+      render: yaml
+    validations:
+      required: true
+
+  - type: textarea
     id: network
     attributes:
       label: Network setup


### PR DESCRIPTION
# What does this implement/fix?

The device status issue template gains two fields so the dashboard's report a device flow (device-builder-frontend#1596) has somewhere to land its prefill: an optional observed textarea for the dashboard reported state (online state, reachability source, IP, versions, installation) and a required config textarea matching the one bug_report.yml gained in #2482, prefilled with known credentials masked and carrying the same "not device specific" escape for manual filers.

**Related issue or feature (if applicable):**

- part of esphome/device-builder-frontend#1596

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#<number> (to follow; the picker wiring for device-builder-frontend#1596 targets these field ids)

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
