### PR TITLE
Add shallow load mode to the device scanner

### DIFF
--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -320,10 +320,14 @@ class DeviceScanner(WakeWorker[str]):
         """Return the configured device for YAML filename *configuration*, or ``None``."""
         return self._index.get_by_configuration(configuration)
 
-    async def scan(self) -> None:
-        """Refresh the device cache from disk, emitting per-file change events."""
+    async def scan(self, shallow: bool = False) -> None:  # noqa: FBT001, FBT002
+        """
+        Refresh the device cache from disk, emitting per-file change events.
+
+        *shallow* skips the resolved-config parse.
+        """
         async with self._lock:
-            await self._do_scan()
+            await self._do_scan(shallow)
 
     async def reload(self, filename: str) -> bool:
         """
@@ -399,7 +403,7 @@ class DeviceScanner(WakeWorker[str]):
                     filename,
                 )
 
-    async def _do_scan(self) -> None:
+    async def _do_scan(self, shallow: bool = False) -> None:  # noqa: FBT001, FBT002
         path_to_cache_key = await run_in_executor(self._build_cache_keys)
 
         old_paths = set(self._index.by_path.keys())
@@ -414,7 +418,7 @@ class DeviceScanner(WakeWorker[str]):
 
         paths_to_load = added_paths | updated_paths
         if paths_to_load:
-            loaded = await run_in_executor(self._load_devices, paths_to_load)
+            loaded = await run_in_executor(self._load_devices, paths_to_load, shallow)
             for path, device in loaded.items():
                 kind = ScanChange.ADDED if path in added_paths else ScanChange.UPDATED
                 previous = self._index.by_path.get(path)
@@ -444,7 +448,7 @@ class DeviceScanner(WakeWorker[str]):
             result[file] = (stat.st_ino, stat.st_dev, stat.st_mtime, stat.st_size)
         return result
 
-    def _load_devices(self, paths: set[Path]) -> dict[Path, Device]:
+    def _load_devices(self, paths: set[Path], shallow: bool = False) -> dict[Path, Device]:  # noqa: FBT001, FBT002
         """Materialise Device models for *paths*. Logs and skips on failure."""
         result: dict[Path, Device] = {}
         get_metadata = self._make_metadata_resolver()
@@ -464,6 +468,7 @@ class DeviceScanner(WakeWorker[str]):
                     queued_update=metadata.queued_update,
                     api_encryption_active=metadata.api_encryption_active,
                     previous=self._index.by_path.get(path),
+                    shallow=shallow,
                 )
             except Exception:  # noqa: BLE001 — best-effort scan; one bad YAML mustn't kill the sweep
                 _LOGGER.warning("Failed to load device from %s", path.name)

--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -13,6 +13,7 @@ import asyncio
 import logging
 from collections.abc import Callable, Iterable, Mapping
 from enum import StrEnum
+from functools import partial
 from pathlib import Path
 from types import MappingProxyType
 from typing import NamedTuple
@@ -320,10 +321,15 @@ class DeviceScanner(WakeWorker[str]):
         """Return the configured device for YAML filename *configuration*, or ``None``."""
         return self._index.get_by_configuration(configuration)
 
-    async def scan(self, shallow: bool = False) -> None:  # noqa: FBT001, FBT002
-        """Rescan the config dir, emitting change events; *shallow* skips the resolved parse."""
+    async def scan(self, *, shallow: bool = False) -> None:
+        """
+        Rescan the config dir, emitting change events; *shallow* skips the resolved parse.
+
+        Shallow rows keep their fresh cache key, so later scans skip
+        them until a ``reload`` / ``request`` deepens the row.
+        """
         async with self._lock:
-            await self._do_scan(shallow)
+            await self._do_scan(shallow=shallow)
 
     async def reload(self, filename: str) -> bool:
         """
@@ -399,7 +405,7 @@ class DeviceScanner(WakeWorker[str]):
                     filename,
                 )
 
-    async def _do_scan(self, shallow: bool = False) -> None:  # noqa: FBT001, FBT002
+    async def _do_scan(self, *, shallow: bool = False) -> None:
         path_to_cache_key = await run_in_executor(self._build_cache_keys)
 
         old_paths = set(self._index.by_path.keys())
@@ -414,7 +420,9 @@ class DeviceScanner(WakeWorker[str]):
 
         paths_to_load = added_paths | updated_paths
         if paths_to_load:
-            loaded = await run_in_executor(self._load_devices, paths_to_load, shallow)
+            loaded = await run_in_executor(
+                partial(self._load_devices, paths_to_load, shallow=shallow)
+            )
             for path, device in loaded.items():
                 kind = ScanChange.ADDED if path in added_paths else ScanChange.UPDATED
                 previous = self._index.by_path.get(path)
@@ -444,7 +452,7 @@ class DeviceScanner(WakeWorker[str]):
             result[file] = (stat.st_ino, stat.st_dev, stat.st_mtime, stat.st_size)
         return result
 
-    def _load_devices(self, paths: set[Path], shallow: bool = False) -> dict[Path, Device]:  # noqa: FBT001, FBT002
+    def _load_devices(self, paths: set[Path], *, shallow: bool = False) -> dict[Path, Device]:
         """Materialise Device models for *paths*. Logs and skips on failure."""
         result: dict[Path, Device] = {}
         get_metadata = self._make_metadata_resolver()

--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -321,11 +321,7 @@ class DeviceScanner(WakeWorker[str]):
         return self._index.get_by_configuration(configuration)
 
     async def scan(self, shallow: bool = False) -> None:  # noqa: FBT001, FBT002
-        """
-        Refresh the device cache from disk, emitting per-file change events.
-
-        *shallow* skips the resolved-config parse.
-        """
+        """Rescan the config dir, emitting change events; *shallow* skips the resolved parse."""
         async with self._lock:
             await self._do_scan(shallow)
 

--- a/esphome_device_builder/helpers/device_yaml/_loading.py
+++ b/esphome_device_builder/helpers/device_yaml/_loading.py
@@ -66,6 +66,7 @@ def load_device_from_storage(
     queued_update: bool = False,
     api_encryption_active: str | None = None,
     previous: Device | None = None,
+    shallow: bool = False,
 ) -> Device:
     """
     Build a Device model from a YAML config file and its StorageJSON.
@@ -111,6 +112,10 @@ def load_device_from_storage(
     *previous* is the prior in-memory Device for this path, when one
     exists. Its ``runtime_state`` carries forward whole so a reload
     doesn't wipe what mDNS / ping has already discovered.
+
+    *shallow* skips the resolved-config parse and the validated-config
+    read; resolved-only fields degrade to their raw-text / StorageJSON
+    fallbacks.
     """
     filename = path.name
     storage = StorageJSON.load(resolve_storage_path(filename))
@@ -122,7 +127,7 @@ def load_device_from_storage(
     # YAML would miss configs that pull the api block in via include
     # or split it across packages. ``None`` on parse failure is fine;
     # ``api_encrypted`` falls back to False.
-    resolved_config = load_device_yaml(path)
+    resolved_config = None if shallow else load_device_yaml(path)
     # Feed the merged ``substitutions:`` from the resolved config back
     # into the meta readers so ``esphome.friendly_name: $room`` resolves
     # against substitutions contributed by ``packages:`` / ``!include``
@@ -365,6 +370,7 @@ def load_device_from_storage(
         # (same gap the ``api_enabled`` union closes via
         # ``loaded_integrations``; this flag has no StorageJSON field).
         ota_partition_access=target_platform == "esp32"
+        and not shallow
         and (
             extract_ota_partition_access(resolved_config)
             or compiled_config_has_ota_partition_access(filename)

--- a/tests/_recording_scanner.py
+++ b/tests/_recording_scanner.py
@@ -59,7 +59,7 @@ class RecordingScanner:
         self.devices: list[object] = []
         self.by_path: dict[Path, object] = {}
 
-    async def scan(self, shallow: bool = False) -> None:
+    async def scan(self, *, shallow: bool = False) -> None:
         self.calls.append(("scan", shallow))
 
     async def reload(self, filename: str) -> bool:

--- a/tests/_recording_scanner.py
+++ b/tests/_recording_scanner.py
@@ -19,7 +19,7 @@ class RecordingScanner:
 
     Mirrors every public method on the production ``DeviceScanner``
     (``scan`` / ``reload`` / ``request`` / ``start`` / ``stop`` /
-    ``get_by_name`` / ``devices`` / ``by_path``). Calls to the
+    ``wait_idle`` / ``get_by_name`` / ``devices`` / ``by_path``). Calls to the
     recordable ones land in ``self.calls`` as
     ``(method_name, *args)``; tests assert on the list directly
     instead of scattering ``MagicMock.assert_awaited_*`` lines.
@@ -59,12 +59,15 @@ class RecordingScanner:
         self.devices: list[object] = []
         self.by_path: dict[Path, object] = {}
 
-    async def scan(self) -> None:
+    async def scan(self, shallow: bool = False) -> None:
         self.calls.append(("scan",))
 
     async def reload(self, filename: str) -> bool:
         self.calls.append(("reload", filename))
         return self._reload_returns
+
+    async def wait_idle(self) -> None:
+        self.calls.append(("wait_idle",))
 
     def request(self, filename: str) -> None:
         self.calls.append(("request", filename))

--- a/tests/_recording_scanner.py
+++ b/tests/_recording_scanner.py
@@ -60,7 +60,7 @@ class RecordingScanner:
         self.by_path: dict[Path, object] = {}
 
     async def scan(self, shallow: bool = False) -> None:
-        self.calls.append(("scan",))
+        self.calls.append(("scan", shallow))
 
     async def reload(self, filename: str) -> bool:
         self.calls.append(("reload", filename))

--- a/tests/benchmarks/test_device_scanner_fleet.py
+++ b/tests/benchmarks/test_device_scanner_fleet.py
@@ -57,6 +57,25 @@ def test_load_devices_fleet(
         scanner._load_devices(paths_set)
 
 
+@pytest.mark.parametrize("fleet_size", [5])
+def test_load_devices_fleet_shallow(
+    benchmark: BenchmarkFixture,
+    tmp_path: Path,
+    fleet_size: int,
+) -> None:
+    """Per-device cold-start seed cost with the resolved parse skipped."""
+    paths = synthesize_fleet(tmp_path, fleet_size)
+    paths_set = set(paths)
+    scanner = _make_scanner(tmp_path)
+
+    warm = scanner._load_devices(paths_set, shallow=True)
+    assert len(warm) == fleet_size
+
+    @benchmark
+    def run() -> None:
+        scanner._load_devices(paths_set, shallow=True)
+
+
 @pytest.mark.parametrize("fleet_size", [50, 200])
 def test_build_cache_keys_fleet(
     benchmark: BenchmarkFixture,

--- a/tests/controllers/devices/test_archive.py
+++ b/tests/controllers/devices/test_archive.py
@@ -393,7 +393,7 @@ async def test_archive_device_full_flow_calls_scanner(
 
     assert not yaml_path.exists()
     assert (tmp_path / "archive" / "kitchen.yaml").exists()
-    assert controller._scanner.calls == [("scan",)]
+    assert controller._scanner.calls == [("scan", False)]
 
 
 async def test_unarchive_device_full_flow_calls_scanner(
@@ -413,7 +413,7 @@ async def test_unarchive_device_full_flow_calls_scanner(
 
     assert not (archive_dir / "kitchen.yaml").exists()
     assert (tmp_path / "kitchen.yaml").exists()
-    assert controller._scanner.calls == [("scan",)]
+    assert controller._scanner.calls == [("scan", False)]
 
 
 async def test_list_archived_full_flow(

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -133,7 +133,7 @@ async def test_delete_device_unlinks_yaml_then_scans(
     await controller.delete_device(configuration="kitchen.yaml")
 
     assert not yaml_path.exists()
-    assert ("scan",) in controller._scanner.calls
+    assert ("scan", False) in controller._scanner.calls
 
 
 @pytest.mark.usefixtures("redirect_storage_path")
@@ -169,7 +169,7 @@ async def test_delete_bulk_returns_per_device_success_with_mixed_outcomes(
         {"configuration": "bedroom.yaml", "success": True},
     ]
     # Only one scan for the whole batch.
-    scan_calls = [c for c in controller._scanner.calls if c == ("scan",)]
+    scan_calls = [c for c in controller._scanner.calls if c == ("scan", False)]
     assert len(scan_calls) == 1
 
 
@@ -210,7 +210,7 @@ async def test_archive_bulk_returns_per_device_success_with_mixed_outcomes(
     assert (tmp_path / "archive" / "kitchen.yaml").exists()
     assert (tmp_path / "archive" / "bedroom.yaml").exists()
     # Only one scan for the whole batch.
-    scan_calls = [c for c in controller._scanner.calls if c == ("scan",)]
+    scan_calls = [c for c in controller._scanner.calls if c == ("scan", False)]
     assert len(scan_calls) == 1
 
 

--- a/tests/controllers/devices/test_clone.py
+++ b/tests/controllers/devices/test_clone.py
@@ -96,7 +96,7 @@ async def test_clone_device_writes_new_yaml_and_swaps_name_friendly_key(
     # Source file untouched.
     assert (tmp_path / "kitchen.yaml").read_text("utf-8") == SOURCE_YAML
     # Scanner nudged so the new file lands in the next ``devices/list``.
-    assert ctrl._scanner.calls == [("scan",)]
+    assert ctrl._scanner.calls == [("scan", False)]
 
 
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -245,7 +245,7 @@ async def test_create_device_emits_minimal_stub_when_no_board_or_file_content(
     assert "Replace this with your actual platform" in content
     assert "api:\n  encryption:\n    key:" in content
     assert "  ssid: !secret wifi_ssid\n" in content
-    assert ctrl._scanner.calls == [("scan",)]
+    assert ctrl._scanner.calls == [("scan", False)]
     # Stub branch deliberately skips the catalog lookup so an
     # arbitrary entry sharing ``esp32dev`` doesn't get pinned to
     # this device's metadata before the user picks real hardware.
@@ -702,7 +702,7 @@ async def test_create_device_accepts_invalid_file_content_for_user_repair(
     # the editor.
     assert (tmp_path / "kitchen.yaml").read_text("utf-8") == invalid_file_content
     # Scanner nudged so the device shows up in ``devices/list``.
-    assert ctrl._scanner.calls == [("scan",)]
+    assert ctrl._scanner.calls == [("scan", False)]
     # Validator must NOT have been called for the upload branch.
     validate.assert_not_called()
 
@@ -757,7 +757,7 @@ async def test_create_device_accepts_old_esphome_version_yaml(
     assert result.configuration == "old-device.yaml"
     written = (tmp_path / "old-device.yaml").read_text("utf-8")
     assert written == legacy_yaml
-    assert ctrl._scanner.calls == [("scan",)]
+    assert ctrl._scanner.calls == [("scan", False)]
 
 
 async def test_create_device_rejects_binary_file_content(
@@ -1119,7 +1119,7 @@ async def test_create_device_overwrite_preserves_metadata(
     assert post.get("labels") == ["kitchen-label"]
     assert post.get("comment") == "my note"
     assert post.get("board_id") == "esp32-pick"
-    assert ctrl._scanner.calls == [("scan",)]
+    assert ctrl._scanner.calls == [("scan", False)]
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't honor POSIX mode bits")

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -124,7 +124,7 @@ async def test_import_device_writes_adoption_yaml_and_returns_path(
     # path; pin the full call list so a regression that double-scans
     # (or sneaks in a stray ``reload``) breaks here instead of
     # silently passing the membership check.
-    assert ctrl._scanner.calls == [("scan",)]
+    assert ctrl._scanner.calls == [("scan", False)]
 
 
 async def test_import_device_omits_wifi_for_ethernet_network(
@@ -1246,7 +1246,7 @@ async def test_import_device_keeps_yaml_when_validator_unavailable(
 
     assert result == {"configuration": "kitchen.yaml"}
     assert (tmp_path / "kitchen.yaml").exists()
-    assert ctrl._scanner.calls == [("scan",)]
+    assert ctrl._scanner.calls == [("scan", False)]
 
 
 async def test_import_device_propagates_generic_runtime_error(

--- a/tests/controllers/devices/test_import_bundle.py
+++ b/tests/controllers/devices/test_import_bundle.py
@@ -115,7 +115,7 @@ async def test_import_bundle_lands_full_tree(
     assert (tmp_path / "secrets.yaml").read_text("utf-8") == "wifi_password: hunter2\n"
     # manifest.json is never written into the config dir.
     assert not (tmp_path / "manifest.json").exists()
-    assert ctrl._scanner.calls == [("scan",)]
+    assert ctrl._scanner.calls == [("scan", False)]
 
 
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers", "_bundle_storage_under_tmp")
@@ -163,7 +163,7 @@ async def test_import_bundle_overwrite_replaces_only_chosen_files(
     # The response reports the partial import honestly.
     assert result.written == ["kitchen.yaml"]
     assert result.kept == ["common/wifi.yaml"]
-    assert ctrl._scanner.calls == [("scan",)]
+    assert ctrl._scanner.calls == [("scan", False)]
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't honor POSIX mode bits")
@@ -234,7 +234,7 @@ async def test_import_bundle_overwrite_main_preserves_metadata(
     assert post.get("labels") == ["lab"]
     assert post.get("comment") == "note"
     assert post.get("board_id") == "esp32-pick"
-    assert ctrl._scanner.calls == [("scan",)]
+    assert ctrl._scanner.calls == [("scan", False)]
 
 
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers", "_bundle_storage_under_tmp")

--- a/tests/controllers/devices/test_listing_api.py
+++ b/tests/controllers/devices/test_listing_api.py
@@ -135,7 +135,7 @@ async def test_list_devices_scans_then_returns_configured_and_importable(
     assert [d.name for d in response.configured] == ["kitchen"]
     assert [d.name for d in response.importable] == ["kitchen-1a2b3c"]
     # Scanner was kicked once before the listing.
-    assert ("scan",) in controller._scanner.calls
+    assert ("scan", False) in controller._scanner.calls
 
 
 async def test_list_devices_filters_importable_already_configured(

--- a/tests/controllers/devices/test_rename.py
+++ b/tests/controllers/devices/test_rename.py
@@ -150,7 +150,7 @@ async def test_rename_underscore_name_to_hyphen_in_place(
     new_content = config.read_text(encoding="utf-8")
     assert read_yaml_scalar(new_content, ("esphome", "name")) == "test-1"
     assert read_yaml_scalar(new_content, ("esphome", "friendly_name")) == "Test_1"
-    assert controller._scanner.calls == [("reload", "test-1.yaml"), ("scan",)]
+    assert controller._scanner.calls == [("reload", "test-1.yaml"), ("scan", False)]
 
 
 async def test_rename_in_place_with_redundant_path_segments(

--- a/tests/controllers/devices/test_rename_config_only.py
+++ b/tests/controllers/devices/test_rename_config_only.py
@@ -42,7 +42,7 @@ async def test_config_only_rename_rewrites_name_and_renames_file(
     assert read_yaml_scalar(new_content, ("esphome", "name")) == "livingroom"
     # Untouched siblings survive the rewrite.
     assert read_yaml_scalar(new_content, ("esphome", "friendly_name")) == "Kitchen Light"
-    assert controller._scanner.calls == [("reload", "livingroom.yaml"), ("scan",)]
+    assert controller._scanner.calls == [("reload", "livingroom.yaml"), ("scan", False)]
 
 
 async def test_config_only_rename_retargets_name_labelled_ap_ssid(
@@ -155,7 +155,7 @@ async def test_config_only_rename_survives_storage_migration_failure(
     assert result == {"configuration": "livingroom.yaml", "job": None}
     assert not (tmp_path / "kitchen.yaml").exists()
     assert (tmp_path / "livingroom.yaml").exists()
-    assert controller._scanner.calls == [("reload", "livingroom.yaml"), ("scan",)]
+    assert controller._scanner.calls == [("reload", "livingroom.yaml"), ("scan", False)]
 
 
 async def test_config_only_rename_rejects_invalid_rewrite(

--- a/tests/controllers/devices/test_rename_metadata.py
+++ b/tests/controllers/devices/test_rename_metadata.py
@@ -161,7 +161,7 @@ async def test_completed_rename_migrates_metadata_then_scans(
     moved = await controller._shared_sidecar.get("livingroom.yaml")
     assert moved.get("labels") == ["a"]
     assert moved.get("comment") == "downstairs"
-    assert controller._scanner.calls == [("reload", "livingroom.yaml"), ("scan",)]
+    assert controller._scanner.calls == [("reload", "livingroom.yaml"), ("scan", False)]
 
 
 async def test_completed_rename_normalizes_new_name_with_extension(
@@ -214,7 +214,7 @@ async def test_completed_rename_scans_even_when_migration_fails(
     firmware_sync.on_job_completed(controller, Event(EventType.JOB_COMPLETED, {"job": job}))
 
     await scheduled[0]
-    assert controller._scanner.calls == [("reload", "livingroom.yaml"), ("scan",)]
+    assert controller._scanner.calls == [("reload", "livingroom.yaml"), ("scan", False)]
 
 
 async def test_migrate_reloads_a_device_the_mtime_cache_would_skip(
@@ -271,4 +271,4 @@ async def test_completed_rename_without_new_name_falls_back_to_scan(
 
     assert len(scheduled) == 1
     await scheduled[0]
-    assert controller._scanner.calls == [("scan",)]
+    assert controller._scanner.calls == [("scan", False)]

--- a/tests/test_device_scanner_branches.py
+++ b/tests/test_device_scanner_branches.py
@@ -441,3 +441,23 @@ async def test_reload_after_shallow_scan_is_deep(tmp_path: Path) -> None:
         assert await scanner.reload("kitchen.yaml") is True
 
     assert seen == [True, False]
+
+
+async def test_plain_scan_does_not_redeepen_shallow_rows(tmp_path: Path) -> None:
+    """Sticky-shallow: a later plain ``scan()`` skips an unchanged shallow row."""
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    _write_yaml(cfg, "kitchen")
+    seen: list[bool] = []
+
+    with patch(
+        "esphome_device_builder.controllers._device_scanner.load_device_from_storage",
+        side_effect=_shallow_capturing_loader(seen),
+    ):
+        scanner, _ = _make_scanner(cfg)
+        await scanner.scan(shallow=True)
+        await scanner.scan()
+
+    # The unchanged cache key skipped the file entirely; only reload /
+    # request deepens the row.
+    assert seen == [True]

--- a/tests/test_device_scanner_branches.py
+++ b/tests/test_device_scanner_branches.py
@@ -374,3 +374,70 @@ async def test_scan_rebuckets_index_before_firing_callback(tmp_path: Path) -> No
     old_bucket, new_bucket = observed[0]
     assert old_bucket == []
     assert [d.name for d in new_bucket] == ["kitchen"]
+
+
+# ---------------------------------------------------------------------------
+# shallow scan threading
+# ---------------------------------------------------------------------------
+
+
+def _shallow_capturing_loader(seen: list[bool]) -> Any:
+    """Loader stub recording the ``shallow`` kwarg it was called with."""
+
+    def _capture(path: Path, *_a: Any, **kw: Any) -> Device:
+        seen.append(kw.get("shallow", False))
+        return Device(name=path.stem, friendly_name=path.stem, configuration=path.name)
+
+    return _capture
+
+
+async def test_scan_shallow_threads_to_loader(tmp_path: Path) -> None:
+    """``scan(shallow=True)`` passes the flag through to ``load_device_from_storage``."""
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    _write_yaml(cfg, "kitchen")
+    seen: list[bool] = []
+
+    with patch(
+        "esphome_device_builder.controllers._device_scanner.load_device_from_storage",
+        side_effect=_shallow_capturing_loader(seen),
+    ):
+        scanner, _ = _make_scanner(cfg)
+        await scanner.scan(shallow=True)
+
+    assert seen == [True]
+
+
+async def test_scan_default_is_deep(tmp_path: Path) -> None:
+    """A bare ``scan()`` loads deep."""
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    _write_yaml(cfg, "kitchen")
+    seen: list[bool] = []
+
+    with patch(
+        "esphome_device_builder.controllers._device_scanner.load_device_from_storage",
+        side_effect=_shallow_capturing_loader(seen),
+    ):
+        scanner, _ = _make_scanner(cfg)
+        await scanner.scan()
+
+    assert seen == [False]
+
+
+async def test_reload_after_shallow_scan_is_deep(tmp_path: Path) -> None:
+    """``reload`` always loads deep, even for a device seeded by a shallow scan."""
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    _write_yaml(cfg, "kitchen")
+    seen: list[bool] = []
+
+    with patch(
+        "esphome_device_builder.controllers._device_scanner.load_device_from_storage",
+        side_effect=_shallow_capturing_loader(seen),
+    ):
+        scanner, _ = _make_scanner(cfg)
+        await scanner.scan(shallow=True)
+        assert await scanner.reload("kitchen.yaml") is True
+
+    assert seen == [True, False]

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -1155,6 +1155,82 @@ def test_load_device_from_storage_resolves_config_once_for_packages(tmp_path: Pa
     assert spy.call_count == 1
 
 
+def test_load_device_from_storage_shallow_skips_resolved_parse(tmp_path: Path) -> None:
+    """``shallow=True`` never parses the resolved config or reads the validated cache."""
+    yaml_file = tmp_path / "kitchen.yaml"
+    yaml_file.write_text("esphome:\n  name: kitchen\nesp32:\n  board: esp32dev\n", encoding="utf-8")
+    with (
+        mock.patch(
+            "esphome_device_builder.helpers.device_yaml._loading.load_device_yaml",
+            side_effect=AssertionError("resolved parse ran in shallow mode"),
+        ),
+        mock.patch(
+            "esphome_device_builder.helpers.device_yaml._loading."
+            "compiled_config_has_ota_partition_access",
+            side_effect=AssertionError("validated-config read ran in shallow mode"),
+        ),
+    ):
+        device = load_device_from_storage(yaml_file, shallow=True)
+    assert device.name == "kitchen"
+    assert device.target_platform == "esp32"
+    assert device.ota_partition_access is False
+
+
+def test_load_device_from_storage_shallow_matches_deep_for_inline_meta(tmp_path: Path) -> None:
+    """Inline meta and the network fingerprint come from raw text, identical either way."""
+    yaml_file = tmp_path / "kitchen.yaml"
+    yaml_file.write_text(
+        "substitutions:\n"
+        "  room: Kitchen\n"
+        "esphome:\n"
+        "  name: kitchen\n"
+        "  friendly_name: ${room} Sensor\n"
+        "  comment: window sill\n"
+        "  area: kitchen\n"
+        "wifi:\n"
+        "  use_address: 192.168.1.50\n",
+        encoding="utf-8",
+    )
+    shallow = load_device_from_storage(yaml_file, shallow=True)
+    deep = load_device_from_storage(yaml_file)
+    assert shallow.name == deep.name == "kitchen"
+    assert shallow.friendly_name == deep.friendly_name == "Kitchen Sensor"
+    assert shallow.comment == deep.comment == "window sill"
+    assert shallow.area == deep.area == "kitchen"
+    assert shallow.network_fingerprint == deep.network_fingerprint != ""
+
+
+def test_load_device_from_storage_shallow_degrades_package_fields(tmp_path: Path) -> None:
+    """Package-contributed blocks wait for the deep load; raw-text fields survive."""
+    (tmp_path / "board.yaml").write_text(
+        "esp32:\n  board: esp32dev\nmqtt:\n  broker: 10.0.0.5\n", encoding="utf-8"
+    )
+    yaml_file = tmp_path / "ble.yaml"
+    yaml_file.write_text(
+        "esphome:\n  name: ble\npackages:\n  board: !include board.yaml\n",
+        encoding="utf-8",
+    )
+    shallow = load_device_from_storage(yaml_file, shallow=True)
+    deep = load_device_from_storage(yaml_file)
+    assert shallow.name == deep.name == "ble"
+    assert shallow.target_platform == ""
+    assert deep.target_platform == "esp32"
+    assert shallow.uses_mqtt is False
+    assert deep.uses_mqtt is True
+    assert shallow.directly_referenced_integrations == []
+
+
+def test_load_device_from_storage_shallow_mqtt_extract_from_raw_text(tmp_path: Path) -> None:
+    """An inline ``mqtt:`` block still yields a usable extract without the resolved parse."""
+    yaml_file = tmp_path / "kitchen.yaml"
+    yaml_file.write_text("esphome:\n  name: kitchen\nmqtt:\n  broker: 10.0.0.5\n", encoding="utf-8")
+    device = load_device_from_storage(yaml_file, shallow=True)
+    assert device.uses_mqtt is True
+    assert device.mqtt_extract is not None
+    assert device.mqtt_extract.main_block == {"broker": "10.0.0.5"}
+    assert device.mqtt_extract.resolved_block is None
+
+
 def test_load_device_from_storage_detects_deep_sleep(tmp_path: Path) -> None:
     """A top-level ``deep_sleep:`` block sets ``uses_deep_sleep``; its absence clears it."""
     sleeper = tmp_path / "sleeper.yaml"


### PR DESCRIPTION
# What does this implement/fix?

Adds a shallow load mode to `load_device_from_storage` and threads it through `DeviceScanner.scan`. A shallow load skips the resolved config parse (`load_device_yaml`, the `yaml_util.load_yaml` plus `resolve_packages` pass) and the validated config read; every resolved-only field degrades to the raw text or StorageJSON fallback that already exists for the mid edit and parse failure paths. `reload` stays deep, so only an explicit `scan(shallow=True)` caller ever gets shallow rows.

There is no production caller yet; this is the plumbing for a follow up that seeds the cold start scan shallow and deep reloads in the background. The startup motivation: on a real fleet the initial scan's resolved parses can block startup for many seconds (23s observed), while the raw text pass is microseconds per device.

The `RecordingScanner` test fake mirrors the new surface (`scan` kwarg, `wait_idle`), and a shallow variant of the fleet benchmark is added; the existing benchmark keeps its function name so its CodSpeed baseline history survives.

**Related issue or feature (if applicable):**

- none, groundwork for the shallow cold start scan

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
