### PR TITLE
Reconcile importable rows when a scan change corrects a device name

### DIFF
--- a/esphome_device_builder/controllers/devices/scan_change.py
+++ b/esphome_device_builder/controllers/devices/scan_change.py
@@ -48,6 +48,7 @@ def on_scan_change(
         # clients stop showing the adopt banner once the device is
         # configured. Idempotent: fires REMOVED only if a row existed.
         controller._on_importable_removed(device.name)
+    _reconcile_importables_on_rename(controller, kind, device, previous)
     if (
         kind in (ScanChange.UPDATED, ScanChange.RELOADED)
         and previous is not None
@@ -115,6 +116,30 @@ def on_scan_change(
         # Idempotent for the controller-driven delete/archive
         # paths; the safety net is external ``rm`` / rename.
         controller._metadata_store.clear_volatile(device.configuration)
+
+
+def _reconcile_importables_on_rename(
+    controller: DevicesController,
+    kind: ScanChange,
+    device: Device,
+    previous: Device | None,
+) -> None:
+    """Retract the corrected name's importable row and resurface the freed one."""
+    if (
+        kind not in (ScanChange.UPDATED, ScanChange.RELOADED)
+        or previous is None
+        or previous.name == device.name
+    ):
+        return
+    # The ADDED retraction keyed on the name at add time; when a later
+    # reload corrects it (a rename, or a package-provided name the
+    # first load couldn't resolve), the importable row for the
+    # corrected name would otherwise stay visible to connected clients
+    # until the next ADDED/REMOVED. The freed old name is the other
+    # half of the transition: a cached announcement the configured-name
+    # filter was suppressing can resurface now.
+    controller._on_importable_removed(device.name)
+    controller._state_monitor.importable.revisit_importable(previous.name)
 
 
 def _sync_network_fingerprint(

--- a/esphome_device_builder/controllers/devices/scan_change.py
+++ b/esphome_device_builder/controllers/devices/scan_change.py
@@ -48,7 +48,7 @@ def on_scan_change(
         # clients stop showing the adopt banner once the device is
         # configured. Idempotent: fires REMOVED only if a row existed.
         controller._on_importable_removed(device.name)
-    _reconcile_importables_on_rename(controller, kind, device, previous)
+    _reconcile_rename(controller, kind, device, previous)
     if (
         kind in (ScanChange.UPDATED, ScanChange.RELOADED)
         and previous is not None
@@ -118,13 +118,13 @@ def on_scan_change(
         controller._metadata_store.clear_volatile(device.configuration)
 
 
-def _reconcile_importables_on_rename(
+def _reconcile_rename(
     controller: DevicesController,
     kind: ScanChange,
     device: Device,
     previous: Device | None,
 ) -> None:
-    """Retract the corrected name's importable row and resurface the freed one."""
+    """Reconcile importables and per-name monitor state after a name correction."""
     if (
         kind not in (ScanChange.UPDATED, ScanChange.RELOADED)
         or previous is None
@@ -135,6 +135,15 @@ def _reconcile_importables_on_rename(
     # name may have a suppressed announcement worth resurfacing.
     controller._on_importable_removed(device.name)
     controller._state_monitor.importable.revisit_importable(previous.name)
+    # The corrected name is as new to the monitor as an ADDED one.
+    controller._state_monitor.probe_reachability(device.name)
+    if not controller._scanner.get_by_name(previous.name):
+        # No sibling YAML still owns the freed name (the scanner index
+        # is already re-keyed when this fires); drop its ledger and
+        # reachability history like the REMOVED branch, or a later
+        # re-add of the name inherits the stale state_source.
+        controller._reachability.clear(previous.name)
+        controller._state_monitor.forget(previous.name)
 
 
 def _sync_network_fingerprint(

--- a/esphome_device_builder/controllers/devices/scan_change.py
+++ b/esphome_device_builder/controllers/devices/scan_change.py
@@ -131,13 +131,8 @@ def _reconcile_importables_on_rename(
         or previous.name == device.name
     ):
         return
-    # The ADDED retraction keyed on the name at add time; when a later
-    # reload corrects it (a rename, or a package-provided name the
-    # first load couldn't resolve), the importable row for the
-    # corrected name would otherwise stay visible to connected clients
-    # until the next ADDED/REMOVED. The freed old name is the other
-    # half of the transition: a cached announcement the configured-name
-    # filter was suppressing can resurface now.
+    # The ADDED retraction keys on the name at add time; the freed old
+    # name may have a suppressed announcement worth resurfacing.
     controller._on_importable_removed(device.name)
     controller._state_monitor.importable.revisit_importable(previous.name)
 

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -1403,6 +1403,57 @@ def test_on_scan_change_added_without_importable_row_is_silent(
     assert captured == []
 
 
+def test_on_scan_change_reloaded_name_change_prunes_importable_row(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    capture_devices_events: CaptureDevicesEventsFactory,
+) -> None:
+    """A reload that corrects the name drops the importable row for the new name."""
+    controller = make_controller(tmp_path, with_state_monitor=True)
+    controller.state.import_result["kitchen"] = _adoptable("kitchen")
+    captured = capture_devices_events(controller, EventType.IMPORTABLE_DEVICE_REMOVED)
+
+    controller._on_scan_change(ScanChange.RELOADED, _device("kitchen"), _device("kitchen-yaml"))
+
+    assert "kitchen" not in controller.state.import_result
+    assert [e.data["name"] for e in captured] == ["kitchen"]
+    assert ("revisit_importable", "kitchen-yaml") in controller._state_monitor.calls
+
+
+def test_on_scan_change_updated_name_change_prunes_importable_row(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    capture_devices_events: CaptureDevicesEventsFactory,
+) -> None:
+    """A YAML edit that renames the device drops the importable row for the new name."""
+    controller = make_controller(tmp_path, with_state_monitor=True)
+    controller.state.import_result["kitchen"] = _adoptable("kitchen")
+    captured = capture_devices_events(controller, EventType.IMPORTABLE_DEVICE_REMOVED)
+
+    controller._on_scan_change(ScanChange.UPDATED, _device("kitchen"), _device("old-kitchen"))
+
+    assert "kitchen" not in controller.state.import_result
+    assert [e.data["name"] for e in captured] == ["kitchen"]
+    assert ("revisit_importable", "old-kitchen") in controller._state_monitor.calls
+
+
+def test_on_scan_change_reloaded_same_name_skips_importable_prune(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    capture_devices_events: CaptureDevicesEventsFactory,
+) -> None:
+    """A same-name reload leaves the importable table untouched."""
+    controller = make_controller(tmp_path, with_state_monitor=True)
+    controller.state.import_result["kitchen"] = _adoptable("kitchen")
+    captured = capture_devices_events(controller, EventType.IMPORTABLE_DEVICE_REMOVED)
+
+    controller._on_scan_change(ScanChange.RELOADED, _device("kitchen"), _device("kitchen"))
+
+    assert "kitchen" in controller.state.import_result
+    assert captured == []
+    assert ("revisit_importable", "kitchen") not in controller._state_monitor.calls
+
+
 # ---------------------------------------------------------------------------
 # _stream_subprocess line_transform hook
 # ---------------------------------------------------------------------------

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -52,6 +52,7 @@ from esphome_device_builder.models import (
     JobStatus,
     JobType,
 )
+from tests._recording_scanner import RecordingScanner
 from tests.conftest import make_device
 
 from .conftest import (
@@ -1452,6 +1453,34 @@ def test_on_scan_change_reloaded_same_name_skips_importable_prune(
     assert "kitchen" in controller.state.import_result
     assert captured == []
     assert ("revisit_importable", "kitchen") not in controller._state_monitor.calls
+
+
+def test_on_scan_change_rename_migrates_monitor_state(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A rename probes the corrected name and forgets the freed name's monitor state."""
+    controller = make_controller(tmp_path, with_state_monitor=True)
+    controller._reachability.observe("old-kitchen", "ping")
+
+    controller._on_scan_change(ScanChange.RELOADED, _device("kitchen"), _device("old-kitchen"))
+
+    assert ("probe_device_ping", "kitchen") in controller._state_monitor.calls
+    assert ("forget", "old-kitchen") in controller._state_monitor.calls
+    assert "old-kitchen" not in controller._reachability._ping_last_seen
+
+
+def test_on_scan_change_rename_keeps_state_for_surviving_sibling(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """The freed name's monitor state survives while a sibling YAML still owns it."""
+    controller = make_controller(tmp_path, with_state_monitor=True)
+    sibling = _device("old-kitchen")
+    controller._scanner = RecordingScanner(devices_by_name={"old-kitchen": [sibling]})
+
+    controller._on_scan_change(ScanChange.RELOADED, _device("kitchen"), _device("old-kitchen"))
+
+    assert ("forget", "old-kitchen") not in controller._state_monitor.calls
+    assert ("probe_device_ping", "kitchen") in controller._state_monitor.calls
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_device_scanner_branches.py
+++ b/tests/test_device_scanner_branches.py
@@ -298,3 +298,79 @@ async def test_scan_removed_passes_none_previous(tmp_path: Path) -> None:
     assert [(kind, dev.name, prev) for kind, dev, prev in events] == [
         (ScanChange.REMOVED, "kitchen", None)
     ]
+
+
+# ---------------------------------------------------------------------------
+# index-before-callback ordering
+# ---------------------------------------------------------------------------
+
+
+async def test_reload_rebuckets_index_before_firing_callback(tmp_path: Path) -> None:
+    """A rename reload re-keys the name index before ``on_change`` observes it."""
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    _write_yaml(cfg, "kitchen")
+    names = iter(["old-kitchen", "kitchen"])
+    observed: list[tuple[list[Device], list[Device]]] = []
+    holder: list[DeviceScanner] = []
+
+    def _on_change(kind: ScanChange, _device: Device, _previous: Device | None) -> None:
+        if kind is ScanChange.RELOADED:
+            observed.append(
+                (holder[0].get_by_name("old-kitchen"), holder[0].get_by_name("kitchen"))
+            )
+
+    with patch(
+        "esphome_device_builder.controllers._device_scanner.load_device_from_storage",
+        side_effect=lambda path, *_a, **_kw: Device(
+            name=next(names), friendly_name=path.stem, configuration=path.name
+        ),
+    ):
+        scanner = DeviceScanner(
+            config_dir=cfg,
+            make_metadata_resolver=lambda: _stub_metadata,
+            on_change=_on_change,
+        )
+        holder.append(scanner)
+        await scanner.scan()
+        assert await scanner.reload("kitchen.yaml") is True
+
+    old_bucket, new_bucket = observed[0]
+    assert old_bucket == []
+    assert [d.name for d in new_bucket] == ["kitchen"]
+
+
+async def test_scan_rebuckets_index_before_firing_callback(tmp_path: Path) -> None:
+    """An UPDATED rename scan re-keys the name index before ``on_change`` observes it."""
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    yaml_path = _write_yaml(cfg, "kitchen")
+    names = iter(["old-kitchen", "kitchen"])
+    observed: list[tuple[list[Device], list[Device]]] = []
+    holder: list[DeviceScanner] = []
+
+    def _on_change(kind: ScanChange, _device: Device, _previous: Device | None) -> None:
+        if kind is ScanChange.UPDATED:
+            observed.append(
+                (holder[0].get_by_name("old-kitchen"), holder[0].get_by_name("kitchen"))
+            )
+
+    with patch(
+        "esphome_device_builder.controllers._device_scanner.load_device_from_storage",
+        side_effect=lambda path, *_a, **_kw: Device(
+            name=next(names), friendly_name=path.stem, configuration=path.name
+        ),
+    ):
+        scanner = DeviceScanner(
+            config_dir=cfg,
+            make_metadata_resolver=lambda: _stub_metadata,
+            on_change=_on_change,
+        )
+        holder.append(scanner)
+        await scanner.scan()
+        yaml_path.write_text("esphome:\n  name: kitchen\n# touched\n", encoding="utf-8")
+        await scanner.scan()
+
+    old_bucket, new_bucket = observed[0]
+    assert old_bucket == []
+    assert [d.name for d in new_bucket] == ["kitchen"]


### PR DESCRIPTION
# What does this implement/fix?

A scan change that corrects a device's name (a rename, or a reload that resolves a package provided name the first load could not see) now reconciles the importable list for both halves of the transition. The row for the corrected name is retracted, so connected clients stop showing the adopt banner for a device that is already configured; the freed old name is revisited through the existing `revisit_importable` path, so a cached announcement that the configured name filter was suppressing can resurface.

Previously the retraction only ran on `ADDED`, keyed on the name at add time, and nothing handled the name changing later; the stale row stayed visible to subscribed clients until the next `ADDED` or `REMOVED` for that name.

**Related issue or feature (if applicable):**

- none, found while planning the shallow cold start scan work

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
