### PR TITLE
Read device YAML off one handle to keep stat and content coherent

### DIFF
--- a/esphome_device_builder/controllers/_device_mqtt_coordinator.py
+++ b/esphome_device_builder/controllers/_device_mqtt_coordinator.py
@@ -229,9 +229,9 @@ class DeviceMqttCoordinator:
                 )
             else:
                 # Scan raced an edit (or the device predates the scanner
-                # carrying extractions) — fall back to reading the file,
-                # re-statting off the read handle so the slow-path cache
-                # key matches the parsed content.
+                # carrying extractions) — fall back to reading the file;
+                # the handle stat keys _resolve_slow's extract-seed
+                # comparison.
                 try:
                     yaml_stat, yaml_content = read_text_with_stat(yaml_path)
                 except OSError:

--- a/esphome_device_builder/controllers/_device_mqtt_coordinator.py
+++ b/esphome_device_builder/controllers/_device_mqtt_coordinator.py
@@ -22,6 +22,7 @@ from esphome.core import EsphomeError
 
 from ..constants import SECRETS_FILENAME
 from ..helpers.async_ import run_in_executor
+from ..helpers.atomic_io import read_text_with_stat
 from ..helpers.device_yaml import (
     _UNRESOLVED_SUBSTITUTION_RE,
     SecretRef,
@@ -229,8 +230,10 @@ class DeviceMqttCoordinator:
             else:
                 # Scan raced an edit (or the device predates the scanner
                 # carrying extractions) — fall back to reading the file.
+                # ``fstat`` off the read handle keeps the slow-path cache
+                # key coherent with the content actually parsed.
                 try:
-                    yaml_content = yaml_path.read_text(encoding="utf-8")
+                    yaml_stat, yaml_content = read_text_with_stat(yaml_path)
                 except OSError:
                     _LOGGER.debug(_UNREADABLE_DEBUG, device.configuration)
                     continue

--- a/esphome_device_builder/controllers/_device_mqtt_coordinator.py
+++ b/esphome_device_builder/controllers/_device_mqtt_coordinator.py
@@ -229,9 +229,9 @@ class DeviceMqttCoordinator:
                 )
             else:
                 # Scan raced an edit (or the device predates the scanner
-                # carrying extractions) — fall back to reading the file.
-                # ``fstat`` off the read handle keeps the slow-path cache
-                # key coherent with the content actually parsed.
+                # carrying extractions) — fall back to reading the file,
+                # re-statting off the read handle so the slow-path cache
+                # key matches the parsed content.
                 try:
                     yaml_stat, yaml_content = read_text_with_stat(yaml_path)
                 except OSError:

--- a/esphome_device_builder/helpers/atomic_io.py
+++ b/esphome_device_builder/helpers/atomic_io.py
@@ -1,5 +1,5 @@
 """
-Atomic filesystem writes for dashboard-internal artefacts.
+Atomic writes and replace-race-coherent reads for dashboard-internal artefacts.
 
 For cert / key / token / metadata-sidecar files, plus the
 mode-preserving rewrite of user-editable YAML.

--- a/esphome_device_builder/helpers/atomic_io.py
+++ b/esphome_device_builder/helpers/atomic_io.py
@@ -96,6 +96,16 @@ def read_bytes_with_retry(path: Path) -> bytes:
     return _retry_windows_permission(path.read_bytes)
 
 
+def read_text_with_stat(path: Path) -> tuple[os.stat_result, str]:
+    """Read *path* off one open handle, pairing the content with the handle's ``fstat``."""
+
+    def _read() -> tuple[os.stat_result, str]:
+        with path.open(encoding="utf-8") as fh:
+            return os.fstat(fh.fileno()), fh.read()
+
+    return _retry_windows_permission(_read)
+
+
 def _staged_write(
     path: Path,
     data: bytes,

--- a/esphome_device_builder/helpers/atomic_io.py
+++ b/esphome_device_builder/helpers/atomic_io.py
@@ -39,6 +39,10 @@ _HARDLINK_UNSUPPORTED_ERRNOS = frozenset({errno.EPERM, errno.EOPNOTSUPP, errno.E
 _REPLACE_RETRIES = 15
 _REPLACE_RETRY_BACKOFF_S = 0.05
 _REPLACE_RETRY_BACKOFF_CAP_S = 0.5
+# Reads sit on per-device scan / reconcile loops, so a persistently
+# unreadable file must fail fast; five attempts (~0.75s worst case)
+# still clears the common sub-second replace window.
+_READ_RETRIES = 5
 
 
 def atomic_write(
@@ -103,7 +107,7 @@ def read_text_with_stat(path: Path) -> tuple[os.stat_result, str]:
         with path.open(encoding="utf-8") as fh:
             return os.fstat(fh.fileno()), fh.read()
 
-    return _retry_windows_permission(_read)
+    return _retry_windows_permission(_read, retries=_READ_RETRIES)
 
 
 def _staged_write(
@@ -183,18 +187,18 @@ def _replace_with_retry(src: Path, dst: Path) -> None:
     _retry_windows_permission(lambda: src.replace(dst))
 
 
-def _retry_windows_permission[T](op: Callable[[], T]) -> T:
+def _retry_windows_permission[T](op: Callable[[], T], retries: int = _REPLACE_RETRIES) -> T:
     """
     Run *op*, retrying a transient Windows ``PermissionError`` with backoff.
 
     POSIX never hits the transient class, so a ``PermissionError``
     there is real and surfaces without a retry.
     """
-    for attempt in range(_REPLACE_RETRIES):
+    for attempt in range(retries):
         try:
             return op()
         except PermissionError:
-            if not _IS_WINDOWS or attempt == _REPLACE_RETRIES - 1:
+            if not _IS_WINDOWS or attempt == retries - 1:
                 raise
             time.sleep(min(_REPLACE_RETRY_BACKOFF_S * 2**attempt, _REPLACE_RETRY_BACKOFF_CAP_S))
     raise AssertionError("unreachable: loop returns or raises")  # pragma: no cover

--- a/esphome_device_builder/helpers/device_yaml/_loading.py
+++ b/esphome_device_builder/helpers/device_yaml/_loading.py
@@ -17,6 +17,7 @@ from esphome.storage_json import StorageJSON
 from ...constants import SECRETS_FILENAME
 from ...models import Device, DeviceRuntimeState
 from ...models.boards import normalize_platform
+from ..atomic_io import read_text_with_stat
 from ..mac_addresses import derive_interface_macs
 from ..storage_path import resolve_compiled_config_path, resolve_storage_path
 from ._mqtt_block import build_mqtt_extract
@@ -372,16 +373,20 @@ def load_device_from_storage(
 
 
 def _snapshot_source_files(path: Path) -> tuple[os.stat_result | None, str, tuple[int, int]]:
-    """Stat + read the YAML and stamp the secrets mtime before the esphome parse."""
+    """
+    Read the YAML off one handle and stamp the secrets mtime before the esphome parse.
+
+    An open failure degrades to a bare ``stat`` with empty content.
+    """
     yaml_stat: os.stat_result | None
     try:
-        yaml_stat = path.stat()
-    except OSError:
-        yaml_stat = None
-    try:
-        yaml_content = path.read_text(encoding="utf-8")
+        yaml_stat, yaml_content = read_text_with_stat(path)
     except OSError:
         yaml_content = ""
+        try:
+            yaml_stat = path.stat()
+        except OSError:
+            yaml_stat = None
     return yaml_stat, yaml_content, safe_stat_key(path.parent / SECRETS_FILENAME)
 
 

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -22,7 +22,9 @@ from esphome_device_builder.helpers.atomic_io import (
 def test_read_text_with_stat_pairs_content_with_the_handle_stat(tmp_path: Path) -> None:
     """The returned stat describes exactly the bytes read."""
     path = tmp_path / "kitchen.yaml"
-    path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    # newline="\n" keeps the on-disk bytes LF-only so the size
+    # comparison holds under Windows' \r\n translation.
+    path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8", newline="\n")
 
     file_stat, content = read_text_with_stat(path)
 

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from esphome_device_builder.helpers.atomic_io import (
+    _READ_RETRIES,
     atomic_write,
     atomic_write_exclusive,
     atomic_write_preserving_mode,
@@ -55,6 +56,26 @@ def test_read_text_with_stat_survives_an_atomic_replace_mid_read(
 
     assert content == "old: 1\n"
     assert file_stat.st_size == len(content.encode())
+
+
+def test_read_text_with_stat_uses_the_bounded_read_retry_window(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A persistently unreadable file surfaces after the bounded read retries."""
+    monkeypatch.setattr("esphome_device_builder.helpers.atomic_io._IS_WINDOWS", True)
+    monkeypatch.setattr("esphome_device_builder.helpers.atomic_io.time.sleep", lambda _s: None)
+    calls = {"n": 0}
+
+    def _denied(self: Path, *args: object, **kwargs: object) -> object:
+        calls["n"] += 1
+        raise PermissionError(5, "Access is denied")
+
+    monkeypatch.setattr(Path, "open", _denied)
+    with pytest.raises(PermissionError):
+        read_text_with_stat(tmp_path / "demo.yaml")
+
+    # The bounded read window, not the 15-attempt write policy.
+    assert calls["n"] == _READ_RETRIES
 
 
 def test_atomic_write_cleans_up_tempfile_on_error(

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -15,7 +15,45 @@ from esphome_device_builder.helpers.atomic_io import (
     atomic_write_exclusive,
     atomic_write_preserving_mode,
     read_bytes_with_retry,
+    read_text_with_stat,
 )
+
+
+def test_read_text_with_stat_pairs_content_with_the_handle_stat(tmp_path: Path) -> None:
+    """The returned stat describes exactly the bytes read."""
+    path = tmp_path / "kitchen.yaml"
+    path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    file_stat, content = read_text_with_stat(path)
+
+    assert content == "esphome:\n  name: kitchen\n"
+    assert file_stat.st_size == len(content.encode())
+    assert file_stat.st_mtime_ns == path.stat().st_mtime_ns
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="cannot replace a file with an open handle")
+def test_read_text_with_stat_survives_an_atomic_replace_mid_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A replace between open and read yields the pre-replace stat and content together."""
+    path = tmp_path / "kitchen.yaml"
+    path.write_text("old: 1\n", encoding="utf-8")
+
+    real_open = Path.open
+
+    def _replace_after_open(self: Path, *args: object, **kwargs: object) -> object:
+        fh = real_open(self, *args, **kwargs)
+        if self.name == "kitchen.yaml":
+            staged = tmp_path / "staged.yaml"
+            staged.write_text("new: 2 and longer\n", encoding="utf-8")
+            staged.replace(path)
+        return fh
+
+    monkeypatch.setattr(Path, "open", _replace_after_open)
+    file_stat, content = read_text_with_stat(path)
+
+    assert content == "old: 1\n"
+    assert file_stat.st_size == len(content.encode())
 
 
 def test_atomic_write_cleans_up_tempfile_on_error(

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -1,4 +1,4 @@
-"""Tests for the shared :mod:`helpers.atomic_io` write primitive."""
+"""Tests for the shared :mod:`helpers.atomic_io` read and write primitives."""
 
 from __future__ import annotations
 
@@ -28,7 +28,6 @@ def test_read_text_with_stat_pairs_content_with_the_handle_stat(tmp_path: Path) 
 
     assert content == "esphome:\n  name: kitchen\n"
     assert file_stat.st_size == len(content.encode())
-    assert file_stat.st_mtime_ns == path.stat().st_mtime_ns
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="cannot replace a file with an open handle")

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -2212,14 +2212,7 @@ def _redirect_ext_storage(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> No
 def test_load_device_falls_back_to_empty_yaml_on_read_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An OSError reading the YAML produces an empty content string, not a crash.
-
-    The scanner can race a file rename / unlink; if the YAML
-    can't be opened, the loader must still return a usable
-    Device rather than blowing up the whole rebuild. Pin the
-    catch so a regression that re-raised the OSError would
-    surface here as a hard failure.
-    """
+    """An OSError opening the YAML yields an empty-content Device, not a crash."""
     yaml_path = tmp_path / "kitchen.yaml"
     yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
     write_storage_json(tmp_path, "kitchen.yaml")

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -39,6 +39,7 @@ from esphome_device_builder.helpers.device_yaml import (
     parse_platform_from_yaml,
     pending_changes_via_hash,
 )
+from esphome_device_builder.helpers.device_yaml._loading import _snapshot_source_files
 from esphome_device_builder.helpers.device_yaml._parsing import (
     _is_valid_esphome_name,
     config_name_add_mac_suffix,
@@ -2214,8 +2215,7 @@ def test_load_device_falls_back_to_empty_yaml_on_read_error(
     """An OSError reading the YAML produces an empty content string, not a crash.
 
     The scanner can race a file rename / unlink; if the YAML
-    disappears between ``Path.exists()`` (in the caller) and
-    ``read_text()``, the loader must still return a usable
+    can't be opened, the loader must still return a usable
     Device rather than blowing up the whole rebuild. Pin the
     catch so a regression that re-raised the OSError would
     surface here as a hard failure.
@@ -2224,15 +2224,15 @@ def test_load_device_falls_back_to_empty_yaml_on_read_error(
     yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
     write_storage_json(tmp_path, "kitchen.yaml")
 
-    real_read_text = Path.read_text
+    real_open = Path.open
 
-    def _failing_read(self: Path, *args: Any, **kwargs: Any) -> str:
+    def _failing_open(self: Path, *args: Any, **kwargs: Any) -> Any:
         if self.name == "kitchen.yaml":
             msg = "permission denied"
             raise OSError(msg)
-        return real_read_text(self, *args, **kwargs)
+        return real_open(self, *args, **kwargs)
 
-    monkeypatch.setattr(Path, "read_text", _failing_read)
+    monkeypatch.setattr(Path, "open", _failing_open)
 
     device = load_device_from_storage(yaml_path)
 
@@ -2240,6 +2240,29 @@ def test_load_device_falls_back_to_empty_yaml_on_read_error(
     # so the loader leans on StorageJSON for those fields.
     assert device.name == "kitchen"  # from StorageJSON.name (write_storage_json default)
     assert device.configuration == "kitchen.yaml"
+
+
+def test_snapshot_degrades_to_a_bare_stat_when_open_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A present-but-unreadable YAML keeps its mtime with empty content."""
+    path = tmp_path / "kitchen.yaml"
+    path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    expected_mtime_ns = path.stat().st_mtime_ns
+
+    real_open = Path.open
+
+    def _denied(self: Path, *args: Any, **kwargs: Any) -> Any:
+        if self.name == "kitchen.yaml":
+            raise PermissionError("denied")
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", _denied)
+    yaml_stat, yaml_content, _secrets_key = _snapshot_source_files(path)
+
+    assert yaml_content == ""
+    assert yaml_stat is not None
+    assert yaml_stat.st_mtime_ns == expected_mtime_ns
 
 
 @pytest.mark.usefixtures("_redirect_ext_storage")

--- a/tests/test_mqtt_coordinator_extract.py
+++ b/tests/test_mqtt_coordinator_extract.py
@@ -286,14 +286,14 @@ async def test_yaml_vanishing_between_stat_and_read_is_skipped(
     device = write_mqtt_device(tmp_path, "kitchen", _BROKER_YAML)
     _bump_mtime(tmp_path / "kitchen.yaml")  # stale extract → fallback read
 
-    real_read_text = Path.read_text
+    real_open = Path.open
 
-    def _gone(self: Path, *args: Any, **kwargs: Any) -> str:
+    def _gone(self: Path, *args: Any, **kwargs: Any) -> Any:
         if self.name == "kitchen.yaml":
             raise OSError("vanished")
-        return real_read_text(self, *args, **kwargs)
+        return real_open(self, *args, **kwargs)
 
-    monkeypatch.setattr(Path, "read_text", _gone)
+    monkeypatch.setattr(Path, "open", _gone)
     coord = make_mqtt_coordinator(tmp_path, [device])
     await coord.reconcile()
 


### PR DESCRIPTION
# What does this implement/fix?

The scanner's YAML snapshot and the MQTT coordinator's stale-extract fallback each stat'd the file and then read it in a separate call, so an atomic-save editor replacing the file between the two calls could pair one version's mtime with the other version's content, leaving a freshness stamp that vouches for bytes it doesn't describe until the next edit.

New `helpers.atomic_io.read_text_with_stat` opens the file once, fstats the open handle, and reads from that same handle, so the (stat, content) pair always describes a single file version; it also rides the module's existing Windows replace-race retry, which the old bare reads never had, with a bounded five-attempt window so a persistently unreadable file fails fast on the scan and reconcile loops. `_snapshot_source_files` keeps its graceful degradation: a present-but-unreadable file falls back to a bare stat so it keeps its mtime, a vanished file still yields no stamp. The coordinator's steady state stays stat-only; the handle read happens only on the stale-extract fallback branch.

The same stat-then-read shape in the device search cache was considered and left alone since it self-heals on the next call; tracked in #2506.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

