### PR TITLE
Raise the upload lane to 8 slots on esphome 2026.8+

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,7 +336,8 @@ against legacy behaviour before assuming the simpler version suffices.
   lane (one job at a time), a network/upload lane (up to
   `MAX_CONCURRENT_UPLOADS` flashes at once — 4, or 8 with esphome
   2026.8+ whose upload subprocess is slimmer and whose log sessions
-  defer the platform import (esphome/esphome#17684, #18093, #18048);
+  defer the platform import (esphome/esphome#17684, esphome/esphome#18093,
+  esphome/esphome#18048);
   the cap bounds subprocess-tree memory), and a single-slot thread
   upload lane, all
   running concurrently, so a slow upload doesn't block the next compile

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,8 +334,9 @@ against legacy behaviour before assuming the simpler version suffices.
   rationale in `docs/ARCHITECTURE.md` "Event bus → Typing event payloads".
 - **Persistent firmware queue — three concurrent lanes.** A CPU/compile
   lane (one job at a time), a network/upload lane (up to
-  `MAX_CONCURRENT_UPLOADS` flashes at once — 4, or 7 with esphome
-  2026.8+ whose upload subprocess is slimmer (esphome/esphome#17684);
+  `MAX_CONCURRENT_UPLOADS` flashes at once — 4, or 9 with esphome
+  2026.8+ whose upload subprocess is slimmer and whose log sessions
+  defer the platform import (esphome/esphome#17684, #18093, #18048);
   the cap bounds subprocess-tree memory), and a single-slot thread
   upload lane, all
   running concurrently, so a slow upload doesn't block the next compile

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,7 +334,7 @@ against legacy behaviour before assuming the simpler version suffices.
   rationale in `docs/ARCHITECTURE.md` "Event bus → Typing event payloads".
 - **Persistent firmware queue — three concurrent lanes.** A CPU/compile
   lane (one job at a time), a network/upload lane (up to
-  `MAX_CONCURRENT_UPLOADS` flashes at once — 4, or 9 with esphome
+  `MAX_CONCURRENT_UPLOADS` flashes at once — 4, or 8 with esphome
   2026.8+ whose upload subprocess is slimmer and whose log sessions
   defer the platform import (esphome/esphome#17684, #18093, #18048);
   the cap bounds subprocess-tree memory), and a single-slot thread

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -200,9 +200,9 @@ firmware/install {configuration} → QUEUED → RUNNING → output... → COMPLE
 - Three concurrent lanes — a compile lane (CPU, one job at a time), an
   upload lane (network, up to `MAX_CONCURRENT_UPLOADS` flashes at once:
   4, or 8 when the installed esphome is 2026.8 or later, whose upload
-  subprocess lazy-loads codegen, config validation, voluptuous and the
-  bundle machinery — ~28 MiB per flash (esphome/esphome#17684,
-  esphome/esphome#18093) — and whose log sessions defer the
+  subprocess defers codegen, config validation, voluptuous and the
+  bundle machinery for ~28 MiB per flash — esphome/esphome#17684 and
+  esphome/esphome#18093 — and whose log sessions defer the
   stacktrace-decoder platform import and so hand back ~10 MiB of host
   budget per open esp32 log stream, esphome/esphome#18048), and a
   single-slot thread upload lane. The lanes run in parallel

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -199,9 +199,12 @@ firmware/install {configuration} → QUEUED → RUNNING → output... → COMPLE
 
 - Three concurrent lanes — a compile lane (CPU, one job at a time), an
   upload lane (network, up to `MAX_CONCURRENT_UPLOADS` flashes at once:
-  4, or 7 when the installed esphome is 2026.8 or later, whose upload
-  subprocess lazy-loads codegen and config validation and so costs
-  roughly a third less RAM per flash, esphome/esphome#17684), and a
+  4, or 9 when the installed esphome is 2026.8 or later, whose upload
+  subprocess lazy-loads codegen, config validation, voluptuous and the
+  bundle machinery — ~28 MiB per flash (esphome/esphome#17684,
+  esphome/esphome#18093) — and whose log sessions defer the
+  stacktrace-decoder platform import and so hand back ~10 MiB of host
+  budget per open esp32 log stream, esphome/esphome#18048), and a
   single-slot thread upload lane. The lanes run in parallel
   so a slow network flash doesn't block the next device's compile
   (#3702), and OTAs don't serialize behind each other (esphome

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -199,7 +199,7 @@ firmware/install {configuration} → QUEUED → RUNNING → output... → COMPLE
 
 - Three concurrent lanes — a compile lane (CPU, one job at a time), an
   upload lane (network, up to `MAX_CONCURRENT_UPLOADS` flashes at once:
-  4, or 9 when the installed esphome is 2026.8 or later, whose upload
+  4, or 8 when the installed esphome is 2026.8 or later, whose upload
   subprocess lazy-loads codegen, config validation, voluptuous and the
   bundle machinery — ~28 MiB per flash (esphome/esphome#17684,
   esphome/esphome#18093) — and whose log sessions defer the

--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -32,19 +32,23 @@ _JOBS_KEY = "_firmware_jobs"
 # once. Each flash is a full esphome subprocess tree; the cap bounds
 # their combined memory on small hosts. esphome 2026.8.0 lazy-loads
 # codegen and config validation out of the upload subprocess
-# (esphome/esphome#17684), cutting per-flash RAM by roughly a third,
-# so that release line and later earn three more slots. The gate trusts
-# every 2026.8 build to carry that change; a dev/beta snapshot from
-# before it merged briefly overclaims. OpenThread
+# (esphome/esphome#17684), defers the voluptuous and bundle imports
+# off the upload fast path (esphome/esphome#18093, ~28 MiB per flash
+# measured), and lazily resolves the stacktrace decoder out of log
+# sessions (esphome/esphome#18048), handing back ~10 MiB of host
+# budget per open esp32 log stream, so that release line and later
+# earn five more slots. The gate trusts every 2026.8 build to carry
+# these changes; a dev/beta snapshot from
+# before they merged briefly overclaims. OpenThread
 # flashes don't count against the cap — they serialize on their own
 # single-slot lane — so peak concurrency is this plus one thread flash.
 _UPLOAD_SLOTS = 4
-_UPLOAD_SLOTS_LEAN_SUBPROCESS = 7
+_UPLOAD_SLOTS_LEAN_SUBPROCESS = 9
 _LEAN_UPLOAD_RELEASE = (2026, 8)
 
 
 def max_concurrent_uploads(esphome_version: str) -> int:
-    """Upload-lane slot count for *esphome_version*: 7 on 2026.8+, else 4."""
+    """Upload-lane slot count for *esphome_version*: 9 on 2026.8+, else 4."""
     if release_line_at_least(esphome_version, _LEAN_UPLOAD_RELEASE):
         return _UPLOAD_SLOTS_LEAN_SUBPROCESS
     return _UPLOAD_SLOTS

--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -37,18 +37,18 @@ _JOBS_KEY = "_firmware_jobs"
 # measured), and lazily resolves the stacktrace decoder out of log
 # sessions (esphome/esphome#18048), handing back ~10 MiB of host
 # budget per open esp32 log stream, so that release line and later
-# earn five more slots. The gate trusts every 2026.8 build to carry
+# earn four more slots. The gate trusts every 2026.8 build to carry
 # these changes; a dev/beta snapshot from
 # before they merged briefly overclaims. OpenThread
 # flashes don't count against the cap — they serialize on their own
 # single-slot lane — so peak concurrency is this plus one thread flash.
 _UPLOAD_SLOTS = 4
-_UPLOAD_SLOTS_LEAN_SUBPROCESS = 9
+_UPLOAD_SLOTS_LEAN_SUBPROCESS = 8
 _LEAN_UPLOAD_RELEASE = (2026, 8)
 
 
 def max_concurrent_uploads(esphome_version: str) -> int:
-    """Upload-lane slot count for *esphome_version*: 9 on 2026.8+, else 4."""
+    """Upload-lane slot count for *esphome_version*: 8 on 2026.8+, else 4."""
     if release_line_at_least(esphome_version, _LEAN_UPLOAD_RELEASE):
         return _UPLOAD_SLOTS_LEAN_SUBPROCESS
     return _UPLOAD_SLOTS

--- a/tests/controllers/firmware/test_parallel_uploads.py
+++ b/tests/controllers/firmware/test_parallel_uploads.py
@@ -163,8 +163,12 @@ async def test_cancel_one_of_three_concurrent_uploads_spares_siblings(
 
 # Each upload sleeps a per-device staggered duration (indexed by the
 # uN.yaml number), then exits 0 — a burst of woken deep-sleep devices
-# whose OTAs take different times.
-_STAGGER_DELAYS = [0.2, 0.05, 0.35, 0.1, 0.05, 0.15, 0.25, 0.1, 0.3, 0.05, 0.2, 0.15, 0.1, 0.25]
+# whose OTAs take different times. Cycled to twice the cap so the list
+# tracks slot-count bumps instead of silently under-seeding the burst.
+_STAGGER_PATTERN = (0.2, 0.05, 0.35, 0.1, 0.05, 0.15, 0.25, 0.1, 0.3)
+_STAGGER_DELAYS = [
+    _STAGGER_PATTERN[i % len(_STAGGER_PATTERN)] for i in range(MAX_CONCURRENT_UPLOADS * 2)
+]
 _STAGGERED_UPLOAD = (
     "import os, sys, time\n"
     "cfg = os.path.basename(next(a for a in sys.argv if a.endswith('.yaml')))\n"
@@ -189,7 +193,6 @@ async def test_upload_burst_drains_cap_at_a_time(
     wire_real_queue(controller)
     _wire_devices(controller)
     controller.state.esphome_cmd = [sys.executable, "-c", _STAGGERED_UPLOAD]
-    assert len(_STAGGER_DELAYS) >= MAX_CONCURRENT_UPLOADS * 2
     names = [f"u{i}.yaml" for i in range(1, MAX_CONCURRENT_UPLOADS * 2 + 1)]
     seed_yamls(tmp_path, *names)
 
@@ -295,7 +298,7 @@ def test_upload_lane_concurrency_defaults() -> None:
     ],
 )
 def test_max_concurrent_uploads_version_gate(version: str, expected: int) -> None:
-    """Esphome 2026.8+ runs the lazy-import upload and log subprocesses, earning 8 slots."""
+    """2026.8+ earns 8 upload slots; older and unknown versions keep 4."""
     assert max_concurrent_uploads(version) == expected
 
 

--- a/tests/controllers/firmware/test_parallel_uploads.py
+++ b/tests/controllers/firmware/test_parallel_uploads.py
@@ -288,14 +288,14 @@ def test_upload_lane_concurrency_defaults() -> None:
     ("version", "expected"),
     [
         pytest.param("2026.7.0", 4, id="pre_lean_release"),
-        pytest.param("2026.8.0", 9, id="lean_release"),
-        pytest.param("2026.8.0-dev", 9, id="lean_dev"),
-        pytest.param("2027.1.0", 9, id="later_release"),
+        pytest.param("2026.8.0", 8, id="lean_release"),
+        pytest.param("2026.8.0-dev", 8, id="lean_dev"),
+        pytest.param("2027.1.0", 8, id="later_release"),
         pytest.param("", 4, id="unknown_version"),
     ],
 )
 def test_max_concurrent_uploads_version_gate(version: str, expected: int) -> None:
-    """Esphome 2026.8+ runs the lazy-import upload and log subprocesses, earning 9 slots."""
+    """Esphome 2026.8+ runs the lazy-import upload and log subprocesses, earning 8 slots."""
     assert max_concurrent_uploads(version) == expected
 
 

--- a/tests/controllers/firmware/test_parallel_uploads.py
+++ b/tests/controllers/firmware/test_parallel_uploads.py
@@ -288,14 +288,14 @@ def test_upload_lane_concurrency_defaults() -> None:
     ("version", "expected"),
     [
         pytest.param("2026.7.0", 4, id="pre_lean_release"),
-        pytest.param("2026.8.0", 7, id="lean_release"),
-        pytest.param("2026.8.0-dev", 7, id="lean_dev"),
-        pytest.param("2027.1.0", 7, id="later_release"),
+        pytest.param("2026.8.0", 9, id="lean_release"),
+        pytest.param("2026.8.0-dev", 9, id="lean_dev"),
+        pytest.param("2027.1.0", 9, id="later_release"),
         pytest.param("", 4, id="unknown_version"),
     ],
 )
 def test_max_concurrent_uploads_version_gate(version: str, expected: int) -> None:
-    """Esphome 2026.8+ runs the lazy-import upload subprocess, earning 7 slots."""
+    """Esphome 2026.8+ runs the lazy-import upload and log subprocesses, earning 9 slots."""
     assert max_concurrent_uploads(version) == expected
 
 


### PR DESCRIPTION
# What does this implement/fix?

> [!WARNING]
> Must not merge until esphome/esphome#18093 and esphome/esphome#18048 do; the extra slots depend on their measured savings landing in 2026.8.

Raises the upload lane from 7 to 8 concurrent flashes when the installed esphome is 2026.8 or later; older versions keep 4. On top of the lazy codegen and validation from esphome/esphome#17684, that release line defers the voluptuous and bundle imports off the upload fast path (esphome/esphome#18093, measured ~28 MiB per flash) and resolves the stacktrace decoder lazily in log sessions (esphome/esphome#18048, ~10 MiB handed back per open esp32 log stream), so the same host budget covers one more slot. Follows up #2206.

**Related issue or feature (if applicable):**

- https://github.com/orgs/esphome/discussions/3781

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
