### PR TITLE
Refuse a non-ASCII certificate_authority instead of aborting the reconcile

### DIFF
--- a/esphome_device_builder/controllers/_device_mqtt_coordinator.py
+++ b/esphome_device_builder/controllers/_device_mqtt_coordinator.py
@@ -498,7 +498,10 @@ def _ca_pem_is_loadable(certificate_authority: str) -> bool:
     """
     try:
         ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT).load_verify_locations(cadata=certificate_authority)
-    except ssl.SSLError as err:
+    except (ssl.SSLError, TypeError, ValueError) as err:
+        # TypeError/ValueError cover non-ASCII bytes and other bad-input
+        # shapes ``load_verify_locations`` raises outside SSLError; an
+        # escape here aborts the whole fleet's reconcile.
         # The gated unresolved warning is generic; keep the concrete
         # parse failure recoverable from the logs.
         _LOGGER.debug("certificate_authority failed to parse: %s", err)

--- a/esphome_device_builder/controllers/_device_mqtt_coordinator.py
+++ b/esphome_device_builder/controllers/_device_mqtt_coordinator.py
@@ -499,9 +499,8 @@ def _ca_pem_is_loadable(certificate_authority: str) -> bool:
     try:
         ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT).load_verify_locations(cadata=certificate_authority)
     except (ssl.SSLError, TypeError, ValueError) as err:
-        # TypeError/ValueError cover non-ASCII bytes and other bad-input
-        # shapes ``load_verify_locations`` raises outside SSLError; an
-        # escape here aborts the whole fleet's reconcile.
+        # ``load_verify_locations`` raises TypeError for non-ASCII cadata
+        # and ValueError for empty data, not SSLError.
         # The gated unresolved warning is generic; keep the concrete
         # parse failure recoverable from the logs.
         _LOGGER.debug("certificate_authority failed to parse: %s", err)

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -256,6 +256,21 @@ def test_parse_mqtt_block_corrupt_ca_returns_none(caplog: pytest.LogCaptureFixtu
     assert any("failed to parse" in r.getMessage() for r in caplog.records)
 
 
+def test_parse_mqtt_block_non_ascii_ca_returns_none(caplog: pytest.LogCaptureFixture) -> None:
+    # A smart quote from copy-paste makes ``load_verify_locations`` raise
+    # TypeError, not SSLError; an escape aborts the fleet's reconcile.
+    yaml = (
+        "mqtt:\n  broker: broker.example\n  certificate_authority: |\n"
+        "    -----BEGIN CERTIFICATE-----\n"
+        "    MIIB\u2019x\n"
+        "    -----END CERTIFICATE-----\n"
+    )
+    target = "esphome_device_builder.controllers._device_mqtt_coordinator"
+    with caplog.at_level("DEBUG", logger=target):
+        assert parse_mqtt_block(yaml) is None
+    assert any("failed to parse" in r.getMessage() for r in caplog.records)
+
+
 @pytest.mark.parametrize(
     ("value", "expected"),
     [

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -258,7 +258,7 @@ def test_parse_mqtt_block_corrupt_ca_returns_none(caplog: pytest.LogCaptureFixtu
 
 def test_parse_mqtt_block_non_ascii_ca_returns_none(caplog: pytest.LogCaptureFixture) -> None:
     # A smart quote from copy-paste makes ``load_verify_locations`` raise
-    # TypeError, not SSLError; an escape aborts the fleet's reconcile.
+    # TypeError, not SSLError.
     yaml = (
         "mqtt:\n  broker: broker.example\n  certificate_authority: |\n"
         "    -----BEGIN CERTIFICATE-----\n"


### PR DESCRIPTION
# What does this implement/fix?

A certificate_authority whose PEM contains a non-ASCII byte, a smart quote from copy-paste or a UTF-8 header from openssl output, passes the PEM marker check and then makes load_verify_locations raise TypeError instead of SSLError. That escaped _collect_brokers and aborted the whole fleet's reconcile, and at startup aborted DevicesController.start().

The parse-time CA check now catches TypeError and ValueError alongside SSLError, routing the bad CA to the existing gated unresolved-broker warning exactly as the function's contract promises; one device's malformed certificate no longer takes down MQTT discovery for every device.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
