### PR TITLE
Accept EsphomeError from the empty idedata sentinel

### DIFF
--- a/tests/test_helper_cli.py
+++ b/tests/test_helper_cli.py
@@ -21,7 +21,7 @@ from types import SimpleNamespace
 
 import pytest
 from esphome.const import KEY_CORE
-from esphome.core import CORE
+from esphome.core import CORE, EsphomeError
 from esphome.platformio.toolchain import KEY_IDEDATA, get_idedata
 from esphome.storage_json import StorageJSON
 
@@ -275,7 +275,10 @@ def test_pin_idedata_pins_a_sentinel_when_the_cache_is_not_required(tmp_path: Pa
     assert KEY_IDEDATA in CORE.data[KEY_CORE]
     # get_idedata answers off the memo, so it can never reach _load_idedata;
     # the empty sentinel then fails the way the latch already handles.
-    with pytest.raises(KeyError):
+    # KeyError on esphome before 2026.8, EsphomeError once IDEData
+    # classifies a stale cache (esphome/esphome#18076); the latch
+    # catches Exception either way.
+    with pytest.raises((KeyError, EsphomeError)):
         _ = get_idedata({}).addr2line_path
 
 

--- a/tests/test_helper_cli.py
+++ b/tests/test_helper_cli.py
@@ -275,9 +275,7 @@ def test_pin_idedata_pins_a_sentinel_when_the_cache_is_not_required(tmp_path: Pa
     assert KEY_IDEDATA in CORE.data[KEY_CORE]
     # get_idedata answers off the memo, so it can never reach _load_idedata;
     # the empty sentinel then fails the way the latch already handles.
-    # KeyError on esphome before 2026.8, EsphomeError once IDEData
-    # classifies a stale cache (esphome/esphome#18076); the latch
-    # catches Exception either way.
+    # Older ESPHome raises KeyError here; newer raises EsphomeError.
     with pytest.raises((KeyError, EsphomeError)):
         _ = get_idedata({}).addr2line_path
 


### PR DESCRIPTION
# What does this implement/fix?

esphome/esphome#18076 teaches IDEData to classify a stale or truncated idedata cache as EsphomeError instead of leaking a raw KeyError, and the downstream job caught our sentinel test pinning the old exception type. The decode latch already catches Exception broadly, so runtime behaviour is unchanged; the test now accepts either type so it stays green on esphome releases from before and after the change.

**Related issue or feature (if applicable):**

- fixes the downstream failure on esphome/esphome#18076

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
