### PR TITLE
Raise the upload lane to 9 slots on esphome 2026.8+

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,10 +334,10 @@ against legacy behaviour before assuming the simpler version suffices.
   rationale in `docs/ARCHITECTURE.md` "Event bus → Typing event payloads".
 - **Persistent firmware queue — three concurrent lanes.** A CPU/compile
   lane (one job at a time), a network/upload lane (up to
-  `MAX_CONCURRENT_UPLOADS` flashes at once — 4, or 8 with esphome
+  `MAX_CONCURRENT_UPLOADS` flashes at once — 4, or 9 with esphome
   2026.8+ whose upload subprocess is slimmer and whose log sessions
   defer the platform import (esphome/esphome#17684, esphome/esphome#18093,
-  esphome/esphome#18048);
+  esphome/esphome#18105, esphome/esphome#18106, esphome/esphome#18048);
   the cap bounds subprocess-tree memory), and a single-slot thread
   upload lane, all
   running concurrently, so a slow upload doesn't block the next compile

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -199,13 +199,15 @@ firmware/install {configuration} → QUEUED → RUNNING → output... → COMPLE
 
 - Three concurrent lanes — a compile lane (CPU, one job at a time), an
   upload lane (network, up to `MAX_CONCURRENT_UPLOADS` flashes at once:
-  4, or 8 when the installed esphome is 2026.8 or later, whose upload
-  subprocess defers codegen, config validation, voluptuous and the
-  bundle machinery for ~28 MiB per flash — esphome/esphome#17684 and
-  esphome/esphome#18093 — and whose log sessions defer the
-  stacktrace-decoder platform import and so hand back ~10 MiB of host
-  budget per open esp32 log stream, esphome/esphome#18048), and a
-  single-slot thread upload lane. The lanes run in parallel
+  4, or 9 when the installed esphome is 2026.8 or later, whose upload
+  subprocess defers codegen, config validation, voluptuous, the bundle
+  machinery and stray stdlib imports, and reads the validated-config
+  cache as JSON so pyyaml never loads on a cache hit, for ~28 MiB peak
+  per flash — esphome/esphome#17684, esphome/esphome#18093,
+  esphome/esphome#18105, esphome/esphome#18106 — and whose log sessions
+  defer the stacktrace-decoder platform import and so hand back ~10 MiB
+  of host budget per open esp32 log stream, esphome/esphome#18048), and
+  a single-slot thread upload lane. The lanes run in parallel
   so a slow network flash doesn't block the next device's compile
   (#3702), and OTAs don't serialize behind each other (esphome
   discussion #3781). The concurrency exists for deep-sleep wake

--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -32,23 +32,25 @@ _JOBS_KEY = "_firmware_jobs"
 # once. Each flash is a full esphome subprocess tree; the cap bounds
 # their combined memory on small hosts. esphome 2026.8.0 lazy-loads
 # codegen and config validation out of the upload subprocess
-# (esphome/esphome#17684), defers the voluptuous and bundle imports
-# off the upload fast path (esphome/esphome#18093, ~28 MiB per flash
-# measured), and lazily resolves the stacktrace decoder out of log
-# sessions (esphome/esphome#18048), handing back ~10 MiB of host
-# budget per open esp32 log stream, so that release line and later
-# earn four more slots. The gate trusts every 2026.8 build to carry
-# these changes; a dev/beta snapshot from
+# (esphome/esphome#17684), defers the voluptuous, bundle and stdlib
+# imports off the upload fast path (esphome/esphome#18093,
+# esphome/esphome#18105), stores the validated-config cache as JSON so
+# a cache-hit upload never loads pyyaml (esphome/esphome#18106, ~28 MiB
+# peak per flash measured after both), and lazily resolves the
+# stacktrace decoder out of log sessions (esphome/esphome#18048),
+# handing back ~10 MiB of host budget per open esp32 log stream, so
+# that release line and later earn five more slots. The gate trusts
+# every 2026.8 build to carry these changes; a dev/beta snapshot from
 # before they merged briefly overclaims. OpenThread
 # flashes don't count against the cap — they serialize on their own
 # single-slot lane — so peak concurrency is this plus one thread flash.
 _UPLOAD_SLOTS = 4
-_UPLOAD_SLOTS_LEAN_SUBPROCESS = 8
+_UPLOAD_SLOTS_LEAN_SUBPROCESS = 9
 _LEAN_UPLOAD_RELEASE = (2026, 8)
 
 
 def max_concurrent_uploads(esphome_version: str) -> int:
-    """Upload-lane slot count for *esphome_version*: 8 on 2026.8+, else 4."""
+    """Upload-lane slot count for *esphome_version*: 9 on 2026.8+, else 4."""
     if release_line_at_least(esphome_version, _LEAN_UPLOAD_RELEASE):
         return _UPLOAD_SLOTS_LEAN_SUBPROCESS
     return _UPLOAD_SLOTS

--- a/tests/controllers/firmware/test_parallel_uploads.py
+++ b/tests/controllers/firmware/test_parallel_uploads.py
@@ -291,14 +291,14 @@ def test_upload_lane_concurrency_defaults() -> None:
     ("version", "expected"),
     [
         pytest.param("2026.7.0", 4, id="pre_lean_release"),
-        pytest.param("2026.8.0", 8, id="lean_release"),
-        pytest.param("2026.8.0-dev", 8, id="lean_dev"),
-        pytest.param("2027.1.0", 8, id="later_release"),
+        pytest.param("2026.8.0", 9, id="lean_release"),
+        pytest.param("2026.8.0-dev", 9, id="lean_dev"),
+        pytest.param("2027.1.0", 9, id="later_release"),
         pytest.param("", 4, id="unknown_version"),
     ],
 )
 def test_max_concurrent_uploads_version_gate(version: str, expected: int) -> None:
-    """2026.8+ earns 8 upload slots; older and unknown versions keep 4."""
+    """2026.8+ earns 9 upload slots; older and unknown versions keep 4."""
     assert max_concurrent_uploads(version) == expected
 
 


### PR DESCRIPTION
# What does this implement/fix?

> [!WARNING]
> Must not merge until esphome/esphome#18105 and esphome/esphome#18106 do; the extra slot depends on their measured savings landing in 2026.8.

Raises the upload lane from 8 to 9 concurrent flashes when the installed esphome is 2026.8 or later; older versions keep 4. On top of the savings #2515 was budgeted on, that release line defers the remaining stdlib imports off the upload fast path (esphome/esphome#18105) and stores the validated config cache as JSON so a cache hit upload never loads pyyaml (esphome/esphome#18106); together they hand back about 2.7 MiB per flash, measured ~28 MiB peak at the start of the OTA transfer, so the same host budget covers one more slot. The burst stagger list in the tests already derives from the cap, so only the gate expectations move. Follows up #2515.

**Related issue or feature (if applicable):**

- https://github.com/orgs/esphome/discussions/3781

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
