### PR TITLE
Centralize validated-config cache awareness and accept the 2026.8 JSON format

### DIFF
--- a/esphome_device_builder/controllers/devices/archive.py
+++ b/esphome_device_builder/controllers/devices/archive.py
@@ -13,12 +13,12 @@ from ...helpers.api import CommandError
 from ...helpers.async_ import run_in_executor
 from ...helpers.build_artifacts import (
     remove_device_files,
-    unlink_compiled_config,
     unlink_storage_sidecar,
     wipe_device_build_dir,
 )
 from ...helpers.device_yaml import parse_esphome_meta
 from ...helpers.storage_path import resolve_storage_path
+from ...helpers.validated_config_cache import unlink_validated_cache
 from ...models import ErrorCode
 from .helpers import _validate_archive_configuration, require_file_exists
 
@@ -75,7 +75,7 @@ async def archive_single(controller: DevicesController, configuration: str) -> N
         wipe_device_build_dir(configuration)
         shutil.move(str(config_path), str(target))
         unlink_storage_sidecar(configuration)
-        unlink_compiled_config(configuration)
+        unlink_validated_cache(configuration)
 
     # Hold the per-file write lock across the move + history commit so a
     # concurrent editor save to the same config can't interleave with the
@@ -166,7 +166,7 @@ async def delete_archived_single(controller: DevicesController, configuration: s
             # sidecars now; leave them alone.
             return False
         unlink_storage_sidecar(configuration)
-        unlink_compiled_config(configuration)
+        unlink_validated_cache(configuration)
         return True
 
     with _translate_archive_fs_errors(configuration, archived=True):

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -64,12 +64,13 @@ from ...constants import TOOLCHAIN_ESP_IDF
 from ...helpers.build_artifacts import _firmware_offset_for_platform, iter_flash_images
 from ...helpers.cross_os_path import cross_os_basename
 from ...helpers.peer_link_bundle import FIRMWARE_MAX_TOTAL_BYTES
-from ...helpers.storage_path import (
-    resolve_compiled_config_path,
-    resolve_idedata_path,
-    resolve_storage_path,
-)
+from ...helpers.storage_path import resolve_idedata_path, resolve_storage_path
 from ...helpers.tarball_read import parse_json_object, read_member
+from ...helpers.validated_config_cache import (
+    CACHE_MEMBER_NAMES,
+    find_validated_cache,
+    member_name_for,
+)
 from .artifact_platforms import build_files_for_platform
 
 if TYPE_CHECKING:
@@ -93,15 +94,16 @@ BUILD_INFO_MEMBER_NAME = "build_info.json"
 # Receiver-side esphome >= 2026.6.0 dumps the validated config alongside
 # the StorageJSON sidecar; reusing it on the offloader lets `esphome
 # upload` / `esphome logs` skip the full `read_config()` pipeline. Optional
-# member: skipped when the receiver predates the cache.
-VALIDATED_YAML_MEMBER_NAME = "validated.yaml"
+# member — skipped when the receiver predates the cache — shipped under
+# whichever member name matches the format the receiver's esphome wrote
+# (``validated.yaml`` before 2026.8, ``validated.json`` after).
 _METADATA_MEMBERS: frozenset[str] = frozenset(
     {
         STORAGE_MEMBER_NAME,
         IDEDATA_MEMBER_NAME,
         PLATFORMIO_INI_MEMBER_NAME,
         BUILD_INFO_MEMBER_NAME,
-        VALIDATED_YAML_MEMBER_NAME,
+        *CACHE_MEMBER_NAMES,
     }
 )
 
@@ -114,7 +116,7 @@ _METADATA_MEMBERS: frozenset[str] = frozenset(
 # sidecar by more than this many seconds -- generous enough to cover
 # `clean_build` + `clean_cmake_cache` running between the two writes,
 # tight enough to never accept a cache from a prior compile cycle.
-_VALIDATED_YAML_STALE_THRESHOLD_S = 60.0
+_VALIDATED_CACHE_STALE_THRESHOLD_S = 60.0
 
 
 # ---------------------------------------------------------------------------
@@ -216,7 +218,7 @@ def _collect_pack_members(  # noqa: C901
             raise FileNotFoundError(msg)
 
     build_info_path = build_path / BUILD_INFO_MEMBER_NAME
-    validated_yaml_path = resolve_compiled_config_path(configuration)
+    validated_cache_path = find_validated_cache(configuration)
     members: list[tuple[str, Path]] = [(STORAGE_MEMBER_NAME, storage_path)]
     if idedata_cache_path.is_file():
         members.append((IDEDATA_MEMBER_NAME, idedata_cache_path))
@@ -224,8 +226,10 @@ def _collect_pack_members(  # noqa: C901
         members.append((PLATFORMIO_INI_MEMBER_NAME, platformio_ini))
     if build_info_path.is_file():
         members.append((BUILD_INFO_MEMBER_NAME, build_info_path))
-    if _validated_yaml_is_fresh(validated_yaml_path, storage_path):
-        members.append((VALIDATED_YAML_MEMBER_NAME, validated_yaml_path))
+    if validated_cache_path is not None and _validated_cache_is_fresh(
+        validated_cache_path, storage_path
+    ):
+        members.append((member_name_for(validated_cache_path), validated_cache_path))
     # Dedupe by basename, not full path: the WS-unpack adapter
     # keys flash images by basename, so a build emitting both
     # ``.pioenvs/<name>/firmware.factory.bin`` and
@@ -268,8 +272,8 @@ def _collect_pack_members(  # noqa: C901
     return members
 
 
-def _validated_yaml_is_fresh(validated_yaml: Path, storage_json: Path) -> bool:
-    """Test that *validated_yaml* was written by the same compile as *storage_json*.
+def _validated_cache_is_fresh(validated_cache: Path, storage_json: Path) -> bool:
+    """Test that *validated_cache* was written by the same compile as *storage_json*.
 
     esphome >= 2026.6 writes both inside one ``update_storage_json``
     call. If the receiver later downgrades to an esphome that doesn't
@@ -279,10 +283,10 @@ def _validated_yaml_is_fresh(validated_yaml: Path, storage_json: Path) -> bool:
     """
     try:
         storage_mtime = storage_json.stat().st_mtime
-        validated_mtime = validated_yaml.stat().st_mtime
+        validated_mtime = validated_cache.stat().st_mtime
     except OSError:
         return False
-    return storage_mtime - validated_mtime <= _VALIDATED_YAML_STALE_THRESHOLD_S
+    return storage_mtime - validated_mtime <= _VALIDATED_CACHE_STALE_THRESHOLD_S
 
 
 def _download_type_files(storage: StorageJSON, storage_path: Path) -> list[str]:

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -96,9 +96,7 @@ BUILD_INFO_MEMBER_NAME = "build_info.json"
 # upload` / `esphome logs` skip the full `read_config()` pipeline. Optional
 # member — skipped when the receiver predates the cache — shipped under
 # whichever member name matches the format the receiver's esphome wrote
-# (``validated.yaml`` before 2026.8, ``validated.json`` after). The
-# cache member names and their path binding live in
-# ``helpers.validated_config_cache``; the rest of the wire set is here.
+# (``validated.yaml`` before 2026.8, ``validated.json`` after).
 _METADATA_MEMBERS: frozenset[str] = frozenset(
     {
         STORAGE_MEMBER_NAME,

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -96,7 +96,9 @@ BUILD_INFO_MEMBER_NAME = "build_info.json"
 # upload` / `esphome logs` skip the full `read_config()` pipeline. Optional
 # member — skipped when the receiver predates the cache — shipped under
 # whichever member name matches the format the receiver's esphome wrote
-# (``validated.yaml`` before 2026.8, ``validated.json`` after).
+# (``validated.yaml`` before 2026.8, ``validated.json`` after). The
+# cache member names and their path binding live in
+# ``helpers.validated_config_cache``; the rest of the wire set is here.
 _METADATA_MEMBERS: frozenset[str] = frozenset(
     {
         STORAGE_MEMBER_NAME,

--- a/esphome_device_builder/helpers/build_artifacts.py
+++ b/esphome_device_builder/helpers/build_artifacts.py
@@ -58,11 +58,8 @@ from esphome.helpers import rmtree
 from esphome.storage_json import StorageJSON
 
 from .json import loads as json_loads
-from .storage_path import (
-    resolve_compiled_config_path,
-    resolve_idedata_path,
-    resolve_storage_path,
-)
+from .storage_path import resolve_idedata_path, resolve_storage_path
+from .validated_config_cache import unlink_validated_cache
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -293,18 +290,6 @@ def wipe_device_build_dir(configuration: str) -> None:
         _LOGGER.debug("wipe_device_build_dir: rmtree(%s) failed: %s", storage.build_path, exc)
 
 
-def unlink_compiled_config(configuration: str) -> None:
-    """Remove the validated-config cache (``<file>.validated.yaml``); no-op if absent."""
-    compiled_path = resolve_compiled_config_path(configuration)
-    try:
-        compiled_path.unlink(missing_ok=True)
-    except OSError as exc:
-        # Same best-effort level + detail as the idedata wipe above:
-        # both are regenerable caches, debug-logged with the exception
-        # so a permissions vs FS failure is distinguishable.
-        _LOGGER.debug("unlink_compiled_config: unlink(%s) failed: %s", compiled_path, exc)
-
-
 def unlink_storage_sidecar(configuration: str) -> None:
     """Remove the StorageJSON sidecar file (no-op if absent).
 
@@ -328,7 +313,7 @@ def remove_device_files(yaml_path: Path, configuration: str) -> None:
     """
     wipe_device_build_dir(configuration)
     unlink_storage_sidecar(configuration)
-    unlink_compiled_config(configuration)
+    unlink_validated_cache(configuration)
     yaml_path.unlink(missing_ok=True)
 
 

--- a/esphome_device_builder/helpers/device_yaml/_loading.py
+++ b/esphome_device_builder/helpers/device_yaml/_loading.py
@@ -19,7 +19,8 @@ from ...models import Device, DeviceRuntimeState
 from ...models.boards import normalize_platform
 from ..atomic_io import read_text_with_stat
 from ..mac_addresses import derive_interface_macs
-from ..storage_path import resolve_compiled_config_path, resolve_storage_path
+from ..storage_path import resolve_storage_path
+from ..validated_config_cache import find_validated_cache, parse_validated_cache
 from ._mqtt_block import build_mqtt_extract
 from ._parsing import (
     _CONF_ALLOW_PARTITION_ACCESS,
@@ -528,29 +529,21 @@ def compiled_config_has_ota_partition_access(configuration: str) -> bool:
     """
     Report whether the last compile's validated-config cache enables partition access.
 
-    ``<data_dir>/storage/<basename>.validated.yaml`` is written by every
-    esphome compile with substitutions, packages (including remote ones
-    the in-process loader can't fetch), and secrets fully resolved. The
-    raw-text scan short-circuits the full parse for the common no-flag
-    case — the cache is the whole resolved config, materially larger than
-    the source YAML, and this runs per device reload. ``clear_secrets=False``
-    mirrors ``esphome.compiled_config``: the read must not wipe the
-    process-wide secrets registry mid-scan.
+    The cache is written by every esphome compile with substitutions,
+    packages (including remote ones the in-process loader can't fetch),
+    and secrets fully resolved. The raw-text scan short-circuits the full
+    parse for the common no-flag case — the cache is the whole resolved
+    config, materially larger than the source YAML, and this runs per
+    device reload.
     """
-    path = resolve_compiled_config_path(configuration)
+    path = find_validated_cache(configuration)
+    if path is None:
+        return False
     try:
         text = path.read_text(encoding="utf-8")
     except OSError:
         return False
     if _CONF_ALLOW_PARTITION_ACCESS not in text:
         return False
-    try:
-        config = yaml_util.load_yaml(path, clear_secrets=False)
-    except EsphomeError as err:
-        # Reached only after the raw-text scan matched, so a cache esphome
-        # itself wrote won't parse — log it or the vanished dialog option is
-        # undiagnosable. Class only: yaml error marks can quote lines from
-        # the secrets-bearing cache.
-        _LOGGER.debug("Validated-config cache %s did not parse (%s)", path, type(err).__name__)
-        return False
-    return isinstance(config, dict) and extract_ota_partition_access(config)
+    config = parse_validated_cache(path)
+    return config is not None and extract_ota_partition_access(config)

--- a/esphome_device_builder/helpers/device_yaml/_loading.py
+++ b/esphome_device_builder/helpers/device_yaml/_loading.py
@@ -545,5 +545,5 @@ def compiled_config_has_ota_partition_access(configuration: str) -> bool:
         return False
     if _CONF_ALLOW_PARTITION_ACCESS not in text:
         return False
-    config = parse_validated_cache(path)
+    config = parse_validated_cache(path, text)
     return config is not None and extract_ota_partition_access(config)

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -7,9 +7,11 @@ filesystem looks as if a local compile produced the build:
 ``<data_dir>/storage/<basename>.json`` is the rewritten StorageJSON
 sidecar, ``<data_dir>/idedata/<name>.json`` is the rewritten idedata
 cache (touched so ``_load_idedata``'s mtime gate hits), and -- when
-the receiver-side esphome shipped one -- ``<basename>.validated.yaml``
-sits next to the JSON sidecar so the next local ``esphome upload`` /
-``esphome logs`` skips ``read_config()`` via esphome's fast path.
+the receiver-side esphome shipped one -- the validated-config cache
+(``<basename>.validated.json``, or ``.validated.yaml`` from pre-2026.8
+receivers) sits next to the JSON sidecar so the next local
+``esphome upload`` / ``esphome logs`` skips ``read_config()`` via
+esphome's fast path.
 """
 
 from __future__ import annotations
@@ -35,18 +37,21 @@ from ..controllers.remote_build.artifacts_tarball import (
     IDEDATA_MEMBER_NAME,
     PLATFORMIO_INI_MEMBER_NAME,
     STORAGE_MEMBER_NAME,
-    VALIDATED_YAML_MEMBER_NAME,
 )
 from .build_artifacts import iter_flash_images
 from .cross_os_path import receiver_pure_path_cls
 from .json import dumps_indent
 from .storage_path import (
-    resolve_compiled_config_path,
     resolve_data_dir,
     resolve_idedata_path,
     resolve_storage_path,
 )
 from .tarball_read import check_member_size, parse_json_object, read_member
+from .validated_config_cache import (
+    CACHE_MEMBER_NAMES,
+    path_for_member,
+    sibling_cache_path,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -72,8 +77,9 @@ class _ExtractedTarball(NamedTuple):
     receiver_build_path: PurePath
     build_path: Path
     # Optional: present when receiver-side esphome wrote a
-    # validated-config cache (>= 2026.6.0).
-    validated_yaml_bytes: bytes | None
+    # validated-config cache (>= 2026.6.0); ``(member_name, payload)``
+    # so staging lands the format the receiver shipped.
+    validated_cache: tuple[str, bytes] | None
 
 
 def materialise_remote_artifacts(tarball: bytes, configuration: str) -> Path:
@@ -101,10 +107,12 @@ def materialise_remote_artifacts(tarball: bytes, configuration: str) -> Path:
             platformio_ini=extracted.build_path / PLATFORMIO_INI_MEMBER_NAME,
             cached_idedata=cached_idedata_path,
         )
-    if extracted.validated_yaml_bytes is not None:
-        _stage_offloader_validated_yaml(
+    if extracted.validated_cache is not None:
+        member_name, payload = extracted.validated_cache
+        _stage_offloader_validated_cache(
             configuration=configuration,
-            payload=extracted.validated_yaml_bytes,
+            member_name=member_name,
+            payload=payload,
         )
     return extracted.build_path
 
@@ -128,9 +136,14 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
             idedata_bytes, total_bytes = _read_member_optional(
                 tar, IDEDATA_MEMBER_NAME, total_so_far=total_bytes
             )
-            validated_yaml_bytes, total_bytes = _read_member_optional(
-                tar, VALIDATED_YAML_MEMBER_NAME, total_so_far=total_bytes
-            )
+            validated_cache: tuple[str, bytes] | None = None
+            for cache_member in CACHE_MEMBER_NAMES:
+                cache_bytes, total_bytes = _read_member_optional(
+                    tar, cache_member, total_so_far=total_bytes
+                )
+                if cache_bytes is not None:
+                    validated_cache = (cache_member, cache_bytes)
+                    break
             receiver_storage = _parse_storage_json(storage_bytes)
             device_name = _device_name_from_storage(receiver_storage)
             receiver_build_path = _receiver_build_path_from_storage(receiver_storage)
@@ -169,7 +182,7 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
                     exclude={
                         STORAGE_MEMBER_NAME,
                         IDEDATA_MEMBER_NAME,
-                        VALIDATED_YAML_MEMBER_NAME,
+                        *CACHE_MEMBER_NAMES,
                     },
                     initial_total_bytes=total_bytes,
                 )
@@ -199,7 +212,7 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
         idedata_bytes=idedata_bytes,
         receiver_build_path=receiver_build_path,
         build_path=build_path,
-        validated_yaml_bytes=validated_yaml_bytes,
+        validated_cache=validated_cache,
     )
 
 
@@ -379,9 +392,10 @@ def _remap_idedata_toolchain_path(data: dict[str, Any]) -> None:
         data["cc_path"] = remapped
 
 
-def _stage_offloader_validated_yaml(
+def _stage_offloader_validated_cache(
     *,
     configuration: str,
+    member_name: str,
     payload: bytes,
 ) -> None:
     """Stage the receiver's validated-config cache at the offloader's path.
@@ -389,10 +403,12 @@ def _stage_offloader_validated_yaml(
     Written 0600 because the cache resolves !secret references inline.
     mtime is touched to "now" so esphome's fast path (which gates on
     cache mtime >= source YAML mtime) takes the cache instead of
-    re-running read_config.
+    re-running read_config. The other format's file is dropped so a
+    stale sibling from a prior esphome version can't shadow this one.
     """
-    path = resolve_compiled_config_path(configuration)
+    path = path_for_member(member_name, configuration)
     path.parent.mkdir(parents=True, exist_ok=True)
+    sibling_cache_path(path, configuration).unlink(missing_ok=True)
     # Open with 0600 at creation time so the file is never momentarily
     # readable at the process umask between write_bytes() and chmod().
     # O_CREAT honours an existing inode's mode bits, so tighten with

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -20,7 +20,6 @@ import io
 import logging
 import os
 import re
-import sys
 import tarfile
 import time
 from collections.abc import Iterator
@@ -28,7 +27,7 @@ from contextlib import contextmanager
 from pathlib import Path, PurePath
 from typing import Any, NamedTuple
 
-from esphome.helpers import rmtree
+from esphome.helpers import rmtree, write_file
 from esphome.storage_json import StorageJSON
 from esphome.writer import storage_should_clean
 
@@ -50,7 +49,7 @@ from .tarball_read import check_member_size, parse_json_object, read_member
 from .validated_config_cache import (
     CACHE_MEMBER_NAMES,
     path_for_member,
-    sibling_cache_path,
+    unlink_validated_cache,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -400,31 +399,17 @@ def _stage_offloader_validated_cache(
 ) -> None:
     """Stage the receiver's validated-config cache at the offloader's path.
 
-    Written 0600 because the cache resolves !secret references inline.
-    mtime is touched to "now" so esphome's fast path (which gates on
-    cache mtime >= source YAML mtime) takes the cache instead of
-    re-running read_config. The other format's file is dropped so a
-    stale sibling from a prior esphome version can't shadow this one.
+    Both formats are dropped first so a stale sibling from a prior
+    esphome version can't shadow this one. ``write_file(private=True)``
+    stages in the destination dir and moves into place, so the
+    secret-bearing cache is never observable half-written or at a
+    permissive mode; the fresh mtime satisfies esphome's fast-path gate
+    (cache mtime >= source YAML mtime).
     """
     path = path_for_member(member_name, configuration)
     path.parent.mkdir(parents=True, exist_ok=True)
-    sibling_cache_path(path, configuration).unlink(missing_ok=True)
-    # Open with 0600 at creation time so the file is never momentarily
-    # readable at the process umask between write_bytes() and chmod().
-    # O_CREAT honours an existing inode's mode bits, so tighten with
-    # an explicit chmod afterwards too (no-op on Windows). O_BINARY
-    # only exists on Windows where it disables the CRLF translation
-    # that would otherwise corrupt the YAML bytes.
-    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_BINARY", 0)
-    fd = os.open(path, flags, 0o600)
-    try:
-        os.write(fd, payload)
-    finally:
-        os.close(fd)
-    if sys.platform != "win32":
-        path.chmod(0o600)
-    now = time.time()
-    os.utime(path, (now, now))
+    unlink_validated_cache(configuration)
+    write_file(path, payload, private=True)
 
 
 @contextmanager

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -27,6 +27,7 @@ from contextlib import contextmanager
 from pathlib import Path, PurePath
 from typing import Any, NamedTuple
 
+from esphome.core import EsphomeError
 from esphome.helpers import rmtree, write_file
 from esphome.storage_json import StorageJSON
 from esphome.writer import storage_should_clean
@@ -397,19 +398,22 @@ def _stage_offloader_validated_cache(
     member_name: str,
     payload: bytes,
 ) -> None:
-    """Stage the receiver's validated-config cache at the offloader's path.
+    """
+    Stage the receiver's validated-config cache, atomically and 0600.
 
-    Both formats are dropped first so a stale sibling from a prior
-    esphome version can't shadow this one. ``write_file(private=True)``
-    stages in the destination dir and moves into place, so the
-    secret-bearing cache is never observable half-written or at a
-    permissive mode; the fresh mtime satisfies esphome's fast-path gate
-    (cache mtime >= source YAML mtime).
+    Best-effort drops both formats first; raises
+    :class:`MaterialiseError` when the write fails.
     """
     path = path_for_member(member_name, configuration)
     path.parent.mkdir(parents=True, exist_ok=True)
     unlink_validated_cache(configuration)
-    write_file(path, payload, private=True)
+    try:
+        write_file(path, payload, private=True)
+    except EsphomeError as err:
+        # write_file wraps OSError; translate so the runner's IO seam
+        # keeps its "materialise IO error" framing.
+        msg = f"could not stage validated-config cache: {err}"
+        raise MaterialiseError(msg) from err
 
 
 @contextmanager

--- a/esphome_device_builder/helpers/storage_path.py
+++ b/esphome_device_builder/helpers/storage_path.py
@@ -127,20 +127,6 @@ def resolve_storage_path(configuration: str) -> Path:
     return resolve_data_dir(configuration) / "storage" / f"{Path(configuration).name}.json"
 
 
-def resolve_compiled_config_path(configuration: str) -> Path:
-    """Return the validated-config cache YAML path for *configuration*.
-
-    Mirror of :func:`esphome.compiled_config.compiled_config_path`:
-    ``<data_dir>/storage/<basename>.validated.yaml``. Routed through
-    :func:`resolve_data_dir` for the same reason as
-    :func:`resolve_storage_path` -- receiver-side remote-build configs
-    land under the per-build subtree.
-    """
-    return (
-        resolve_data_dir(configuration) / "storage" / f"{Path(configuration).name}.validated.yaml"
-    )
-
-
 def resolve_idedata_path(configuration: str, *, name: str) -> Path:
     """Return the cached ``idedata/<name>.json`` path for *configuration*.
 

--- a/esphome_device_builder/helpers/validated_config_cache.py
+++ b/esphome_device_builder/helpers/validated_config_cache.py
@@ -2,11 +2,11 @@
 Validated-config cache (esphome's ``compiled_config``) awareness.
 
 esphome < 2026.8 writes ``<basename>.validated.yaml`` (a raw YAML dump);
-2026.8+ writes ``<basename>.validated.json`` (a ``{"v", "esphome",
-"config"}`` envelope) and removes the legacy file on save. Single source
-of truth for the dashboard side: path resolution, newest-cache
-discovery, format-detected parsing, removal, and the remote-build
-tarball member naming.
+2026.8+ writes ``<basename>.validated.json`` wrapped in a
+``{"v", "esphome", "config"}`` envelope and removes the legacy file on
+save. Single source of truth for the dashboard side: path resolution,
+newest-cache discovery, format-detected parsing, removal, and the
+remote-build tarball member naming.
 """
 
 from __future__ import annotations
@@ -69,11 +69,11 @@ def find_validated_cache(configuration: str) -> Path | None:
     return freshest
 
 
-def parse_validated_cache(path: Path, text: str | None = None) -> dict[Any, Any] | None:
+def parse_validated_cache(path: Path, text: str | bytes | None = None) -> dict[Any, Any] | None:
     """
     Parse the cache at *path* (format from suffix) into a plain config dict.
 
-    *text* skips a re-read when the caller already has the JSON bytes.
+    *text* skips a re-read when the caller already holds the JSON content.
     JSON caches keep their lambda sentinels as dicts (no ``Lambda``
     revival — the dashboard only reads flags); the YAML parse keeps
     ``clear_secrets=False`` so the read never wipes the process-wide

--- a/esphome_device_builder/helpers/validated_config_cache.py
+++ b/esphome_device_builder/helpers/validated_config_cache.py
@@ -11,7 +11,6 @@ tarball member naming.
 
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
 from typing import Any
@@ -19,19 +18,25 @@ from typing import Any
 from esphome import yaml_util
 from esphome.core import EsphomeError
 
+from .json import loads as json_loads
 from .storage_path import resolve_data_dir
 
 _LOGGER = logging.getLogger(__name__)
 
-_JSON_SUFFIX = ".validated.json"
-_LEGACY_YAML_SUFFIX = ".validated.yaml"
-_ENVELOPE_VERSION = 1
-
 # Remote-build tarball member basenames; the receiver ships whichever
-# file its esphome wrote.
+# file its esphome wrote. Order is the read preference should a tarball
+# ever carry both.
 JSON_CACHE_MEMBER_NAME = "validated.json"
 LEGACY_YAML_CACHE_MEMBER_NAME = "validated.yaml"
 CACHE_MEMBER_NAMES = (JSON_CACHE_MEMBER_NAME, LEGACY_YAML_CACHE_MEMBER_NAME)
+
+_JSON_SUFFIX = f".{JSON_CACHE_MEMBER_NAME}"
+_LEGACY_YAML_SUFFIX = f".{LEGACY_YAML_CACHE_MEMBER_NAME}"
+# Mirrors esphome.compiled_config._CACHE_VERSION; bump together. The
+# envelope's "esphome" version stamp is deliberately ignored here: the
+# dashboard only reads flags, so a cache from a different esphome
+# version is still a valid read (esphome itself re-validates).
+_ENVELOPE_VERSION = 1
 
 
 def json_cache_path(configuration: str) -> Path:
@@ -53,7 +58,7 @@ def find_validated_cache(configuration: str) -> Path | None:
     """
     freshest: Path | None = None
     freshest_mtime = float("-inf")
-    for path in (json_cache_path(configuration), legacy_yaml_cache_path(configuration)):
+    for path in _cache_paths(configuration):
         try:
             mtime = path.stat().st_mtime
         except OSError:
@@ -64,10 +69,11 @@ def find_validated_cache(configuration: str) -> Path | None:
     return freshest
 
 
-def parse_validated_cache(path: Path) -> dict[Any, Any] | None:
+def parse_validated_cache(path: Path, text: str | None = None) -> dict[Any, Any] | None:
     """
     Parse the cache at *path* (format from suffix) into a plain config dict.
 
+    *text* skips a re-read when the caller already has the JSON bytes.
     JSON caches keep their lambda sentinels as dicts (no ``Lambda``
     revival — the dashboard only reads flags); the YAML parse keeps
     ``clear_secrets=False`` so the read never wipes the process-wide
@@ -76,11 +82,12 @@ def parse_validated_cache(path: Path) -> dict[Any, Any] | None:
     """
     if path.name.endswith(_JSON_SUFFIX):
         try:
-            envelope = json.loads(path.read_text(encoding="utf-8"))
+            envelope = json_loads(text if text is not None else path.read_bytes())
         except (OSError, ValueError) as err:
             _log_unparseable(path, err)
             return None
         if not isinstance(envelope, dict) or envelope.get("v") != _ENVELOPE_VERSION:
+            _LOGGER.debug("Validated-config cache %s has a foreign envelope", path)
             return None
         config = envelope.get("config")
         return config if isinstance(config, dict) else None
@@ -94,7 +101,7 @@ def parse_validated_cache(path: Path) -> dict[Any, Any] | None:
 
 def unlink_validated_cache(configuration: str) -> None:
     """Remove both cache formats for *configuration*; no-op if absent."""
-    for path in (json_cache_path(configuration), legacy_yaml_cache_path(configuration)):
+    for path in _cache_paths(configuration):
         try:
             path.unlink(missing_ok=True)
         except OSError as exc:
@@ -105,28 +112,24 @@ def unlink_validated_cache(configuration: str) -> None:
 
 def member_name_for(cache_path: Path) -> str:
     """Return the tarball member basename for *cache_path*."""
-    return (
-        JSON_CACHE_MEMBER_NAME
-        if cache_path.name.endswith(_JSON_SUFFIX)
-        else (LEGACY_YAML_CACHE_MEMBER_NAME)
-    )
+    if cache_path.name.endswith(_JSON_SUFFIX):
+        return JSON_CACHE_MEMBER_NAME
+    return LEGACY_YAML_CACHE_MEMBER_NAME
 
 
 def path_for_member(member_name: str, configuration: str) -> Path:
     """Return the local cache path a tarball *member_name* stages to."""
-    if member_name == JSON_CACHE_MEMBER_NAME:
-        return json_cache_path(configuration)
-    if member_name == LEGACY_YAML_CACHE_MEMBER_NAME:
-        return legacy_yaml_cache_path(configuration)
-    msg = f"unknown validated-cache member {member_name!r}"
-    raise ValueError(msg)
+    if member_name not in CACHE_MEMBER_NAMES:
+        msg = f"unknown validated-cache member {member_name!r}"
+        raise ValueError(msg)
+    return _cache_path(configuration, f".{member_name}")
 
 
-def sibling_cache_path(cache_path: Path, configuration: str) -> Path:
-    """Return the other format's path so a stager can drop the stale sibling."""
-    if cache_path.name.endswith(_JSON_SUFFIX):
-        return legacy_yaml_cache_path(configuration)
-    return json_cache_path(configuration)
+def _cache_paths(configuration: str) -> tuple[Path, Path]:
+    """Both formats' paths off one data-dir resolve; JSON first."""
+    storage_dir = resolve_data_dir(configuration) / "storage"
+    name = Path(configuration).name
+    return (storage_dir / f"{name}{_JSON_SUFFIX}", storage_dir / f"{name}{_LEGACY_YAML_SUFFIX}")
 
 
 def _cache_path(configuration: str, suffix: str) -> Path:

--- a/esphome_device_builder/helpers/validated_config_cache.py
+++ b/esphome_device_builder/helpers/validated_config_cache.py
@@ -1,0 +1,139 @@
+"""
+Validated-config cache (esphome's ``compiled_config``) awareness.
+
+esphome < 2026.8 writes ``<basename>.validated.yaml`` (a raw YAML dump);
+2026.8+ writes ``<basename>.validated.json`` (a ``{"v", "esphome",
+"config"}`` envelope) and removes the legacy file on save. Single source
+of truth for the dashboard side: path resolution, newest-cache
+discovery, format-detected parsing, removal, and the remote-build
+tarball member naming.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from esphome import yaml_util
+from esphome.core import EsphomeError
+
+from .storage_path import resolve_data_dir
+
+_LOGGER = logging.getLogger(__name__)
+
+_JSON_SUFFIX = ".validated.json"
+_LEGACY_YAML_SUFFIX = ".validated.yaml"
+_ENVELOPE_VERSION = 1
+
+# Remote-build tarball member basenames; the receiver ships whichever
+# file its esphome wrote.
+JSON_CACHE_MEMBER_NAME = "validated.json"
+LEGACY_YAML_CACHE_MEMBER_NAME = "validated.yaml"
+CACHE_MEMBER_NAMES = (JSON_CACHE_MEMBER_NAME, LEGACY_YAML_CACHE_MEMBER_NAME)
+
+
+def json_cache_path(configuration: str) -> Path:
+    """Return the 2026.8+ JSON cache path for *configuration*."""
+    return _cache_path(configuration, _JSON_SUFFIX)
+
+
+def legacy_yaml_cache_path(configuration: str) -> Path:
+    """Return the pre-2026.8 YAML cache path for *configuration*."""
+    return _cache_path(configuration, _LEGACY_YAML_SUFFIX)
+
+
+def find_validated_cache(configuration: str) -> Path | None:
+    """
+    Return the freshest on-disk cache for *configuration*, or ``None``.
+
+    Newest mtime wins so an esphome up/downgrade that leaves the other
+    format's file lingering never shadows the file current compiles write.
+    """
+    freshest: Path | None = None
+    freshest_mtime = float("-inf")
+    for path in (json_cache_path(configuration), legacy_yaml_cache_path(configuration)):
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            continue
+        if mtime > freshest_mtime:
+            freshest = path
+            freshest_mtime = mtime
+    return freshest
+
+
+def parse_validated_cache(path: Path) -> dict[Any, Any] | None:
+    """
+    Parse the cache at *path* (format from suffix) into a plain config dict.
+
+    JSON caches keep their lambda sentinels as dicts (no ``Lambda``
+    revival — the dashboard only reads flags); the YAML parse keeps
+    ``clear_secrets=False`` so the read never wipes the process-wide
+    secrets registry mid-scan. Unparseable or foreign-shaped caches
+    return ``None``.
+    """
+    if path.name.endswith(_JSON_SUFFIX):
+        try:
+            envelope = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as err:
+            _log_unparseable(path, err)
+            return None
+        if not isinstance(envelope, dict) or envelope.get("v") != _ENVELOPE_VERSION:
+            return None
+        config = envelope.get("config")
+        return config if isinstance(config, dict) else None
+    try:
+        config = yaml_util.load_yaml(path, clear_secrets=False)
+    except EsphomeError as err:
+        _log_unparseable(path, err)
+        return None
+    return config if isinstance(config, dict) else None
+
+
+def unlink_validated_cache(configuration: str) -> None:
+    """Remove both cache formats for *configuration*; no-op if absent."""
+    for path in (json_cache_path(configuration), legacy_yaml_cache_path(configuration)):
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            # Best-effort: a regenerable cache, debug-logged so a
+            # permissions vs FS failure is distinguishable.
+            _LOGGER.debug("unlink_validated_cache: unlink(%s) failed: %s", path, exc)
+
+
+def member_name_for(cache_path: Path) -> str:
+    """Return the tarball member basename for *cache_path*."""
+    return (
+        JSON_CACHE_MEMBER_NAME
+        if cache_path.name.endswith(_JSON_SUFFIX)
+        else (LEGACY_YAML_CACHE_MEMBER_NAME)
+    )
+
+
+def path_for_member(member_name: str, configuration: str) -> Path:
+    """Return the local cache path a tarball *member_name* stages to."""
+    if member_name == JSON_CACHE_MEMBER_NAME:
+        return json_cache_path(configuration)
+    if member_name == LEGACY_YAML_CACHE_MEMBER_NAME:
+        return legacy_yaml_cache_path(configuration)
+    msg = f"unknown validated-cache member {member_name!r}"
+    raise ValueError(msg)
+
+
+def sibling_cache_path(cache_path: Path, configuration: str) -> Path:
+    """Return the other format's path so a stager can drop the stale sibling."""
+    if cache_path.name.endswith(_JSON_SUFFIX):
+        return legacy_yaml_cache_path(configuration)
+    return json_cache_path(configuration)
+
+
+def _cache_path(configuration: str, suffix: str) -> Path:
+    """Mirror ``esphome.compiled_config``'s layout under the resolved data dir."""
+    return resolve_data_dir(configuration) / "storage" / f"{Path(configuration).name}{suffix}"
+
+
+def _log_unparseable(path: Path, err: Exception) -> None:
+    # Class only: error detail can quote lines from the secrets-bearing cache.
+    _LOGGER.debug("Validated-config cache %s did not parse (%s)", path, type(err).__name__)

--- a/esphome_device_builder/helpers/validated_config_cache.py
+++ b/esphome_device_builder/helpers/validated_config_cache.py
@@ -3,10 +3,7 @@ Validated-config cache (esphome's ``compiled_config``) awareness.
 
 esphome < 2026.8 writes ``<basename>.validated.yaml`` (a raw YAML dump);
 2026.8+ writes ``<basename>.validated.json`` wrapped in a
-``{"v", "esphome", "config"}`` envelope and removes the legacy file on
-save. Single source of truth for the dashboard side: path resolution,
-newest-cache discovery, format-detected parsing, removal, and the
-remote-build tarball member naming.
+``{"v", "esphome", "config"}`` envelope.
 """
 
 from __future__ import annotations
@@ -50,18 +47,16 @@ def legacy_yaml_cache_path(configuration: str) -> Path:
 
 
 def find_validated_cache(configuration: str) -> Path | None:
-    """
-    Return the freshest on-disk cache for *configuration*, or ``None``.
-
-    Newest mtime wins so an esphome up/downgrade that leaves the other
-    format's file lingering never shadows the file current compiles write.
-    """
+    """Return the freshest on-disk cache for *configuration*, or ``None``."""
     freshest: Path | None = None
     freshest_mtime = float("-inf")
     for path in _cache_paths(configuration):
         try:
             mtime = path.stat().st_mtime
-        except OSError:
+        except FileNotFoundError:
+            continue
+        except OSError as err:
+            _LOGGER.debug("Validated-config cache %s unreadable (%s)", path, type(err).__name__)
             continue
         if mtime > freshest_mtime:
             freshest = path

--- a/tests/controllers/devices/test_archive.py
+++ b/tests/controllers/devices/test_archive.py
@@ -148,11 +148,14 @@ async def test_archive_wipes_build_caches(
     idedata.write_text("{}", encoding="utf-8")
     validated = tmp_path / ".esphome" / "storage" / "kitchen.yaml.validated.yaml"
     validated.write_text("esphome: {}\n", encoding="utf-8")
+    validated_json = tmp_path / ".esphome" / "storage" / "kitchen.yaml.validated.json"
+    validated_json.write_text('{"v": 1, "config": {"esphome": {}}}', encoding="utf-8")
 
     await controller._archive_single("kitchen.yaml")
 
     assert not idedata.exists()
     assert not validated.exists()
+    assert not validated_json.exists()
 
 
 async def test_archive_clears_volatile_metadata_keeps_identity(
@@ -643,6 +646,8 @@ async def test_delete_archived_removes_yaml_and_sidecars(
     storage_path.write_text("{}", encoding="utf-8")
     validated_path = storage_dir / "kitchen.yaml.validated.yaml"
     validated_path.write_text("esphome: {}\n", encoding="utf-8")
+    validated_json_path = storage_dir / "kitchen.yaml.validated.json"
+    validated_json_path.write_text('{"v": 1, "config": {"esphome": {}}}', encoding="utf-8")
 
     controller = make_controller(tmp_path)
     await controller._delete_archived_single("kitchen.yaml")
@@ -650,6 +655,7 @@ async def test_delete_archived_removes_yaml_and_sidecars(
     assert not (archive_dir / "kitchen.yaml").exists()
     assert not storage_path.exists()
     assert not validated_path.exists()
+    assert not validated_json_path.exists()
 
 
 async def test_delete_archived_preserves_active_sidecars(

--- a/tests/controllers/devices/test_delete.py
+++ b/tests/controllers/devices/test_delete.py
@@ -25,17 +25,22 @@ from tests._storage_fixtures import write_storage_json
 from .conftest import MakeControllerFactory
 
 
-def _cache_paths(config_dir: Path, configuration: str) -> tuple[Path, Path]:
-    """Return ``(idedata_cache, validated_config_cache)`` for *configuration*.
+def _cache_paths(config_dir: Path, configuration: str) -> tuple[Path, Path, Path]:
+    """Return ``(idedata_cache, validated_yaml, validated_json)`` for *configuration*.
 
     The idedata cache is keyed on the device ``name`` (the YAML
-    stem here); the validated-config cache is keyed on the YAML
-    filename — matching esphome's own layout under ``.esphome``.
+    stem here); the validated-config caches are keyed on the YAML
+    filename — matching esphome's own layout under ``.esphome``
+    (YAML before 2026.8, JSON after).
     """
     stem = Path(configuration).stem
     idedata = config_dir / ".esphome" / "idedata" / f"{stem}.json"
-    validated = config_dir / ".esphome" / "storage" / f"{configuration}.validated.yaml"
-    return idedata, validated
+    storage_dir = config_dir / ".esphome" / "storage"
+    return (
+        idedata,
+        storage_dir / f"{configuration}.validated.yaml",
+        storage_dir / f"{configuration}.validated.json",
+    )
 
 
 def _seed_device(
@@ -60,11 +65,12 @@ def _seed_device(
         (build_path / "src").mkdir()
         (build_path / "src" / "main.cpp").write_text("// fake\n", encoding="utf-8")
 
-    idedata, validated = _cache_paths(config_dir, configuration)
+    idedata, validated_yaml, validated_json = _cache_paths(config_dir, configuration)
     idedata.parent.mkdir(parents=True, exist_ok=True)
     idedata.write_text("{}", encoding="utf-8")
-    validated.parent.mkdir(parents=True, exist_ok=True)
-    validated.write_text("esphome: {}\n", encoding="utf-8")
+    validated_yaml.parent.mkdir(parents=True, exist_ok=True)
+    validated_yaml.write_text("esphome: {}\n", encoding="utf-8")
+    validated_json.write_text('{"v": 1, "config": {"esphome": {}}}', encoding="utf-8")
 
     write_storage_json(
         config_dir,
@@ -86,7 +92,7 @@ async def test_delete_wipes_build_directory(
     """
     controller = make_controller(tmp_path)
     yaml_path, build_path = _seed_device(tmp_path, "kitchen.yaml")
-    idedata, validated = _cache_paths(tmp_path, "kitchen.yaml")
+    idedata, validated_yaml, validated_json = _cache_paths(tmp_path, "kitchen.yaml")
 
     await controller._delete_single("kitchen.yaml")
 
@@ -94,9 +100,10 @@ async def test_delete_wipes_build_directory(
     assert not build_path.exists()
     assert not (tmp_path / ".esphome" / "storage" / "kitchen.yaml.json").exists()
     # Regenerable build caches keyed off the device go too, so a
-    # recycled name doesn't pick up stale idedata / validated YAML.
+    # recycled name doesn't pick up stale idedata / validated config.
     assert not idedata.exists()
-    assert not validated.exists()
+    assert not validated_yaml.exists()
+    assert not validated_json.exists()
 
 
 @pytest.mark.usefixtures("redirect_storage_path")
@@ -107,7 +114,7 @@ async def test_delete_wipes_idedata_when_no_build_path(
     controller = make_controller(tmp_path)
     yaml_path = tmp_path / "kitchen.yaml"
     yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
-    idedata, _ = _cache_paths(tmp_path, "kitchen.yaml")
+    idedata, _, _ = _cache_paths(tmp_path, "kitchen.yaml")
     idedata.parent.mkdir(parents=True, exist_ok=True)
     idedata.write_text("{}", encoding="utf-8")
     write_storage_json(tmp_path, "kitchen.yaml", overrides={"build_path": None})
@@ -125,7 +132,7 @@ async def test_delete_tolerates_idedata_unlink_failure(
     """An OSError unlinking the idedata cache doesn't unwind the delete."""
     controller = make_controller(tmp_path)
     yaml_path, _ = _seed_device(tmp_path, "kitchen.yaml")
-    idedata, _ = _cache_paths(tmp_path, "kitchen.yaml")
+    idedata, _, _ = _cache_paths(tmp_path, "kitchen.yaml")
     # Swap the cache file for a directory so unlink() raises OSError.
     idedata.unlink()
     idedata.mkdir()
@@ -142,15 +149,15 @@ async def test_delete_tolerates_compiled_config_unlink_failure(
     """An OSError unlinking the validated-config cache is logged, not raised."""
     controller = make_controller(tmp_path)
     yaml_path, _ = _seed_device(tmp_path, "kitchen.yaml")
-    _, validated = _cache_paths(tmp_path, "kitchen.yaml")
-    validated.unlink()
-    validated.mkdir()
+    _, validated_yaml, _ = _cache_paths(tmp_path, "kitchen.yaml")
+    validated_yaml.unlink()
+    validated_yaml.mkdir()
 
     with caplog.at_level(logging.DEBUG):
         await controller._delete_single("kitchen.yaml")
 
     assert not yaml_path.exists()
-    assert any("unlink_compiled_config" in rec.message for rec in caplog.records)
+    assert any("unlink_validated_cache" in rec.message for rec in caplog.records)
 
 
 @pytest.mark.usefixtures("redirect_storage_path")

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -6,7 +6,10 @@ hand-rolled text scanning makes regression risk meaningful.
 
 from __future__ import annotations
 
+import json
 import logging
+import os
+import time
 from copy import deepcopy
 from pathlib import Path
 from types import SimpleNamespace
@@ -2453,6 +2456,50 @@ def test_load_device_ota_partition_access_from_validated_cache(tmp_path: Path) -
     device = load_device_from_storage(yaml_path)
 
     assert device.ota_partition_access is True
+
+
+def test_load_device_ota_partition_access_from_json_cache(tmp_path: Path) -> None:
+    """The 2026.8+ JSON cache arms the flag the same way the YAML cache did."""
+    yaml_path = tmp_path / "lamp.yaml"
+    yaml_path.write_text("esphome:\n  name: lamp\n", encoding="utf-8")
+    write_storage_json(tmp_path, "lamp.yaml")
+    cache = tmp_path / ".esphome" / "storage" / "lamp.yaml.validated.json"
+    cache.write_text(
+        json.dumps(
+            {
+                "v": 1,
+                "esphome": "2026.8.0",
+                "config": {"ota": [{"platform": "esphome", "allow_partition_access": True}]},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.ota_partition_access is True
+
+
+def test_load_device_ota_partition_access_prefers_newer_json_cache(tmp_path: Path) -> None:
+    """With both formats on disk, the newer file decides."""
+    yaml_path = tmp_path / "lamp.yaml"
+    yaml_path.write_text("esphome:\n  name: lamp\n", encoding="utf-8")
+    write_storage_json(tmp_path, "lamp.yaml")
+    storage_dir = tmp_path / ".esphome" / "storage"
+    stale_yaml = storage_dir / "lamp.yaml.validated.yaml"
+    stale_yaml.write_text(
+        "ota:\n- platform: esphome\n  allow_partition_access: true\n", encoding="utf-8"
+    )
+    old = time.time() - 3600
+    os.utime(stale_yaml, (old, old))
+    fresh_json = storage_dir / "lamp.yaml.validated.json"
+    fresh_json.write_text(
+        json.dumps({"v": 1, "config": {"ota": [{"platform": "esphome"}]}}), encoding="utf-8"
+    )
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.ota_partition_access is False
 
 
 def test_load_device_ota_partition_access_cache_without_flag(tmp_path: Path) -> None:

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -3669,3 +3669,16 @@ def test_secret_bearing_rebuild_compares_equal(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     assert load_device_from_storage(yaml_file) == load_device_from_storage(yaml_file)
+
+
+def test_load_device_ota_partition_access_unreadable_cache(tmp_path: Path) -> None:
+    """A cache that stats but cannot be read stays off instead of raising."""
+    yaml_path = tmp_path / "lamp.yaml"
+    yaml_path.write_text("esphome:\n  name: lamp\n", encoding="utf-8")
+    write_storage_json(tmp_path, "lamp.yaml")
+    # A directory at the cache path: stat succeeds, read_text raises OSError.
+    (tmp_path / ".esphome" / "storage" / "lamp.yaml.validated.json").mkdir(parents=True)
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.ota_partition_access is False

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -25,7 +25,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
-from esphome.core import CORE
+from esphome.core import CORE, EsphomeError
 from esphome.storage_json import StorageJSON
 
 from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
@@ -246,6 +246,24 @@ def test_materialise_stages_validated_json_for_esphome_fast_path(
     assert staged.read_bytes() == cache_body
     if sys.platform != "win32":
         assert (staged.stat().st_mode & 0o777) == 0o600
+
+
+def test_materialise_cache_write_failure_raises_materialise_error(
+    paired_roots: tuple[Path, Path],
+) -> None:
+    """write_file's EsphomeError translates so the runner's IO seam catches it."""
+    receiver_root, offloader_root = paired_roots
+    cache_body = b'{"v": 1, "esphome": "2026.8.0", "config": {"esphome": {"name": "kitchen"}}}'
+    tarball = _pack_in_tmp(receiver_root, validated_json=cache_body)
+
+    with (
+        patch(
+            "esphome_device_builder.helpers.remote_artifacts_materialise.write_file",
+            side_effect=EsphomeError("disk full"),
+        ),
+        pytest.raises(MaterialiseError, match="could not stage validated-config cache"),
+    ):
+        _materialise_in_tmp(tarball, offloader_root)
 
 
 def test_materialise_json_cache_drops_stale_yaml_sibling(

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -33,7 +33,6 @@ from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
     IDEDATA_MEMBER_NAME,
     PLATFORMIO_INI_MEMBER_NAME,
     STORAGE_MEMBER_NAME,
-    VALIDATED_YAML_MEMBER_NAME,
     pack_build_artifacts,
 )
 from esphome_device_builder.helpers.config_hash import read_build_info_hash
@@ -44,9 +43,15 @@ from esphome_device_builder.helpers.remote_artifacts_materialise import (
     materialise_remote_artifacts,
 )
 from esphome_device_builder.helpers.storage_path import (
-    resolve_compiled_config_path,
     resolve_idedata_path,
     resolve_storage_path,
+)
+from esphome_device_builder.helpers.validated_config_cache import (
+    JSON_CACHE_MEMBER_NAME,
+    LEGACY_YAML_CACHE_MEMBER_NAME,
+    find_validated_cache,
+    json_cache_path,
+    legacy_yaml_cache_path,
 )
 from tests.test_remote_build_artifacts_download import _write_receiver_state
 
@@ -213,13 +218,55 @@ def test_materialise_stages_validated_yaml_for_esphome_fast_path(
 
     sentinel = offloader_root / "___DASHBOARD_SENTINEL___.yaml"
     with patch.object(CORE, "config_path", sentinel):
-        staged = resolve_compiled_config_path("kitchen.yaml")
+        staged = legacy_yaml_cache_path("kitchen.yaml")
     assert staged.read_bytes() == cache_body
     # 0600 because the cache resolves !secret inline. POSIX mode bits
     # are inapplicable on Windows -- the offloader's chmod call is a
     # no-op there, so skip the assertion rather than fight ACL shape.
     if sys.platform != "win32":
         assert (staged.stat().st_mode & 0o777) == 0o600
+
+
+def test_materialise_stages_validated_json_for_esphome_fast_path(
+    paired_roots: tuple[Path, Path],
+) -> None:
+    """A 2026.8+ receiver ships the JSON cache; it stages at the JSON path."""
+    receiver_root, offloader_root = paired_roots
+    cache_body = b'{"v": 1, "esphome": "2026.8.0", "config": {"esphome": {"name": "kitchen"}}}'
+    tarball = _pack_in_tmp(receiver_root, validated_json=cache_body)
+
+    with tarfile.open(fileobj=io.BytesIO(tarball), mode="r:gz") as tar:
+        assert JSON_CACHE_MEMBER_NAME in tar.getnames()
+
+    _materialise_in_tmp(tarball, offloader_root)
+
+    sentinel = offloader_root / "___DASHBOARD_SENTINEL___.yaml"
+    with patch.object(CORE, "config_path", sentinel):
+        staged = json_cache_path("kitchen.yaml")
+    assert staged.read_bytes() == cache_body
+    if sys.platform != "win32":
+        assert (staged.stat().st_mode & 0o777) == 0o600
+
+
+def test_materialise_json_cache_drops_stale_yaml_sibling(
+    paired_roots: tuple[Path, Path],
+) -> None:
+    """Staging one format removes the other so a stale sibling can't shadow it."""
+    receiver_root, offloader_root = paired_roots
+    cache_body = b'{"v": 1, "esphome": "2026.8.0", "config": {"esphome": {"name": "kitchen"}}}'
+    tarball = _pack_in_tmp(receiver_root, validated_json=cache_body)
+
+    sentinel = offloader_root / "___DASHBOARD_SENTINEL___.yaml"
+    with patch.object(CORE, "config_path", sentinel):
+        stale_yaml = legacy_yaml_cache_path("kitchen.yaml")
+        stale_yaml.parent.mkdir(parents=True, exist_ok=True)
+        stale_yaml.write_bytes(b"esphome:\n  name: stale\n")
+
+    _materialise_in_tmp(tarball, offloader_root)
+
+    with patch.object(CORE, "config_path", sentinel):
+        assert not legacy_yaml_cache_path("kitchen.yaml").exists()
+        assert json_cache_path("kitchen.yaml").read_bytes() == cache_body
 
 
 def test_materialise_handles_missing_validated_yaml(
@@ -232,8 +279,7 @@ def test_materialise_handles_missing_validated_yaml(
 
     sentinel = offloader_root / "___DASHBOARD_SENTINEL___.yaml"
     with patch.object(CORE, "config_path", sentinel):
-        staged = resolve_compiled_config_path("kitchen.yaml")
-    assert not staged.exists()
+        assert find_validated_cache("kitchen.yaml") is None
 
 
 def test_pack_skips_stale_validated_yaml_after_esphome_downgrade(
@@ -258,11 +304,11 @@ def test_pack_skips_stale_validated_yaml_after_esphome_downgrade(
         tarball = pack_build_artifacts("kitchen.yaml").tarball
 
     with tarfile.open(fileobj=io.BytesIO(tarball), mode="r:gz") as tar:
-        assert VALIDATED_YAML_MEMBER_NAME not in tar.getnames()
+        assert LEGACY_YAML_CACHE_MEMBER_NAME not in tar.getnames()
 
     _materialise_in_tmp(tarball, offloader_root)
     with patch.object(CORE, "config_path", offloader_root / "___DASHBOARD_SENTINEL___.yaml"):
-        assert not resolve_compiled_config_path("kitchen.yaml").exists()
+        assert find_validated_cache("kitchen.yaml") is None
 
 
 def test_materialise_handles_missing_build_info_json(

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -41,6 +41,7 @@ from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
     UnpackArtifactsError,
     _download_type_files,
     _render_tarball,
+    _validated_cache_is_fresh,
     pack_build_artifacts,
     read_artifacts_tarball,
     unpack_artifacts_response,
@@ -1462,3 +1463,10 @@ def test_read_artifacts_tarball_surfaces_malformed_tarball_as_unpack_error() -> 
     """A corrupt gzip / tar header → ``UnpackArtifactsError`` (not a tarfile traceback)."""
     with pytest.raises(UnpackArtifactsError, match="is malformed"):
         read_artifacts_tarball(b"definitely not a tarball")
+
+
+def test_validated_cache_freshness_unstatable_is_stale(tmp_path: Path) -> None:
+    """A cache or sidecar that cannot be statted never packs."""
+    assert (
+        _validated_cache_is_fresh(tmp_path / "gone.validated.json", tmp_path / "gone.json") is False
+    )

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -52,9 +52,12 @@ from esphome_device_builder.definitions import EMPTY_PLATFORM_CAPABILITIES
 from esphome_device_builder.helpers.build_artifacts import load_build_artifacts
 from esphome_device_builder.helpers.peer_link_bundle import BUNDLE_CHUNK_SIZE_BYTES
 from esphome_device_builder.helpers.storage_path import (
-    resolve_compiled_config_path,
     resolve_idedata_path,
     resolve_storage_path,
+)
+from esphome_device_builder.helpers.validated_config_cache import (
+    json_cache_path,
+    legacy_yaml_cache_path,
 )
 from esphome_device_builder.models import (
     DownloadArtifactsFrameData,
@@ -610,6 +613,7 @@ def _write_receiver_state(
     extras: list[tuple[str, str]] | None = None,
     extra_build_files: dict[str, bytes] | None = None,
     validated_yaml: bytes | None = None,
+    validated_json: bytes | None = None,
     native_idf: bool = False,
 ) -> dict[str, Path]:
     """Lay down a minimal receiver-side build state on disk.
@@ -714,10 +718,15 @@ def _write_receiver_state(
         )
         paths["idedata_path"] = idedata_path
     if validated_yaml is not None:
-        validated_yaml_path = resolve_compiled_config_path(configuration)
+        validated_yaml_path = legacy_yaml_cache_path(configuration)
         validated_yaml_path.parent.mkdir(parents=True, exist_ok=True)
         validated_yaml_path.write_bytes(validated_yaml)
         paths["validated_yaml_path"] = validated_yaml_path
+    if validated_json is not None:
+        validated_json_path = json_cache_path(configuration)
+        validated_json_path.parent.mkdir(parents=True, exist_ok=True)
+        validated_json_path.write_bytes(validated_json)
+        paths["validated_json_path"] = validated_json_path
     return paths
 
 

--- a/tests/test_validated_config_cache.py
+++ b/tests/test_validated_config_cache.py
@@ -1,0 +1,127 @@
+"""Tests for the validated-config cache awareness helper."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from esphome_device_builder.helpers.validated_config_cache import (
+    JSON_CACHE_MEMBER_NAME,
+    LEGACY_YAML_CACHE_MEMBER_NAME,
+    find_validated_cache,
+    json_cache_path,
+    legacy_yaml_cache_path,
+    member_name_for,
+    parse_validated_cache,
+    path_for_member,
+    sibling_cache_path,
+    unlink_validated_cache,
+)
+
+_CONFIG = {"esphome": {"name": "lamp"}, "ota": [{"platform": "esphome"}]}
+
+
+def _write_json_cache(tmp_path: Path, envelope: object) -> Path:
+    path = json_cache_path("lamp.yaml")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(envelope), encoding="utf-8")
+    return path
+
+
+def _write_yaml_cache(tmp_path: Path, body: str = "esphome:\n  name: lamp\n") -> Path:
+    path = legacy_yaml_cache_path("lamp.yaml")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_paths_mirror_esphome_layout(tmp_path: Path) -> None:
+    assert json_cache_path("lamp.yaml").name == "lamp.yaml.validated.json"
+    assert legacy_yaml_cache_path("lamp.yaml").name == "lamp.yaml.validated.yaml"
+    assert json_cache_path("lamp.yaml").parent.name == "storage"
+
+
+def test_find_returns_none_without_caches(tmp_path: Path) -> None:
+    assert find_validated_cache("lamp.yaml") is None
+
+
+@pytest.mark.parametrize("newer", ["json", "yaml"])
+def test_find_prefers_newer_mtime(tmp_path: Path, newer: str) -> None:
+    """An up/downgrade's lingering sibling never shadows current compiles."""
+    json_path = _write_json_cache(tmp_path, {"v": 1, "config": _CONFIG})
+    yaml_path = _write_yaml_cache(tmp_path)
+    old = time.time() - 3600
+    stale = yaml_path if newer == "json" else json_path
+    os.utime(stale, (old, old))
+
+    expected = json_path if newer == "json" else yaml_path
+    assert find_validated_cache("lamp.yaml") == expected
+
+
+def test_parse_json_envelope(tmp_path: Path) -> None:
+    path = _write_json_cache(tmp_path, {"v": 1, "esphome": "2026.8.0", "config": _CONFIG})
+    assert parse_validated_cache(path) == _CONFIG
+
+
+@pytest.mark.parametrize(
+    "envelope",
+    [
+        pytest.param({"v": 2, "config": {}}, id="future_version"),
+        pytest.param({"config": {}}, id="missing_version"),
+        pytest.param({"v": 1, "config": []}, id="non_dict_config"),
+        pytest.param({"v": 1}, id="missing_config"),
+        pytest.param(["not", "a", "dict"], id="non_dict_envelope"),
+    ],
+)
+def test_parse_json_rejects_foreign_shapes(tmp_path: Path, envelope: object) -> None:
+    path = _write_json_cache(tmp_path, envelope)
+    assert parse_validated_cache(path) is None
+
+
+def test_parse_json_rejects_invalid_json(tmp_path: Path) -> None:
+    path = json_cache_path("lamp.yaml")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('{"v": 1, "config":', encoding="utf-8")
+    assert parse_validated_cache(path) is None
+
+
+def test_parse_legacy_yaml(tmp_path: Path) -> None:
+    path = _write_yaml_cache(tmp_path, "ota:\n- platform: esphome\n")
+    assert parse_validated_cache(path) == {"ota": [{"platform": "esphome"}]}
+
+
+def test_parse_legacy_yaml_rejects_invalid(tmp_path: Path) -> None:
+    path = _write_yaml_cache(tmp_path, "ota: [platform: esphome\nbroken: true")
+    assert parse_validated_cache(path) is None
+
+
+def test_unlink_removes_both_formats(tmp_path: Path) -> None:
+    json_path = _write_json_cache(tmp_path, {"v": 1, "config": _CONFIG})
+    yaml_path = _write_yaml_cache(tmp_path)
+
+    unlink_validated_cache("lamp.yaml")
+
+    assert not json_path.exists()
+    assert not yaml_path.exists()
+
+
+def test_member_name_round_trip(tmp_path: Path) -> None:
+    json_path = json_cache_path("lamp.yaml")
+    yaml_path = legacy_yaml_cache_path("lamp.yaml")
+    assert member_name_for(json_path) == JSON_CACHE_MEMBER_NAME
+    assert member_name_for(yaml_path) == LEGACY_YAML_CACHE_MEMBER_NAME
+    assert path_for_member(JSON_CACHE_MEMBER_NAME, "lamp.yaml") == json_path
+    assert path_for_member(LEGACY_YAML_CACHE_MEMBER_NAME, "lamp.yaml") == yaml_path
+    with pytest.raises(ValueError, match="unknown validated-cache member"):
+        path_for_member("validated.toml", "lamp.yaml")
+
+
+def test_sibling_cache_path(tmp_path: Path) -> None:
+    json_path = json_cache_path("lamp.yaml")
+    yaml_path = legacy_yaml_cache_path("lamp.yaml")
+    assert sibling_cache_path(json_path, "lamp.yaml") == yaml_path
+    assert sibling_cache_path(yaml_path, "lamp.yaml") == json_path

--- a/tests/test_validated_config_cache.py
+++ b/tests/test_validated_config_cache.py
@@ -18,42 +18,41 @@ from esphome_device_builder.helpers.validated_config_cache import (
     member_name_for,
     parse_validated_cache,
     path_for_member,
-    sibling_cache_path,
     unlink_validated_cache,
 )
 
 _CONFIG = {"esphome": {"name": "lamp"}, "ota": [{"platform": "esphome"}]}
 
 
-def _write_json_cache(tmp_path: Path, envelope: object) -> Path:
+def _write_json_cache(envelope: object) -> Path:
     path = json_cache_path("lamp.yaml")
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(envelope), encoding="utf-8")
     return path
 
 
-def _write_yaml_cache(tmp_path: Path, body: str = "esphome:\n  name: lamp\n") -> Path:
+def _write_yaml_cache(body: str = "esphome:\n  name: lamp\n") -> Path:
     path = legacy_yaml_cache_path("lamp.yaml")
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(body, encoding="utf-8")
     return path
 
 
-def test_paths_mirror_esphome_layout(tmp_path: Path) -> None:
+def test_paths_mirror_esphome_layout() -> None:
     assert json_cache_path("lamp.yaml").name == "lamp.yaml.validated.json"
     assert legacy_yaml_cache_path("lamp.yaml").name == "lamp.yaml.validated.yaml"
     assert json_cache_path("lamp.yaml").parent.name == "storage"
 
 
-def test_find_returns_none_without_caches(tmp_path: Path) -> None:
+def test_find_returns_none_without_caches() -> None:
     assert find_validated_cache("lamp.yaml") is None
 
 
 @pytest.mark.parametrize("newer", ["json", "yaml"])
-def test_find_prefers_newer_mtime(tmp_path: Path, newer: str) -> None:
+def test_find_prefers_newer_mtime(newer: str) -> None:
     """An up/downgrade's lingering sibling never shadows current compiles."""
-    json_path = _write_json_cache(tmp_path, {"v": 1, "config": _CONFIG})
-    yaml_path = _write_yaml_cache(tmp_path)
+    json_path = _write_json_cache({"v": 1, "config": _CONFIG})
+    yaml_path = _write_yaml_cache()
     old = time.time() - 3600
     stale = yaml_path if newer == "json" else json_path
     os.utime(stale, (old, old))
@@ -62,8 +61,8 @@ def test_find_prefers_newer_mtime(tmp_path: Path, newer: str) -> None:
     assert find_validated_cache("lamp.yaml") == expected
 
 
-def test_parse_json_envelope(tmp_path: Path) -> None:
-    path = _write_json_cache(tmp_path, {"v": 1, "esphome": "2026.8.0", "config": _CONFIG})
+def test_parse_json_envelope() -> None:
+    path = _write_json_cache({"v": 1, "esphome": "2026.8.0", "config": _CONFIG})
     assert parse_validated_cache(path) == _CONFIG
 
 
@@ -77,31 +76,31 @@ def test_parse_json_envelope(tmp_path: Path) -> None:
         pytest.param(["not", "a", "dict"], id="non_dict_envelope"),
     ],
 )
-def test_parse_json_rejects_foreign_shapes(tmp_path: Path, envelope: object) -> None:
-    path = _write_json_cache(tmp_path, envelope)
+def test_parse_json_rejects_foreign_shapes(envelope: object) -> None:
+    path = _write_json_cache(envelope)
     assert parse_validated_cache(path) is None
 
 
-def test_parse_json_rejects_invalid_json(tmp_path: Path) -> None:
+def test_parse_json_rejects_invalid_json() -> None:
     path = json_cache_path("lamp.yaml")
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text('{"v": 1, "config":', encoding="utf-8")
     assert parse_validated_cache(path) is None
 
 
-def test_parse_legacy_yaml(tmp_path: Path) -> None:
-    path = _write_yaml_cache(tmp_path, "ota:\n- platform: esphome\n")
+def test_parse_legacy_yaml() -> None:
+    path = _write_yaml_cache("ota:\n- platform: esphome\n")
     assert parse_validated_cache(path) == {"ota": [{"platform": "esphome"}]}
 
 
-def test_parse_legacy_yaml_rejects_invalid(tmp_path: Path) -> None:
-    path = _write_yaml_cache(tmp_path, "ota: [platform: esphome\nbroken: true")
+def test_parse_legacy_yaml_rejects_invalid() -> None:
+    path = _write_yaml_cache("ota: [platform: esphome\nbroken: true")
     assert parse_validated_cache(path) is None
 
 
-def test_unlink_removes_both_formats(tmp_path: Path) -> None:
-    json_path = _write_json_cache(tmp_path, {"v": 1, "config": _CONFIG})
-    yaml_path = _write_yaml_cache(tmp_path)
+def test_unlink_removes_both_formats() -> None:
+    json_path = _write_json_cache({"v": 1, "config": _CONFIG})
+    yaml_path = _write_yaml_cache()
 
     unlink_validated_cache("lamp.yaml")
 
@@ -109,7 +108,7 @@ def test_unlink_removes_both_formats(tmp_path: Path) -> None:
     assert not yaml_path.exists()
 
 
-def test_member_name_round_trip(tmp_path: Path) -> None:
+def test_member_name_round_trip() -> None:
     json_path = json_cache_path("lamp.yaml")
     yaml_path = legacy_yaml_cache_path("lamp.yaml")
     assert member_name_for(json_path) == JSON_CACHE_MEMBER_NAME
@@ -118,10 +117,3 @@ def test_member_name_round_trip(tmp_path: Path) -> None:
     assert path_for_member(LEGACY_YAML_CACHE_MEMBER_NAME, "lamp.yaml") == yaml_path
     with pytest.raises(ValueError, match="unknown validated-cache member"):
         path_for_member("validated.toml", "lamp.yaml")
-
-
-def test_sibling_cache_path(tmp_path: Path) -> None:
-    json_path = json_cache_path("lamp.yaml")
-    yaml_path = legacy_yaml_cache_path("lamp.yaml")
-    assert sibling_cache_path(json_path, "lamp.yaml") == yaml_path
-    assert sibling_cache_path(yaml_path, "lamp.yaml") == json_path

--- a/tests/test_validated_config_cache.py
+++ b/tests/test_validated_config_cache.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import time
 from pathlib import Path
@@ -117,3 +118,19 @@ def test_member_name_round_trip() -> None:
     assert path_for_member(LEGACY_YAML_CACHE_MEMBER_NAME, "lamp.yaml") == yaml_path
     with pytest.raises(ValueError, match="unknown validated-cache member"):
         path_for_member("validated.toml", "lamp.yaml")
+
+
+def test_find_logs_unreadable_cache(caplog: pytest.LogCaptureFixture) -> None:
+    """A stat failure that isn't absence is debug-logged and skipped."""
+    storage_parent = json_cache_path("lamp.yaml").parent
+    storage_parent.parent.mkdir(parents=True, exist_ok=True)
+    # A file where the storage dir should be: stat under it raises
+    # NotADirectoryError, an OSError that isn't FileNotFoundError.
+    storage_parent.write_text("not a directory", encoding="utf-8")
+
+    with caplog.at_level(
+        logging.DEBUG, logger="esphome_device_builder.helpers.validated_config_cache"
+    ):
+        assert find_validated_cache("lamp.yaml") is None
+
+    assert "unreadable" in caplog.text

--- a/tests/test_validated_config_cache.py
+++ b/tests/test_validated_config_cache.py
@@ -120,13 +120,20 @@ def test_member_name_round_trip() -> None:
         path_for_member("validated.toml", "lamp.yaml")
 
 
-def test_find_logs_unreadable_cache(caplog: pytest.LogCaptureFixture) -> None:
+def test_find_logs_unreadable_cache(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A stat failure that isn't absence is debug-logged and skipped."""
-    storage_parent = json_cache_path("lamp.yaml").parent
-    storage_parent.parent.mkdir(parents=True, exist_ok=True)
-    # A file where the storage dir should be: stat under it raises
-    # NotADirectoryError, an OSError that isn't FileNotFoundError.
-    storage_parent.write_text("not a directory", encoding="utf-8")
+    real_stat = Path.stat
+
+    def _denied_stat(self: Path, **kwargs: object) -> object:
+        # Windows maps a mid-path file to FileNotFoundError, so drive the
+        # non-absence branch directly instead of through the filesystem.
+        if ".validated." in self.name:
+            raise PermissionError(13, "denied", str(self))
+        return real_stat(self, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "stat", _denied_stat)
 
     with caplog.at_level(
         logging.DEBUG, logger="esphome_device_builder.helpers.validated_config_cache"


### PR DESCRIPTION
# What does this implement/fix?

esphome 2026.8 stores the validated config cache as `<basename>.validated.json` while older releases write `<basename>.validated.yaml`; the dashboard knew the old filename in four separate places. This adds `helpers/validated_config_cache.py` as the single owner of cache paths, discovery, parsing and removal; the partition access scan, the delete and archive flows, the remote build tarball packer and the offloader side materialiser all route through it. Both formats are handled wherever a cache is read, removed or shipped; the freshest file wins when both exist, the tarball ships whichever format the receiver's esphome wrote under a matching member name, and staging one format drops the stale sibling so it cannot shadow newer compiles.

**Related issue or feature (if applicable):**

- esphome/esphome#18106

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
