### PR TITLE
Key the yaml-search cache on the read handle's fstat

### DIFF
--- a/esphome_device_builder/controllers/devices/_yaml_search_cache.py
+++ b/esphome_device_builder/controllers/devices/_yaml_search_cache.py
@@ -77,12 +77,8 @@ class YamlSearchCache:
           they're routine in a fleet that's actively being edited
           — and never propagate; ``yaml/search`` is best-effort
           across the fleet, not a per-device contract);
-        - the file's on-disk size exceeds ``MAX_FILE_BYTES``. The
-          byte ceiling is checked from ``stat.st_size`` *before*
-          opening and re-checked off the open handle before the
-          read, so a pathological multi-megabyte YAML never gets
-          loaded into Python memory — the cache stays bounded
-          regardless of what the filesystem holds.
+        - the file's size exceeds ``MAX_FILE_BYTES`` (the file is
+          never loaded into memory).
         """
         async with self._lock:
             try:

--- a/esphome_device_builder/controllers/devices/_yaml_search_cache.py
+++ b/esphome_device_builder/controllers/devices/_yaml_search_cache.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from collections.abc import Iterable
 from pathlib import Path
 
@@ -78,10 +79,10 @@ class YamlSearchCache:
           across the fleet, not a per-device contract);
         - the file's on-disk size exceeds ``MAX_FILE_BYTES``. The
           byte ceiling is checked from ``stat.st_size`` *before*
-          ``read_text``, so a pathological multi-megabyte YAML
-          never gets loaded into Python memory in the first place
-          — the cache stays bounded regardless of what the
-          filesystem holds.
+          opening and re-checked off the open handle before the
+          read, so a pathological multi-megabyte YAML never gets
+          loaded into Python memory — the cache stays bounded
+          regardless of what the filesystem holds.
         """
         async with self._lock:
             try:
@@ -109,15 +110,24 @@ class YamlSearchCache:
                 return cached[1]
 
             try:
-                text = await asyncio.to_thread(path.read_text, encoding="utf-8", errors="replace")
+                entry = await asyncio.to_thread(_read_for_cache, path)
             except OSError as exc:
                 _LOGGER.debug("yaml-search-cache: read %s failed: %s", configuration, exc)
                 self._entries.pop(configuration, None)
                 return None
 
-            lines = text.splitlines()
-            self._entries[configuration] = (stat.st_mtime_ns, lines)
-            return lines
+            if entry is None:
+                _LOGGER.debug(
+                    "yaml-search-cache: %s grew over the %d-byte cap between stat and "
+                    "open — skipped",
+                    configuration,
+                    MAX_FILE_BYTES,
+                )
+                self._entries.pop(configuration, None)
+                return None
+
+            self._entries[configuration] = entry
+            return entry[1]
 
     def prune(self, live_configurations: Iterable[str]) -> None:
         """Drop entries for configurations not in *live_configurations*.
@@ -129,3 +139,17 @@ class YamlSearchCache:
         live = set(live_configurations)
         for stale in [k for k in self._entries if k not in live]:
             del self._entries[stale]
+
+
+def _read_for_cache(path: Path) -> tuple[int, list[str]] | None:
+    """
+    Read *path* off one open handle, keyed on the handle's ``fstat``.
+
+    ``None`` when the handle's size exceeds ``MAX_FILE_BYTES``.
+    """
+    with path.open("rb") as fh:
+        file_stat = os.fstat(fh.fileno())
+        if file_stat.st_size > MAX_FILE_BYTES:
+            return None
+        data = fh.read()
+    return file_stat.st_mtime_ns, data.decode("utf-8", errors="replace").splitlines()

--- a/esphome_device_builder/controllers/devices/_yaml_search_cache.py
+++ b/esphome_device_builder/controllers/devices/_yaml_search_cache.py
@@ -77,8 +77,8 @@ class YamlSearchCache:
           they're routine in a fleet that's actively being edited
           — and never propagate; ``yaml/search`` is best-effort
           across the fleet, not a per-device contract);
-        - the file's size exceeds ``MAX_FILE_BYTES`` (the file is
-          never loaded into memory).
+        - the file's size exceeds ``MAX_FILE_BYTES`` (reads stay
+          bounded at the cap and oversize content is never cached).
         """
         async with self._lock:
             try:

--- a/esphome_device_builder/controllers/devices/_yaml_search_cache.py
+++ b/esphome_device_builder/controllers/devices/_yaml_search_cache.py
@@ -141,11 +141,15 @@ def _read_for_cache(path: Path) -> tuple[int, list[str]] | None:
     """
     Read *path* off one open handle, keyed on the handle's ``fstat``.
 
-    ``None`` when the handle's size exceeds ``MAX_FILE_BYTES``.
+    ``None`` when the content exceeds ``MAX_FILE_BYTES``.
     """
     with path.open("rb") as fh:
         file_stat = os.fstat(fh.fileno())
         if file_stat.st_size > MAX_FILE_BYTES:
             return None
-        data = fh.read()
+        # Bounded read: an in-place append after the fstat could
+        # otherwise grow the read past the cap.
+        data = fh.read(MAX_FILE_BYTES + 1)
+    if len(data) > MAX_FILE_BYTES:
+        return None
     return file_stat.st_mtime_ns, data.decode("utf-8", errors="replace").splitlines()

--- a/tests/controllers/devices/test_yaml_search_cache.py
+++ b/tests/controllers/devices/test_yaml_search_cache.py
@@ -367,6 +367,11 @@ async def test_replace_between_stat_and_read_caches_the_read_version(
 
     # The pre-replace handle's bytes, keyed on that version's mtime.
     assert first == ["wifi:"]
+    # Guarantee the replacement's mtime differs from the cached key —
+    # on a coarse-granularity filesystem the replace can land in the
+    # same tick as the original write.
+    new_mtime = path.stat().st_mtime_ns + 1_000_000_000
+    os.utime(path, ns=(new_mtime, new_mtime))
     # The next call's fresh stat misses the old key and reads the
     # replacement.
     second = await cache.get_lines("kitchen.yaml", path)

--- a/tests/controllers/devices/test_yaml_search_cache.py
+++ b/tests/controllers/devices/test_yaml_search_cache.py
@@ -17,20 +17,26 @@ Branches:
   stale cache entry.
 - ``prune`` drops only stale entries.
 - Concurrent calls against the same file serialise via the
-  internal lock — pinned by counting how many times
-  ``read_text`` is invoked under a deliberate race.
+  internal lock — pinned by counting how many times the read
+  helper is invoked under a deliberate race.
 """
 
 from __future__ import annotations
 
 import asyncio
 import os
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
+from esphome_device_builder.controllers.devices import _yaml_search_cache as cache_module
 from esphome_device_builder.controllers.devices._yaml_search_cache import (
     MAX_FILE_BYTES,
     YamlSearchCache,
+    _read_for_cache,
 )
 
 # ---------------------------------------------------------------------------
@@ -61,7 +67,7 @@ async def test_warm_call_returns_cached_without_reading(tmp_path: Path) -> None:
     The whole point of the cache: a debounced keystroke storm
     should hit the disk once per file per mtime, not once per
     keystroke. Pin that contract by replacing the underlying
-    ``read_text`` after the warm-up call and asserting it never
+    read helper after the warm-up call and asserting it never
     fires on the second.
     """
     cache = YamlSearchCache()
@@ -69,9 +75,11 @@ async def test_warm_call_returns_cached_without_reading(tmp_path: Path) -> None:
     path.write_text("wifi:\n", encoding="utf-8")
     first = await cache.get_lines("kitchen.yaml", path)
 
-    # Replace path.read_text on this specific Path instance with a
-    # sentinel — if the cache calls it, the test fails loudly.
-    with patch.object(Path, "read_text", side_effect=AssertionError("warm path must not re-read")):
+    # Replace the module's read helper with a sentinel — if the
+    # cache calls it, the test fails loudly.
+    with patch.object(
+        cache_module, "_read_for_cache", side_effect=AssertionError("warm path must not re-read")
+    ):
         second = await cache.get_lines("kitchen.yaml", path)
 
     assert second is first  # same list object — the cache returned the cached one
@@ -142,7 +150,7 @@ async def test_unreadable_file_returns_none_and_clears_stale(tmp_path: Path) -> 
     """File stats OK but read fails → ``None`` + cache entry removed.
 
     Covers the rare race where a YAML is rm'd between the
-    cache's ``stat`` and ``read_text`` calls (atomic-save churn,
+    cache's ``stat`` and the read (atomic-save churn,
     aggressive cleanup tooling, etc.). The cache must treat this
     the same way it treats a stat failure: prune the entry,
     return ``None``, let the search loop skip the device.
@@ -158,20 +166,19 @@ async def test_unreadable_file_returns_none_and_clears_stale(tmp_path: Path) -> 
     new_mtime = path.stat().st_mtime_ns + 1_000_000_000
     os.utime(path, ns=(new_mtime, new_mtime))
 
-    # Now make ``read_text`` fail on the next call. Stat still
-    # works (the path is real); the failure is read-side only.
-    real_read = Path.read_text
+    # Now make the read fail on the next call. Stat still works
+    # (the path is real); the failure is read-side only.
     call_count = 0
 
-    def _failing_read(self: Path, *args: object, **kwargs: object) -> str:
+    def _failing_read(target: Path) -> tuple[int, list[str]] | None:
         nonlocal call_count
         call_count += 1
-        if self == path and call_count == 1:
+        if call_count == 1:
             msg = "I/O error mid-read"
             raise OSError(msg)
-        return real_read(self, *args, **kwargs)  # type: ignore[arg-type]
+        return _read_for_cache(target)
 
-    with patch.object(Path, "read_text", _failing_read):
+    with patch.object(cache_module, "_read_for_cache", _failing_read):
         result = await cache.get_lines("kitchen.yaml", path)
 
     assert result is None
@@ -200,8 +207,10 @@ async def test_prune_drops_only_stale_entries(tmp_path: Path) -> None:
     # Only "a.yaml" is live now.
     cache.prune(["a.yaml"])
 
-    # b.yaml's entry was removed — re-fetch hits the read path.
-    with patch.object(Path, "read_text", side_effect=AssertionError("a.yaml should be cached")):
+    # a.yaml's entry survived — re-fetch stays on the warm path.
+    with patch.object(
+        cache_module, "_read_for_cache", side_effect=AssertionError("a.yaml should be cached")
+    ):
         await cache.get_lines("a.yaml", a)
     # b.yaml is no longer cached, so a fresh fetch reads — this
     # would raise if it were still cached (above) but works fine
@@ -221,21 +230,20 @@ async def test_concurrent_misses_against_same_file_read_once(tmp_path: Path) -> 
     Without the cache lock both coroutines would stat + read and
     write the same entry; the duplicate I/O is wasteful but not
     incorrect. Pin the lock-mediated single-read behaviour by
-    counting ``read_text`` invocations across a parallel pair.
+    counting read-helper invocations across a parallel pair.
     """
     cache = YamlSearchCache()
     path = tmp_path / "kitchen.yaml"
     path.write_text("wifi:\n", encoding="utf-8")
 
-    real_read = Path.read_text
     call_count = 0
 
-    def _counting_read(self: Path, *args: object, **kwargs: object) -> str:
+    def _counting_read(target: Path) -> tuple[int, list[str]] | None:
         nonlocal call_count
         call_count += 1
-        return real_read(self, *args, **kwargs)  # type: ignore[arg-type]
+        return _read_for_cache(target)
 
-    with patch.object(Path, "read_text", _counting_read):
+    with patch.object(cache_module, "_read_for_cache", _counting_read):
         a, b = await asyncio.gather(
             cache.get_lines("kitchen.yaml", path),
             cache.get_lines("kitchen.yaml", path),
@@ -253,15 +261,15 @@ async def test_concurrent_misses_against_same_file_read_once(tmp_path: Path) -> 
 
 
 async def test_oversize_file_returns_none_without_loading(tmp_path: Path) -> None:
-    """Files past ``MAX_FILE_BYTES`` are skipped *before* read_text fires.
+    """Files past ``MAX_FILE_BYTES`` are skipped before the read fires.
 
     Defends the cache's memory footprint against pathological
     files (machine-generated YAML, accidentally-checked-in build
     output). The on-disk size is checked from ``stat.st_size``;
-    if the file is over the cap, ``read_text`` is never called
+    if the file is over the cap, the read helper is never called
     and no entry lands in the cache.
 
-    Pin both halves: returns ``None``, AND ``read_text`` was not
+    Pin both halves: returns ``None``, AND the read helper was not
     invoked (i.e. we didn't pay the megabyte read cost just to
     immediately drop it).
     """
@@ -270,15 +278,14 @@ async def test_oversize_file_returns_none_without_loading(tmp_path: Path) -> Non
     # One byte past the cap — minimum to exercise the >cap branch.
     path.write_bytes(b"x" * (MAX_FILE_BYTES + 1))
 
-    real_read = Path.read_text
     read_calls = 0
 
-    def _counting_read(self: Path, *args: object, **kwargs: object) -> str:
+    def _counting_read(target: Path) -> tuple[int, list[str]] | None:
         nonlocal read_calls
         read_calls += 1
-        return real_read(self, *args, **kwargs)  # type: ignore[arg-type]
+        return _read_for_cache(target)
 
-    with patch.object(Path, "read_text", _counting_read):
+    with patch.object(cache_module, "_read_for_cache", _counting_read):
         result = await cache.get_lines("huge.yaml", path)
 
     assert result is None
@@ -317,3 +324,58 @@ async def test_oversize_file_drops_stale_cache_entry(tmp_path: Path) -> None:
     os.utime(path, ns=(new_mtime, new_mtime))
     third = await cache.get_lines("kitchen.yaml", path)
     assert third == ["api:"]
+
+
+async def test_file_growing_past_cap_between_stat_and_open_is_skipped(
+    tmp_path: Path,
+) -> None:
+    """A grow race slipping past the stat check is caught off the open handle."""
+    cache = YamlSearchCache()
+    path = tmp_path / "kitchen.yaml"
+    path.write_text("wifi:\n", encoding="utf-8")
+    first = await cache.get_lines("kitchen.yaml", path)
+    assert first == ["wifi:"]
+
+    path.write_bytes(b"x" * (MAX_FILE_BYTES + 1))
+    # A stat snapshot from before the growth: under the cap, mtime
+    # differing from the cached key so the read path is reached.
+    stale_stat = SimpleNamespace(st_size=7, st_mtime_ns=path.stat().st_mtime_ns + 1)
+
+    with patch.object(Path, "stat", return_value=stale_stat):
+        second = await cache.get_lines("kitchen.yaml", path)
+
+    assert second is None
+    # The entry was dropped, not shadowed — a shrunk file repopulates.
+    path.write_text("api:\n", encoding="utf-8")
+    third = await cache.get_lines("kitchen.yaml", path)
+    assert third == ["api:"]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="cannot replace a file with an open handle")
+async def test_replace_between_stat_and_read_caches_the_read_version(
+    tmp_path: Path,
+) -> None:
+    """A replace racing the read caches the read bytes under their own mtime."""
+    cache = YamlSearchCache()
+    path = tmp_path / "kitchen.yaml"
+    path.write_text("wifi:\n", encoding="utf-8")
+
+    real_open = Path.open
+
+    def _replace_after_open(self: Path, *args: object, **kwargs: object) -> object:
+        fh = real_open(self, *args, **kwargs)
+        if self.name == "kitchen.yaml":
+            staged = tmp_path / "staged.yaml"
+            staged.write_text("api:\n", encoding="utf-8")
+            staged.replace(path)
+        return fh
+
+    with patch.object(Path, "open", _replace_after_open):
+        first = await cache.get_lines("kitchen.yaml", path)
+
+    # The pre-replace handle's bytes, keyed on that version's mtime.
+    assert first == ["wifi:"]
+    # The next call's fresh stat misses the old key and reads the
+    # replacement.
+    second = await cache.get_lines("kitchen.yaml", path)
+    assert second == ["api:"]

--- a/tests/controllers/devices/test_yaml_search_cache.py
+++ b/tests/controllers/devices/test_yaml_search_cache.py
@@ -168,17 +168,7 @@ async def test_unreadable_file_returns_none_and_clears_stale(tmp_path: Path) -> 
 
     # Now make the read fail on the next call. Stat still works
     # (the path is real); the failure is read-side only.
-    call_count = 0
-
-    def _failing_read(target: Path) -> tuple[int, list[str]] | None:
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            msg = "I/O error mid-read"
-            raise OSError(msg)
-        return _read_for_cache(target)
-
-    with patch.object(cache_module, "_read_for_cache", _failing_read):
+    with patch.object(cache_module, "_read_for_cache", side_effect=OSError("I/O error mid-read")):
         result = await cache.get_lines("kitchen.yaml", path)
 
     assert result is None
@@ -236,14 +226,7 @@ async def test_concurrent_misses_against_same_file_read_once(tmp_path: Path) -> 
     path = tmp_path / "kitchen.yaml"
     path.write_text("wifi:\n", encoding="utf-8")
 
-    call_count = 0
-
-    def _counting_read(target: Path) -> tuple[int, list[str]] | None:
-        nonlocal call_count
-        call_count += 1
-        return _read_for_cache(target)
-
-    with patch.object(cache_module, "_read_for_cache", _counting_read):
+    with patch.object(cache_module, "_read_for_cache", wraps=_read_for_cache) as mock_read:
         a, b = await asyncio.gather(
             cache.get_lines("kitchen.yaml", path),
             cache.get_lines("kitchen.yaml", path),
@@ -252,7 +235,7 @@ async def test_concurrent_misses_against_same_file_read_once(tmp_path: Path) -> 
     assert a == b == ["wifi:"]
     # One read, not two — the lock collapsed the second miss into
     # a cache hit once the first finished.
-    assert call_count == 1
+    assert mock_read.call_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -278,18 +261,12 @@ async def test_oversize_file_returns_none_without_loading(tmp_path: Path) -> Non
     # One byte past the cap — minimum to exercise the >cap branch.
     path.write_bytes(b"x" * (MAX_FILE_BYTES + 1))
 
-    read_calls = 0
-
-    def _counting_read(target: Path) -> tuple[int, list[str]] | None:
-        nonlocal read_calls
-        read_calls += 1
-        return _read_for_cache(target)
-
-    with patch.object(cache_module, "_read_for_cache", _counting_read):
+    with patch.object(
+        cache_module, "_read_for_cache", side_effect=AssertionError("oversize must not be read")
+    ):
         result = await cache.get_lines("huge.yaml", path)
 
     assert result is None
-    assert read_calls == 0
 
 
 async def test_oversize_file_drops_stale_cache_entry(tmp_path: Path) -> None:
@@ -335,18 +312,21 @@ async def test_file_growing_past_cap_between_stat_and_open_is_skipped(
     path.write_text("wifi:\n", encoding="utf-8")
     first = await cache.get_lines("kitchen.yaml", path)
     assert first == ["wifi:"]
+    cached_mtime = path.stat().st_mtime_ns
 
     path.write_bytes(b"x" * (MAX_FILE_BYTES + 1))
     # A stat snapshot from before the growth: under the cap, mtime
     # differing from the cached key so the read path is reached.
-    stale_stat = SimpleNamespace(st_size=7, st_mtime_ns=path.stat().st_mtime_ns + 1)
+    stale_stat = SimpleNamespace(st_size=7, st_mtime_ns=cached_mtime + 1)
 
     with patch.object(Path, "stat", return_value=stale_stat):
         second = await cache.get_lines("kitchen.yaml", path)
 
     assert second is None
-    # The entry was dropped, not shadowed — a shrunk file repopulates.
+    # The entry was dropped, not shadowed: restore the cached mtime
+    # onto new content — a surviving stale entry would be returned.
     path.write_text("api:\n", encoding="utf-8")
+    os.utime(path, ns=(cached_mtime, cached_mtime))
     third = await cache.get_lines("kitchen.yaml", path)
     assert third == ["api:"]
 

--- a/tests/controllers/devices/test_yaml_search_cache.py
+++ b/tests/controllers/devices/test_yaml_search_cache.py
@@ -331,6 +331,18 @@ async def test_file_growing_past_cap_between_stat_and_open_is_skipped(
     assert third == ["api:"]
 
 
+def test_read_for_cache_bounds_a_file_growing_after_the_fstat(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An in-place grow past the cap after the fstat still returns ``None``."""
+    path = tmp_path / "kitchen.yaml"
+    path.write_bytes(b"x" * (MAX_FILE_BYTES + 1))
+    pre_growth = SimpleNamespace(st_size=7, st_mtime_ns=123)
+    monkeypatch.setattr(cache_module.os, "fstat", lambda _fd: pre_growth)
+
+    assert _read_for_cache(path) is None
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="cannot replace a file with an open handle")
 async def test_replace_between_stat_and_read_caches_the_read_version(
     tmp_path: Path,


### PR DESCRIPTION
# What does this implement/fix?

The yaml/search line cache stat'd the file and then read it in a separate call, caching the split lines under the earlier stat's mtime; an atomic replace landing between the two cached the new content under the old key. The mismatch self-healed on the next search, so this was a one-search wobble rather than a sticky defect.

Cache misses now read through a private `_read_for_cache`: open the file once, fstat the open handle, re-check the `MAX_FILE_BYTES` cap off that fstat, read from the same handle, and key the entry on the handle's `st_mtime_ns`, so an atomic replace can no longer split the key from the bytes (a non-atomic in-place rewrite racing the read can still pair them briefly and self-heals on the next stat). The warm path stays a single stat with no open; the pre-open size check is kept so a repeatedly searched oversize file never pays an open. The `errors="replace"` decode is preserved, which is also why this site keeps its own read instead of calling `helpers.atomic_io.read_text_with_stat` from #2507 (strict UTF-8, no size guard); the two PRs are independent.

A Windows sharing-violation during the read lands in the existing OSError arm (entry dropped, next keystroke re-reads); a retry inside the cache's single lock would head-of-line-block every concurrent search, so none is added.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2506

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

