### PR TITLE
Extract the logged background-task spawn into create_logged_task

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -25,10 +25,9 @@ import asyncio
 import contextlib
 import logging
 from collections.abc import Awaitable, Callable
-from functools import partial
 from typing import Any, Protocol
 
-from ...helpers.async_ import create_eager_task, drain_tasks, log_task_exit
+from ...helpers.async_ import create_eager_task, create_logged_task, drain_tasks
 from ...helpers.ip import drop_unusable_addresses, is_unusable_address
 from ...helpers.mac_addresses import normalize_mac
 from ...helpers.subscriber_presence import SubscriberPresence
@@ -221,12 +220,9 @@ class DeviceStateMonitor(TaskControllerBase):
         """Start the importable flow, mDNS browser, ping sweep, API info fallback, and reviver."""
         self.importable.setup()
         await self.mdns.start()
-        self._ping_task = asyncio.create_task(self.ping.run())
-        self._ping_task.add_done_callback(partial(log_task_exit, "Ping sweep"))
-        self._api_info_task = asyncio.create_task(self.api_info.run())
-        self._api_info_task.add_done_callback(partial(log_task_exit, "API info fallback"))
-        self._api_reviver_task = asyncio.create_task(self.api_reviver.run())
-        self._api_reviver_task.add_done_callback(partial(log_task_exit, "API reviver"))
+        self._ping_task = create_logged_task(self.ping.run(), "Ping sweep")
+        self._api_info_task = create_logged_task(self.api_info.run(), "API info fallback")
+        self._api_reviver_task = create_logged_task(self.api_reviver.run(), "API reviver")
 
     async def stop(self) -> None:
         """Tear down the browser and drain the ping + API + resolve tasks (bounded)."""

--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -220,9 +220,9 @@ class DeviceStateMonitor(TaskControllerBase):
         """Start the importable flow, mDNS browser, ping sweep, API info fallback, and reviver."""
         self.importable.setup()
         await self.mdns.start()
-        self._ping_task = create_logged_task(self.ping.run(), "Ping sweep")
-        self._api_info_task = create_logged_task(self.api_info.run(), "API info fallback")
-        self._api_reviver_task = create_logged_task(self.api_reviver.run(), "API reviver")
+        self._ping_task = create_logged_task(self.ping.run(), name="Ping sweep")
+        self._api_info_task = create_logged_task(self.api_info.run(), name="API info fallback")
+        self._api_reviver_task = create_logged_task(self.api_reviver.run(), name="API reviver")
 
     async def stop(self) -> None:
         """Tear down the browser and drain the ping + API + resolve tasks (bounded)."""

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Callable, Mapping
-from functools import partial
 from operator import attrgetter
 from typing import TYPE_CHECKING, Any
 
@@ -29,7 +28,7 @@ from zeroconf import (
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
 from zeroconf.const import _CLASS_IN, _TYPE_A, _TYPE_AAAA, _TYPE_SRV, _TYPE_TXT
 
-from ...helpers.async_ import drain_tasks, log_task_exit
+from ...helpers.async_ import create_logged_task, drain_tasks
 from ...helpers.hostname import normalize_hostname
 from ...helpers.ip import drop_unusable_addresses
 from ...models import DeviceState
@@ -140,9 +139,8 @@ class MdnsSource:
         # Keep the responder bound to the live interface set (VPN / Wi-Fi /
         # Docker churn) for the instance's lifetime; cancelled in close_zeroconf.
         if self._zeroconf is not None:
-            self._interface_monitor_task = asyncio.create_task(monitor_interfaces(self._zeroconf))
-            self._interface_monitor_task.add_done_callback(
-                partial(log_task_exit, "Interface monitor")
+            self._interface_monitor_task = create_logged_task(
+                monitor_interfaces(self._zeroconf), "Interface monitor"
             )
 
     async def cancel_browser(self) -> None:

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -140,7 +140,7 @@ class MdnsSource:
         # Docker churn) for the instance's lifetime; cancelled in close_zeroconf.
         if self._zeroconf is not None:
             self._interface_monitor_task = create_logged_task(
-                monitor_interfaces(self._zeroconf), "Interface monitor"
+                monitor_interfaces(self._zeroconf), name="Interface monitor"
             )
 
     async def cancel_browser(self) -> None:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -323,7 +323,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
             # before ``start()`` returns, so the drain batch is fully
             # staged for coalescing.
             self._refine_task = create_logged_task(
-                refine.refine_shallow_scan(self), "Cold-start refine"
+                refine.refine_shallow_scan(self), name="Cold-start refine"
             )
 
     async def stop(self) -> None:
@@ -366,7 +366,9 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
             self._mqtt_reconcile_handle = None
             if self._stopped:
                 return
-            task = create_logged_task(self._mqtt_coordinator.reconcile(), "MQTT reconcile nudge")
+            task = create_logged_task(
+                self._mqtt_coordinator.reconcile(), name="MQTT reconcile nudge"
+            )
             self._mqtt_reconcile_tasks.add(task)
             task.add_done_callback(self._mqtt_reconcile_tasks.discard)
 

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
-from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -20,7 +19,7 @@ from esphome.zeroconf import AsyncEsphomeZeroconf
 
 from ...constants import is_secrets_file
 from ...helpers.api import CommandError, api_command
-from ...helpers.async_ import create_eager_task, drain_tasks, log_task_exit, run_in_executor
+from ...helpers.async_ import create_logged_task, drain_tasks, run_in_executor
 from ...helpers.build_size import BuildSizeRefreshResult
 from ...helpers.device_yaml import board_requires_wifi
 from ...helpers.event_bus import Event
@@ -323,10 +322,9 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
             # Eager: the request loop runs to its ``wait_idle`` park
             # before ``start()`` returns, so the drain batch is fully
             # staged for coalescing.
-            self._refine_task = create_eager_task(
-                refine.refine_shallow_scan(self), name="Cold-start refine"
+            self._refine_task = create_logged_task(
+                refine.refine_shallow_scan(self), "Cold-start refine"
             )
-            self._refine_task.add_done_callback(partial(log_task_exit, "Cold-start refine"))
 
     async def stop(self) -> None:
         """Stop background monitors so the process exits cleanly."""
@@ -368,11 +366,8 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
             self._mqtt_reconcile_handle = None
             if self._stopped:
                 return
-            task = create_eager_task(
-                self._mqtt_coordinator.reconcile(), name="MQTT reconcile nudge"
-            )
+            task = create_logged_task(self._mqtt_coordinator.reconcile(), "MQTT reconcile nudge")
             self._mqtt_reconcile_tasks.add(task)
-            task.add_done_callback(partial(log_task_exit, "MQTT reconcile nudge"))
             task.add_done_callback(self._mqtt_reconcile_tasks.discard)
 
         self._mqtt_reconcile_handle = asyncio.get_running_loop().call_later(

--- a/esphome_device_builder/controllers/remote_build/_task_window.py
+++ b/esphome_device_builder/controllers/remote_build/_task_window.py
@@ -22,17 +22,19 @@ class TaskWindow:
         """Whether any tracked task is live."""
         return bool(self._tasks)
 
-    def track(
-        self, coro: Coroutine[Any, Any, None], *, name: str, label: str
-    ) -> asyncio.Task[None] | None:
+    def track(self, coro: Coroutine[Any, Any, None], *, name: str) -> asyncio.Task[None] | None:
         """Run *coro* as a tracked task; refused (``None``) once stopped."""
         if self.stopped:
             coro.close()
             return None
+        # Deliberately lazy (not ``create_logged_task``): callers
+        # register bookkeeping against the returned task before its
+        # first segment runs — an eager start lets an extract outrun
+        # its cancel registration.
         task = asyncio.create_task(coro, name=name)
         self._tasks.add(task)
         task.add_done_callback(self._tasks.discard)
-        task.add_done_callback(partial(log_task_exit, label))
+        task.add_done_callback(partial(log_task_exit, name))
         return task
 
     async def wait_idle(self) -> None:

--- a/esphome_device_builder/controllers/remote_build/artifacts_download.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_download.py
@@ -259,8 +259,7 @@ class ArtifactsDownloadSender:
 
         task = self._downloads.track(
             self._run_download(session, job_id, firmware_job.configuration),
-            name=f"artifacts-download-{job_id}",
-            label=f"artifacts download {job_id}",
+            name=f"artifacts download {job_id}",
         )
         if task is None:
             _LOGGER.warning(

--- a/esphome_device_builder/controllers/remote_build/submit_job/_extract_window.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job/_extract_window.py
@@ -28,11 +28,7 @@ class ExtractWindow(TaskWindow):
 
     def spawn(self, key: _Key, coro: Coroutine[Any, Any, None]) -> None:
         """Run *coro* as the tracked extract task for *key*; refused once stopped."""
-        task = self.track(
-            coro,
-            name=f"submit-job-extract-{key[1]}",
-            label=f"submit-job extract {key[1]}",
-        )
+        task = self.track(coro, name=f"submit-job extract {key[1]}")
         if task is None:
             return
         self._index[key] = task

--- a/esphome_device_builder/helpers/async_.py
+++ b/esphome_device_builder/helpers/async_.py
@@ -71,8 +71,8 @@ async def run_in_executor[T](fn: Callable[..., T], *args: Any) -> T:
 
 def create_logged_task[T](
     coro: Coroutine[Any, Any, T],
-    name: str,
     *,
+    name: str,
     loop: AbstractEventLoop | None = None,
 ) -> Task[T]:
     """Create a named eager task that logs an unexpected crash."""

--- a/esphome_device_builder/helpers/async_.py
+++ b/esphome_device_builder/helpers/async_.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from asyncio import AbstractEventLoop, Task, gather, get_running_loop
 from collections.abc import Callable, Coroutine, Iterable
+from functools import partial
 from typing import Any
 
 _LOGGER = logging.getLogger(__name__)
@@ -66,6 +67,18 @@ async def run_in_executor[T](fn: Callable[..., T], *args: Any) -> T:
     case. Pass a ``functools.partial`` / lambda when *fn* needs keywords.
     """
     return await get_running_loop().run_in_executor(None, fn, *args)
+
+
+def create_logged_task[T](
+    coro: Coroutine[Any, Any, T],
+    name: str,
+    *,
+    loop: AbstractEventLoop | None = None,
+) -> Task[T]:
+    """Create a named eager task that logs an unexpected crash."""
+    task = create_eager_task(coro, name=name, loop=loop)
+    task.add_done_callback(partial(log_task_exit, name))
+    return task
 
 
 def create_eager_task[T](

--- a/tests/test_helpers_async.py
+++ b/tests/test_helpers_async.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 
-from esphome_device_builder.helpers.async_ import create_eager_task
+import pytest
+
+from esphome_device_builder.helpers.async_ import create_eager_task, create_logged_task
 
 
 async def test_eager_task_runs_synchronously_until_first_await() -> None:
@@ -49,3 +51,28 @@ async def test_eager_task_uses_explicit_loop() -> None:
     task = create_eager_task(coro(), loop=loop)
     assert task.get_loop() is loop
     await task
+
+
+async def test_logged_task_starts_eagerly_and_names_the_task() -> None:
+    ran: list[bool] = []
+
+    async def coro() -> None:
+        ran.append(True)
+
+    task = create_logged_task(coro(), "worker")
+    assert ran == [True]
+    assert task.get_name() == "worker"
+    await task
+
+
+async def test_logged_task_logs_a_crash(caplog: pytest.LogCaptureFixture) -> None:
+    async def coro() -> None:
+        await asyncio.sleep(0)
+        raise RuntimeError("simulated crash")
+
+    target = "esphome_device_builder.helpers.async_"
+    with caplog.at_level("ERROR", logger=target):
+        task = create_logged_task(coro(), "doomed worker")
+        await asyncio.gather(task, return_exceptions=True)
+
+    assert any("doomed worker crashed" in r.getMessage() for r in caplog.records)

--- a/tests/test_helpers_async.py
+++ b/tests/test_helpers_async.py
@@ -59,7 +59,7 @@ async def test_logged_task_starts_eagerly_and_names_the_task() -> None:
     async def coro() -> None:
         ran.append(True)
 
-    task = create_logged_task(coro(), "worker")
+    task = create_logged_task(coro(), name="worker")
     assert ran == [True]
     assert task.get_name() == "worker"
     await task
@@ -72,7 +72,24 @@ async def test_logged_task_logs_a_crash(caplog: pytest.LogCaptureFixture) -> Non
 
     target = "esphome_device_builder.helpers.async_"
     with caplog.at_level("ERROR", logger=target):
-        task = create_logged_task(coro(), "doomed worker")
+        task = create_logged_task(coro(), name="doomed worker")
         await asyncio.gather(task, return_exceptions=True)
 
     assert any("doomed worker crashed" in r.getMessage() for r in caplog.records)
+
+
+async def test_logged_task_logs_a_crash_before_the_first_await(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def coro() -> None:
+        raise RuntimeError("synchronous crash")
+
+    target = "esphome_device_builder.helpers.async_"
+    with caplog.at_level("ERROR", logger=target):
+        # Completes inside create_eager_task; the logger attaches to an
+        # already-settled task and must still fire.
+        task = create_logged_task(coro(), name="instant casualty")
+        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.sleep(0)
+
+    assert any("instant casualty crashed" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
# What does this implement/fix?

Extracts the repeated background task spawn pattern into `helpers.async_.create_logged_task(coro, name)`: an eager named task with a `log_task_exit` done callback, so a crash logs at crash time instead of dying silently. Six sites convert: the cold start refine and MQTT nudge spawns, the three state monitor loops (which also gain task names they never had), and the mDNS interface monitor.

The four previously lazy spawns (the three monitor loops and the interface monitor) become eager; all four suspend at their first statement (bootstrap sleeps or an executor hop), so the only observable delta is the loop's running flag flipping during `start()` instead of on the next loop turn.

`TaskWindow.track` keeps its lazy spawn on purpose, callers register cancel bookkeeping against the returned task before its first segment runs, and an eager start lets an extract outrun that registration (a comment now pins the reason). Its redundant `name`/`label` pair collapses to one `name` used for both the task and the log line.

**Related issue or feature (if applicable):**

- follow up to #2514

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
