### PR TITLE
Retry storage regeneration with backoff before stamping a failure

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -402,13 +402,23 @@ Two rules the refine established that every later caller inherits:
   reload-driven path (labels, build size, post-compile refresh) now means "the
   row changed", not "a reload ran". The gate suppresses every RELOADED side
   effect in `on_scan_change`, not just the frame — all are implied by row
-  equality except `regenerate_failed.discard`, whose real repair path is a
-  YAML edit (`UPDATED`) anyway.
+  equality except `regen.reset` (failure marker, armed retry timer, strike
+  count), whose real repair path is a YAML edit (`UPDATED`) anyway.
 - **The refine emits `RELOADED`, never `UPDATED`.** `DEVICE_YAML_UPDATED`
   (version-history commits) keys on `UPDATED`, and the network-fingerprint
   regen deliberately skips `RELOADED` (it fires on `ADDED`/`UPDATED` to catch
   out-of-band edits), so a restart's refine burst can neither commit to git
   nor spawn `--only-generate` per device.
+- **Regen failures retry before they stamp** (#2532). A failed
+  `--only-generate` gets a bounded escalating retry (3 attempts, 30/60/120s)
+  before the session `regen.failed` marker and the one-hour disk stamp — a
+  transient environment failure (interrupted package clone, DNS) is
+  indistinguishable from a broken YAML without parsing subprocess stderr, so
+  every failure retries. The stamp is written only once the budget is spent;
+  a shutdown mid-window stamps any armed retries first so a restart loop
+  can't spend a fresh budget each cycle. Success at any attempt clears the
+  ladder and reloads the scanner, which also repairs an earlier swallowed
+  in-process package resolve.
 
 ## Authentication
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -402,8 +402,11 @@ Two rules the refine established that every later caller inherits:
   reload-driven path (labels, build size, post-compile refresh) now means "the
   row changed", not "a reload ran". The gate suppresses every RELOADED side
   effect in `on_scan_change`, not just the frame — all are implied by row
-  equality except `regen.reset` (failure marker, armed retry timer, strike
-  count), whose real repair path is a YAML edit (`UPDATED`) anyway.
+  equality except the regen failure marker: `RELOADED` discards it, while the
+  armed retry timer and strike count deliberately survive (the cold-start
+  refine's `RELOADED` burst must not cancel a pending recovery); the full
+  `regen.reset` runs only on `UPDATED`/`REMOVED`, whose real repair path is a
+  YAML edit anyway.
 - **The refine emits `RELOADED`, never `UPDATED`.** `DEVICE_YAML_UPDATED`
   (version-history commits) keys on `UPDATED`, and the network-fingerprint
   regen deliberately skips `RELOADED` (it fires on `ADDED`/`UPDATED` to catch

--- a/esphome_device_builder/controllers/devices/_state.py
+++ b/esphome_device_builder/controllers/devices/_state.py
@@ -28,9 +28,49 @@ What lives here vs on the controller:
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 
 from ...models import AdoptableDevice
+
+
+@dataclass
+class RegenState:
+    """
+    Bookkeeping for background ``--only-generate`` runs.
+
+    ``pending`` blocks duplicate schedules while a run is in flight;
+    ``failed`` blocks retries until the YAML changes (cleared by
+    ``scan_change``); ``retry_timers`` + ``retry_strikes`` drive the
+    bounded escalating retry between a failure and the disk stamp.
+    """
+
+    pending: set[str] = field(default_factory=set)
+    failed: set[str] = field(default_factory=set)
+    retry_timers: dict[str, asyncio.TimerHandle] = field(default_factory=dict)
+    retry_strikes: dict[str, int] = field(default_factory=dict)
+
+    def arm_retry(self, configuration: str, handle: asyncio.TimerHandle) -> None:
+        """Install *handle* as the pending retry, cancelling any prior one."""
+        existing = self.retry_timers.pop(configuration, None)
+        if existing is not None:
+            existing.cancel()
+        self.retry_timers[configuration] = handle
+
+    def reset(self, configuration: str) -> None:
+        """Drop *configuration*'s failure marker, retry timer, and strikes."""
+        self.failed.discard(configuration)
+        handle = self.retry_timers.pop(configuration, None)
+        if handle is not None:
+            handle.cancel()
+        self.retry_strikes.pop(configuration, None)
+
+    def cancel_all_retry_timers(self) -> None:
+        """Cancel every pending retry timer and drop the strike counts."""
+        for handle in self.retry_timers.values():
+            handle.cancel()
+        self.retry_timers.clear()
+        self.retry_strikes.clear()
 
 
 @dataclass
@@ -43,15 +83,10 @@ class DevicesState:
     # picks first.
     esphome_cmd: list[str] = field(default_factory=list)
 
-    # Background ``--only-generate`` bookkeeping. Three guards:
-    # ``regenerate_pending`` blocks duplicate schedules while
-    # the subprocess is in flight; ``regenerate_failed`` blocks
-    # retries until the YAML changes (cleared on
-    # ``ScanChange.UPDATED``); the controller's
-    # ``_regenerate_lock`` (kept on the controller) serialises
-    # the actual subprocess.
-    regenerate_pending: set[str] = field(default_factory=set)
-    regenerate_failed: set[str] = field(default_factory=set)
+    # Background ``--only-generate`` bookkeeping; the controller's
+    # ``_regenerate_lock`` (kept on the controller) serialises the
+    # actual subprocess.
+    regen: RegenState = field(default_factory=RegenState)
 
     # Discovery / import state. Keyed by ``device.name`` so the
     # WebSocket layer and ``devices/ignore`` can address entries

--- a/esphome_device_builder/controllers/devices/_state.py
+++ b/esphome_device_builder/controllers/devices/_state.py
@@ -39,10 +39,9 @@ class RegenState:
     """
     Bookkeeping for background ``--only-generate`` runs.
 
-    ``pending`` blocks duplicate schedules while a run is in flight;
-    ``failed`` blocks retries until the YAML changes (cleared by
-    ``scan_change``); ``retry_timers`` + ``retry_strikes`` drive the
-    bounded escalating retry between a failure and the disk stamp.
+    ``pending`` dedupes in-flight schedules, ``failed`` blocks retries
+    until the YAML changes, and the retry fields drive the bounded
+    escalating retry between a failure and the disk stamp.
     """
 
     pending: set[str] = field(default_factory=set)

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -333,6 +333,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
             self._unsub_job_completed()
             self._unsub_job_completed = None
         self._cancel_reprobe_timers()
+        self.state.regen.cancel_all_retry_timers()
         if self._mqtt_reconcile_handle is not None:
             self._mqtt_reconcile_handle.cancel()
             self._mqtt_reconcile_handle = None

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -100,7 +100,7 @@ _LOGGER = logging.getLogger(__name__)
 
 # How long the persisted "regen failed" stamp is honoured before a
 # restart-time check is allowed to re-spawn ``--only-generate`` for
-# the same untouched YAML. The in-memory ``_regenerate_failed`` set
+# the same untouched YAML. The in-memory ``state.regen.failed`` set
 # blocks within a session until the user edits the YAML; the TTL
 # only applies cross-restart, so a transient external problem
 # (git package server flaky, DNS hiccup) eventually recovers
@@ -177,13 +177,15 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         # Background ``--only-generate`` bookkeeping. ``--only-generate``
         # validates a YAML and writes its ``StorageJSON`` without doing
         # a real build; we trigger it whenever a YAML is saved or
-        # first-seen with no compile output. Three guards stop us from
+        # first-seen with no compile output. Four bounds stop us from
         # spinning:
-        #   * ``state.regenerate_pending`` — configurations already in
+        #   * ``state.regen.pending`` — configurations already in
         #     flight (scheduled but not yet finished). Skip duplicate
         #     schedules.
-        #   * ``state.regenerate_failed`` — YAMLs whose last attempt
-        #     failed. Don't retry until the file changes (cleared on
+        #   * a bounded escalating retry between a failure and giving
+        #     up (``storage_regen._MAX_REGEN_RETRIES`` attempts).
+        #   * ``state.regen.failed`` — YAMLs whose retry budget is
+        #     spent. Don't retry until the file changes (cleared on
         #     ``ScanChange.UPDATED``).
         #   * ``_regenerate_lock`` — serialises the actual subprocess
         #     so we don't spawn N esphome compiles in parallel.
@@ -333,7 +335,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
             self._unsub_job_completed()
             self._unsub_job_completed = None
         self._cancel_reprobe_timers()
-        self.state.regen.cancel_all_retry_timers()
+        await storage_regen.shutdown(self)
         if self._mqtt_reconcile_handle is not None:
             self._mqtt_reconcile_handle.cancel()
             self._mqtt_reconcile_handle = None

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -186,7 +186,8 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         #     up (``storage_regen._MAX_REGEN_RETRIES`` attempts).
         #   * ``state.regen.failed`` — YAMLs whose retry budget is
         #     spent. Don't retry until the file changes (cleared on
-        #     ``ScanChange.UPDATED``).
+        #     ``UPDATED``/``REMOVED`` along with the retry ladder, and
+        #     on ``RELOADED`` on its own).
         #   * ``_regenerate_lock`` — serialises the actual subprocess
         #     so we don't spawn N esphome compiles in parallel.
         self._regenerate_lock = asyncio.Lock()

--- a/esphome_device_builder/controllers/devices/scan_change.py
+++ b/esphome_device_builder/controllers/devices/scan_change.py
@@ -61,11 +61,11 @@ def on_scan_change(
         # waits out the remainder of the periodic interval.
         controller._state_monitor.address_retargeted(device.name)
     if kind in (ScanChange.UPDATED, ScanChange.RELOADED, ScanChange.REMOVED):
-        # YAML cache key changed (or a reload re-read it); clear any
-        # prior failure marker so the next edit gets a fresh chance at
-        # ``--only-generate`` (and re-creating a deleted file
-        # later doesn't inherit the old failure).
-        controller.state.regenerate_failed.discard(device.configuration)
+        # YAML cache key changed (or a reload re-read it); drop any
+        # prior failure marker and retry state so the next edit gets a
+        # fresh chance at ``--only-generate`` (and re-creating a
+        # deleted file later doesn't inherit the old failure).
+        controller.state.regen.reset(device.configuration)
     if kind in (ScanChange.ADDED, ScanChange.UPDATED, ScanChange.RELOADED):
         _sync_network_fingerprint(controller, kind, device)
     _nudge_mqtt(controller, kind, device, previous)

--- a/esphome_device_builder/controllers/devices/scan_change.py
+++ b/esphome_device_builder/controllers/devices/scan_change.py
@@ -60,12 +60,7 @@ def on_scan_change(
         # keeps pinging addresses resolved from the old one (#2486) or
         # waits out the remainder of the periodic interval.
         controller._state_monitor.address_retargeted(device.name)
-    if kind in (ScanChange.UPDATED, ScanChange.RELOADED, ScanChange.REMOVED):
-        # YAML cache key changed (or a reload re-read it); drop any
-        # prior failure marker and retry state so the next edit gets a
-        # fresh chance at ``--only-generate`` (and re-creating a
-        # deleted file later doesn't inherit the old failure).
-        controller.state.regen.reset(device.configuration)
+    _reconcile_regen_state(controller, kind, device)
     if kind in (ScanChange.ADDED, ScanChange.UPDATED, ScanChange.RELOADED):
         _sync_network_fingerprint(controller, kind, device)
     _nudge_mqtt(controller, kind, device, previous)
@@ -117,6 +112,25 @@ def on_scan_change(
         # Idempotent for the controller-driven delete/archive
         # paths; the safety net is external ``rm`` / rename.
         controller._metadata_store.clear_volatile(device.configuration)
+
+
+def _reconcile_regen_state(
+    controller: DevicesController,
+    kind: ScanChange,
+    device: Device,
+) -> None:
+    """Reset or trim the regen failure state after a scan change."""
+    if kind in (ScanChange.UPDATED, ScanChange.REMOVED):
+        # YAML cache key changed or the file is gone; drop the failure
+        # marker and any armed retry so the next sight starts fresh
+        # (re-creating a deleted file doesn't inherit the old failure).
+        controller.state.regen.reset(device.configuration)
+    elif kind is ScanChange.RELOADED:
+        # Metadata reload, YAML unchanged: a stale failure marker clears
+        # (a post-compile reload proves the YAML builds) but an armed
+        # retry survives — the cold-start refine's RELOADED must not
+        # cancel the only pending recovery.
+        controller.state.regen.failed.discard(device.configuration)
 
 
 def _reconcile_rename(

--- a/esphome_device_builder/controllers/devices/storage_regen.py
+++ b/esphome_device_builder/controllers/devices/storage_regen.py
@@ -37,10 +37,10 @@ def schedule(controller: DevicesController, configuration: str) -> None:
     """
     Run ``esphome compile --only-generate <yaml>`` in the background.
 
-    Three guards bound the spawn rate: in-memory pending +
-    failed sets (per-session), an on-disk failure stamp
-    (cross-restart, TTL-gated), and ``_regenerate_lock``
-    serialising the subprocess itself.
+    Spawn rate is bounded four ways: the in-memory pending + failed
+    sets (per-session), a bounded escalating retry between a failure
+    and the failed marker, an on-disk failure stamp (cross-restart,
+    TTL-gated), and ``_regenerate_lock`` serialising the subprocess.
     """
     if is_secrets_file(configuration):
         # Shared credentials, not a buildable config: no build dir to
@@ -61,6 +61,18 @@ def schedule(controller: DevicesController, configuration: str) -> None:
     controller._db.create_background_task(_run(controller, configuration))
 
 
+async def shutdown(controller: DevicesController) -> None:
+    """
+    Stamp configurations with an armed retry, then cancel every timer.
+
+    A restart inside the retry window must not forget the failure, or
+    a restart loop spends a fresh spawn budget every cycle.
+    """
+    for configuration in list(controller.state.regen.retry_timers):
+        await controller._stamp_regen_failure(configuration)
+    controller.state.regen.cancel_all_retry_timers()
+
+
 async def _run(controller: DevicesController, configuration: str) -> None:
     try:
         # Routed through the controller's bound delegates so
@@ -78,8 +90,14 @@ async def _run(controller: DevicesController, configuration: str) -> None:
             return
         if _schedule_retry(controller, configuration):
             return
+        attempts = controller.state.regen.retry_strikes.get(configuration, 0) + 1
         controller.state.regen.reset(configuration)
         controller.state.regen.failed.add(configuration)
+        _LOGGER.warning(
+            "Storage regenerate for %s failed %d times; giving up until the YAML changes",
+            configuration,
+            attempts,
+        )
         await controller._stamp_regen_failure(configuration)
     finally:
         controller.state.regen.pending.discard(configuration)

--- a/esphome_device_builder/controllers/devices/storage_regen.py
+++ b/esphome_device_builder/controllers/devices/storage_regen.py
@@ -25,6 +25,13 @@ _LOGGER = logging.getLogger(__name__)
 # later without having to touch the file.
 _REGEN_FAILURE_TTL_SECONDS: float = 3600.0
 
+# Every failure gets a bounded escalating retry before the stamp:
+# a transient environment failure (interrupted package clone, DNS,
+# network) is indistinguishable from a broken YAML without parsing
+# stderr, and parsing is brittle.
+_RETRY_BACKOFF_BASE_SECONDS: float = 30.0
+_MAX_REGEN_RETRIES: int = 3
+
 
 def schedule(controller: DevicesController, configuration: str) -> None:
     """
@@ -41,16 +48,16 @@ def schedule(controller: DevicesController, configuration: str) -> None:
         return
     if not controller.state.esphome_cmd:
         return  # ``start()`` hasn't run yet.
-    if configuration in controller.state.regenerate_pending:
+    if configuration in controller.state.regen.pending:
         return  # already scheduled.
-    if configuration in controller.state.regenerate_failed:
+    if configuration in controller.state.regen.failed:
         # Same-session retry would replay the same error.
         return
 
     # Mark synchronously so a second same-tick call sees the
     # marker before the coroutine yields. ``_run``'s finally
     # discards on completion.
-    controller.state.regenerate_pending.add(configuration)
+    controller.state.regen.pending.add(configuration)
     controller._db.create_background_task(_run(controller, configuration))
 
 
@@ -60,18 +67,22 @@ async def _run(controller: DevicesController, configuration: str) -> None:
         # tests patching any of the four async helpers on the
         # class still intercept.
         if await controller._regen_already_failed_recently_async(configuration):
-            controller.state.regenerate_failed.add(configuration)
+            controller.state.regen.failed.add(configuration)
             return
         async with controller._regenerate_lock:
             success = await controller._spawn_only_generate(configuration)
         if success:
+            controller.state.regen.reset(configuration)
             await controller._finalize_regen_success(configuration)
             await controller._scanner.reload(configuration)
-        else:
-            controller.state.regenerate_failed.add(configuration)
-            await controller._stamp_regen_failure(configuration)
+            return
+        if _schedule_retry(controller, configuration):
+            return
+        controller.state.regen.reset(configuration)
+        controller.state.regen.failed.add(configuration)
+        await controller._stamp_regen_failure(configuration)
     finally:
-        controller.state.regenerate_pending.discard(configuration)
+        controller.state.regen.pending.discard(configuration)
 
 
 async def spawn_only_generate(controller: DevicesController, configuration: str) -> bool:
@@ -80,7 +91,7 @@ async def spawn_only_generate(controller: DevicesController, configuration: str)
 
     Exceptions during spawn and non-zero exit codes both
     produce False so the caller takes the same
-    persist-failure-stamp branch.
+    retry-then-stamp branch.
     """
     config_path = str(controller._db.settings.rel_path(configuration))
     cmd = [*controller.state.esphome_cmd, "--dashboard", "compile", "--only-generate", config_path]
@@ -182,3 +193,28 @@ async def finalize_success(controller: DevicesController, configuration: str) ->
         )
         return
     _LOGGER.debug("Stored expected_config_hash for %s: %s", configuration, new_hash)
+
+
+def _schedule_retry(controller: DevicesController, configuration: str) -> bool:
+    """Arm one escalating-backoff retry; False once the budget is spent."""
+    regen = controller.state.regen
+    strikes = regen.retry_strikes.get(configuration, 0)
+    if strikes >= _MAX_REGEN_RETRIES:
+        return False
+    regen.retry_strikes[configuration] = strikes + 1
+    delay = _RETRY_BACKOFF_BASE_SECONDS * 2**strikes
+    _LOGGER.debug(
+        "Storage regenerate for %s failed; retrying in %.0fs (attempt %d/%d)",
+        configuration,
+        delay,
+        strikes + 1,
+        _MAX_REGEN_RETRIES,
+    )
+    loop = asyncio.get_running_loop()
+    regen.arm_retry(configuration, loop.call_later(delay, _fire_retry, controller, configuration))
+    return True
+
+
+def _fire_retry(controller: DevicesController, configuration: str) -> None:
+    controller.state.regen.retry_timers.pop(configuration, None)
+    schedule(controller, configuration)

--- a/esphome_device_builder/controllers/devices/storage_regen.py
+++ b/esphome_device_builder/controllers/devices/storage_regen.py
@@ -62,15 +62,13 @@ def schedule(controller: DevicesController, configuration: str) -> None:
 
 
 async def shutdown(controller: DevicesController) -> None:
-    """
-    Stamp configurations with an armed retry, then cancel every timer.
-
-    A restart inside the retry window must not forget the failure, or
-    a restart loop spends a fresh spawn budget every cycle.
-    """
-    for configuration in list(controller.state.regen.retry_timers):
-        await controller._stamp_regen_failure(configuration)
+    """Cancel every armed retry, stamping each so a restart remembers the failure."""
+    # Cancel before the stamp's executor hop, or a timer expiring in
+    # that window fires ``schedule`` after the task drain.
+    armed = list(controller.state.regen.retry_timers)
     controller.state.regen.cancel_all_retry_timers()
+    for configuration in armed:
+        await controller._stamp_regen_failure(configuration)
 
 
 async def _run(controller: DevicesController, configuration: str) -> None:

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -30,7 +30,7 @@ from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.controllers.devices._metadata_store import DeviceMetadataStore
 from esphome_device_builder.controllers.devices._pending_keys_store import PendingKeysStore
 from esphome_device_builder.controllers.devices._shared_sidecar import SharedSidecarClient
-from esphome_device_builder.controllers.devices._state import DevicesState
+from esphome_device_builder.controllers.devices._state import DevicesState, RegenState
 from esphome_device_builder.controllers.devices._yaml_search_cache import YamlSearchCache
 from esphome_device_builder.controllers.devices.import_upload import UploadTokens
 from esphome_device_builder.helpers.device_yaml import configuration_stem
@@ -474,9 +474,8 @@ def make_controller() -> MakeControllerFactory:
     copy-pasting (and a ``DevicesController`` field rename only
     has to update one site).
 
-    ``with_regenerate_state=True`` adds the three guards
-    (``_regenerate_pending`` / ``_regenerate_failed`` /
-    ``_regenerate_lock``) plus a real
+    ``with_regenerate_state=True`` adds a fresh ``state.regen``
+    plus the ``_regenerate_lock`` and a real
     ``_db.create_background_task`` that records spawned tasks on
     ``controller._spawned_tasks`` (test-only attr) so callers can
     ``await`` them — used by the ``_schedule_storage_regenerate``
@@ -594,8 +593,7 @@ def make_controller() -> MakeControllerFactory:
 
             controller._db.create_background_task = _create_bg
             controller._spawned_tasks = spawned_tasks  # type: ignore[attr-defined]
-            controller.state.regenerate_pending = set()
-            controller.state.regenerate_failed = set()
+            controller.state.regen = RegenState()
             controller._regenerate_lock = asyncio.Lock()
 
         controller.state.esphome_cmd = esphome_cmd if esphome_cmd is not None else []

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -26,6 +26,7 @@ Grouped by surface:
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock
@@ -1082,7 +1083,7 @@ def test_get_devices_bridge_returns_scanner_property(
 # ---------------------------------------------------------------------------
 
 
-def test_on_scan_change_updated_clears_regenerate_failed_marker(
+async def test_on_scan_change_updated_clears_regenerate_failed_marker(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
     """A YAML edit clears the prior storage-regenerate failure marker.
@@ -1094,12 +1095,18 @@ def test_on_scan_change_updated_clears_regenerate_failed_marker(
     storage refresh forever.
     """
     controller = make_controller(tmp_path, with_state_monitor=True, with_regenerate_state=True)
-    controller.state.regenerate_failed.add("kitchen.yaml")
+    controller.state.regen.failed.add("kitchen.yaml")
+    controller.state.regen.retry_strikes["kitchen.yaml"] = 1
+    handle = asyncio.get_running_loop().call_later(30.0, lambda: None)
+    controller.state.regen.retry_timers["kitchen.yaml"] = handle
     device = _device("kitchen")
 
     controller._on_scan_change(ScanChange.UPDATED, device)
 
-    assert "kitchen.yaml" not in controller.state.regenerate_failed
+    assert "kitchen.yaml" not in controller.state.regen.failed
+    assert handle.cancelled()
+    assert controller.state.regen.retry_timers == {}
+    assert controller.state.regen.retry_strikes == {}
 
 
 def test_on_scan_change_updated_fires_yaml_updated(

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -1109,6 +1109,31 @@ async def test_on_scan_change_updated_clears_regenerate_failed_marker(
     assert controller.state.regen.retry_strikes == {}
 
 
+async def test_on_scan_change_reloaded_keeps_armed_retry(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A metadata reload clears the failure marker but not the armed retry.
+
+    The cold-start refine emits RELOADED for every device; cancelling
+    the retry there would drop the only pending recovery for a config
+    whose first regen failed.
+    """
+    controller = make_controller(tmp_path, with_state_monitor=True, with_regenerate_state=True)
+    controller.state.regen.failed.add("kitchen.yaml")
+    controller.state.regen.retry_strikes["kitchen.yaml"] = 1
+    handle = asyncio.get_running_loop().call_later(30.0, lambda: None)
+    controller.state.regen.retry_timers["kitchen.yaml"] = handle
+    device = _device("kitchen")
+
+    controller._on_scan_change(ScanChange.RELOADED, device)
+
+    assert "kitchen.yaml" not in controller.state.regen.failed
+    assert not handle.cancelled()
+    assert controller.state.regen.retry_timers == {"kitchen.yaml": handle}
+    assert controller.state.regen.retry_strikes == {"kitchen.yaml": 1}
+    handle.cancel()
+
+
 def test_on_scan_change_updated_fires_yaml_updated(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -1083,7 +1083,7 @@ def test_get_devices_bridge_returns_scanner_property(
 # ---------------------------------------------------------------------------
 
 
-async def test_on_scan_change_updated_clears_regenerate_failed_marker(
+async def test_on_scan_change_updated_resets_regen_state(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
     """A YAML edit clears the prior storage-regenerate failure marker.

--- a/tests/controllers/devices/test_encryption_key.py
+++ b/tests/controllers/devices/test_encryption_key.py
@@ -264,7 +264,7 @@ async def test_set_encryption_key_never_compiled_package_device_gets_key(
     _configure(ctrl, tmp_path, yaml_text, api_enabled=False)
     # The bypass-init _db mock would swallow the post-persist regen
     # task's coroutine; pre-marking pending short-circuits the schedule.
-    ctrl.state.regenerate_pending.add("kitchen.yaml")
+    ctrl.state.regen.pending.add("kitchen.yaml")
 
     result = await ctrl.set_encryption_key(name="kitchen", key=KEY, mac="aabbccddeeff")
 

--- a/tests/controllers/devices/test_metadata_resolver.py
+++ b/tests/controllers/devices/test_metadata_resolver.py
@@ -279,7 +279,7 @@ def test_added_device_without_hash_triggers_regenerate(
     controller = DevicesController.__new__(DevicesController)
     controller._db = MagicMock()
     controller.state = DevicesState()
-    controller.state.regenerate_failed = set()
+    controller.state.regen.failed = set()
     controller._state_monitor = RecordingStateMonitor()
     controller._metadata_store = MagicMock(**{"get.return_value": {}})
     regenerated: list[str] = []
@@ -325,7 +325,7 @@ def test_added_device_fully_populated_does_not_regenerate(
     controller = DevicesController.__new__(DevicesController)
     controller._db = MagicMock()
     controller.state = DevicesState()
-    controller.state.regenerate_failed = set()
+    controller.state.regen.failed = set()
     controller._state_monitor = MagicMock()
     controller._metadata_store = MagicMock(**{"get.return_value": {}})
     regenerated: list[str] = []

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -1180,6 +1180,50 @@ async def test_shutdown_stamps_armed_retries(
     assert "regen_failed_at" in _read_store(controller, "kitchen.yaml")
 
 
+async def test_stop_stamps_armed_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """``stop()`` reaches the shutdown stamp for an armed retry."""
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+        return _FakeProc(returncode=2, stderr=b"fatal: could not clone")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        _fake_spawn,
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+    assert "kitchen.yaml" in controller.state.regen.retry_timers
+
+    # The bypass-init controller lacks the collaborators ``stop()``
+    # tears down after the regen shutdown; stub just enough to reach it.
+    controller._scanner.stop = AsyncMock()
+    for attr, value in {
+        "_stopped": False,
+        "_unsub_job_completed": None,
+        "_reprobe_timers": {},
+        "_mqtt_reconcile_handle": None,
+        "_mqtt_reconcile_tasks": set(),
+        "_refine_task": None,
+        "_build_size": AsyncMock(),
+        "_mqtt_coordinator": AsyncMock(),
+        "_state_monitor": AsyncMock(),
+        "_shutdown_callbacks": [],
+    }.items():
+        setattr(controller, attr, value)
+
+    await controller.stop()
+
+    assert controller.state.regen.retry_timers == {}
+    assert "regen_failed_at" in _read_store(controller, "kitchen.yaml")
+
+
 async def test_arm_retry_replaces_and_cancels_prior_handle() -> None:
     """Re-arming for the same configuration cancels the prior timer."""
     state = RegenState()

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -1153,6 +1153,22 @@ async def test_regenerate_retry_budget_exhausts_to_stamp(
     assert "regen_failed_at" in _read_store(controller, "kitchen.yaml")
 
 
+async def test_arm_retry_replaces_and_cancels_prior_handle() -> None:
+    """Re-arming for the same configuration cancels the prior timer."""
+    state = RegenState()
+    loop = asyncio.get_running_loop()
+    first = loop.call_later(30.0, lambda: None)
+    second = loop.call_later(30.0, lambda: None)
+
+    state.arm_retry("kitchen.yaml", first)
+    state.arm_retry("kitchen.yaml", second)
+
+    assert first.cancelled()
+    assert not second.cancelled()
+    assert state.retry_timers == {"kitchen.yaml": second}
+    state.cancel_all_retry_timers()
+
+
 async def test_cancel_all_retry_timers_cancels_pending_handles() -> None:
     """``stop()``'s mass-cancel leaves no live retry timer or strike behind."""
     state = RegenState()

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -23,7 +23,7 @@ import asyncio
 import logging
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -33,7 +33,7 @@ from esphome_device_builder.controllers.devices._state import RegenState
 from tests._storage_fixtures import write_storage_json
 from tests.conftest import make_device, wait_until
 
-from .conftest import MakeControllerFactory
+from .conftest import MakeControllerFactory, MakeDbFactory
 
 
 def _seed_store(controller: DevicesController, filename: str, **fields: Any) -> None:
@@ -1180,48 +1180,25 @@ async def test_shutdown_stamps_armed_retries(
     assert "regen_failed_at" in _read_store(controller, "kitchen.yaml")
 
 
-async def test_stop_stamps_armed_retries(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    make_controller: MakeControllerFactory,
-) -> None:
+async def test_stop_stamps_armed_retries(tmp_path: Path, make_db: MakeDbFactory) -> None:
     """``stop()`` reaches the shutdown stamp for an armed retry."""
-    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    controller = DevicesController(make_db(tmp_path))
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
-
-    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
-        return _FakeProc(returncode=2, stderr=b"fatal: could not clone")
-
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
-        _fake_spawn,
+    controller.state.regen.retry_strikes["kitchen.yaml"] = 1
+    controller.state.regen.retry_timers["kitchen.yaml"] = asyncio.get_running_loop().call_later(
+        30.0, lambda: None
     )
 
-    controller._schedule_storage_regenerate("kitchen.yaml")
-    await _drain(controller)
-    assert "kitchen.yaml" in controller.state.regen.retry_timers
-
-    # The bypass-init controller lacks the collaborators ``stop()``
-    # tears down after the regen shutdown; stub just enough to reach it.
-    controller._scanner.stop = AsyncMock()
-    for attr, value in {
-        "_stopped": False,
-        "_unsub_job_completed": None,
-        "_reprobe_timers": {},
-        "_mqtt_reconcile_handle": None,
-        "_mqtt_reconcile_tasks": set(),
-        "_refine_task": None,
-        "_build_size": AsyncMock(),
-        "_mqtt_coordinator": AsyncMock(),
-        "_state_monitor": AsyncMock(),
-        "_shutdown_callbacks": [],
-    }.items():
-        setattr(controller, attr, value)
-
-    await controller.stop()
+    with (
+        patch.multiple(controller._state_monitor, stop=AsyncMock()),
+        patch.multiple(controller._mqtt_coordinator, stop=AsyncMock()),
+        patch.multiple(controller._build_size, stop=AsyncMock()),
+        patch.multiple(controller._scanner, stop=AsyncMock()),
+    ):
+        await controller.stop()
 
     assert controller.state.regen.retry_timers == {}
-    assert "regen_failed_at" in _read_store(controller, "kitchen.yaml")
+    assert "regen_failed_at" in controller._metadata_store.get("kitchen.yaml")
 
 
 async def test_arm_retry_replaces_and_cancels_prior_handle() -> None:

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -1153,6 +1153,33 @@ async def test_regenerate_retry_budget_exhausts_to_stamp(
     assert "regen_failed_at" in _read_store(controller, "kitchen.yaml")
 
 
+async def test_shutdown_stamps_armed_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A shutdown inside the retry window persists the failure stamp."""
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+        return _FakeProc(returncode=2, stderr=b"fatal: could not clone")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        _fake_spawn,
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+    assert "kitchen.yaml" in controller.state.regen.retry_timers
+
+    await storage_regen.shutdown(controller)
+
+    assert controller.state.regen.retry_timers == {}
+    assert "regen_failed_at" in _read_store(controller, "kitchen.yaml")
+
+
 async def test_arm_retry_replaces_and_cancels_prior_handle() -> None:
     """Re-arming for the same configuration cancels the prior timer."""
     state = RegenState()

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -28,9 +28,10 @@ from unittest.mock import AsyncMock
 import pytest
 
 from esphome_device_builder.controllers._device_scanner import ScanChange
-from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.controllers.devices import DevicesController, storage_regen
+from esphome_device_builder.controllers.devices._state import RegenState
 from tests._storage_fixtures import write_storage_json
-from tests.conftest import make_device
+from tests.conftest import make_device, wait_until
 
 from .conftest import MakeControllerFactory
 
@@ -69,6 +70,11 @@ class _FakeProc:
 
     async def communicate(self) -> tuple[bytes, bytes]:
         return (b"", self._stderr)
+
+
+def _spend_retry_budget(controller: DevicesController, configuration: str) -> None:
+    """Consume the retry budget so the next failure stamps immediately."""
+    controller.state.regen.retry_strikes[configuration] = storage_regen._MAX_REGEN_RETRIES
 
 
 async def _drain(controller: DevicesController) -> None:
@@ -143,9 +149,9 @@ async def test_regenerate_spawns_esphome_compile_only_generate(
     reload_calls = [c for c in controller._scanner.calls if c[0] == "reload"]
     assert reload_calls == [("reload", "kitchen.yaml")]
     # Pending guard cleared in the ``finally``.
-    assert controller.state.regenerate_pending == set()
+    assert controller.state.regen.pending == set()
     # Success → not in failed set.
-    assert controller.state.regenerate_failed == set()
+    assert controller.state.regen.failed == set()
 
 
 async def test_out_of_band_network_edit_spawns_only_generate(
@@ -210,7 +216,7 @@ def test_regenerate_skips_when_esphome_cmd_unset(
     controller._schedule_storage_regenerate("kitchen.yaml")
 
     assert controller._spawned_tasks == []  # type: ignore[attr-defined]
-    assert controller.state.regenerate_pending == set()
+    assert controller.state.regen.pending == set()
 
 
 def test_regenerate_skips_secrets_yaml(
@@ -226,7 +232,7 @@ def test_regenerate_skips_secrets_yaml(
     controller._schedule_storage_regenerate("secrets.yaml")
 
     assert controller._spawned_tasks == []  # type: ignore[attr-defined]
-    assert controller.state.regenerate_pending == set()
+    assert controller.state.regen.pending == set()
 
 
 def test_regenerate_skips_duplicate_schedule(
@@ -239,7 +245,7 @@ def test_regenerate_skips_duplicate_schedule(
     same YAML.
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
-    controller.state.regenerate_pending.add("kitchen.yaml")
+    controller.state.regen.pending.add("kitchen.yaml")
 
     controller._schedule_storage_regenerate("kitchen.yaml")
 
@@ -257,7 +263,7 @@ def test_regenerate_skips_after_failed_marker(
     bad input.
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
-    controller.state.regenerate_failed.add("kitchen.yaml")
+    controller.state.regen.failed.add("kitchen.yaml")
 
     controller._schedule_storage_regenerate("kitchen.yaml")
 
@@ -274,13 +280,14 @@ async def test_regenerate_marks_failed_on_nonzero_exit(
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """``esphome compile`` exiting non-zero → no reload, ``_regenerate_failed`` set.
+    """Non-zero exit with the retry budget spent → no reload, failure remembered.
 
     Captures the typical "user saved a YAML with a syntax error"
     case. The controller has to remember the failure so the
     next save (with the same broken YAML) doesn't re-spawn.
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    _spend_retry_budget(controller, "kitchen.yaml")
 
     async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
         return _FakeProc(returncode=1, stderr=b"YAML parse error at line 3")
@@ -302,9 +309,9 @@ async def test_regenerate_marks_failed_on_nonzero_exit(
     # Failure → reload skipped, persist skipped, failed marker set.
     assert not any(c[0] == "reload" for c in controller._scanner.calls)
     assert persist_calls == []
-    assert controller.state.regenerate_failed == {"kitchen.yaml"}
+    assert controller.state.regen.failed == {"kitchen.yaml"}
     # Pending cleared via the ``finally``.
-    assert controller.state.regenerate_pending == set()
+    assert controller.state.regen.pending == set()
 
 
 async def test_regenerate_marks_failed_on_spawn_oserror(
@@ -312,7 +319,7 @@ async def test_regenerate_marks_failed_on_spawn_oserror(
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """``create_subprocess_exec`` raising → ``_regenerate_failed`` set.
+    """Spawn raising with the retry budget spent → failure remembered.
 
     Triggers when ``esphome`` is missing from PATH (broken pip
     install, dashboard running outside its venv). The pending
@@ -321,6 +328,7 @@ async def test_regenerate_marks_failed_on_spawn_oserror(
     duplicate-schedule guard.
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    _spend_retry_budget(controller, "kitchen.yaml")
 
     async def _broken_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
         raise OSError("esphome: command not found")
@@ -341,8 +349,8 @@ async def test_regenerate_marks_failed_on_spawn_oserror(
     await _drain(controller)
 
     assert not any(c[0] == "reload" for c in controller._scanner.calls)
-    assert controller.state.regenerate_failed == {"kitchen.yaml"}
-    assert controller.state.regenerate_pending == set()
+    assert controller.state.regen.failed == {"kitchen.yaml"}
+    assert controller.state.regen.pending == set()
 
 
 # ---------------------------------------------------------------------------
@@ -386,10 +394,10 @@ async def test_regenerate_dedupes_same_tick_calls(
     assert len(controller._spawned_tasks) == 1  # type: ignore[attr-defined]
     # Sync ``.add()`` in ``schedule`` is the load-bearing piece —
     # without it the second call wouldn't see the marker yet.
-    assert controller.state.regenerate_pending == {"kitchen.yaml"}
+    assert controller.state.regen.pending == {"kitchen.yaml"}
 
     await _drain(controller)
-    assert controller.state.regenerate_pending == set()
+    assert controller.state.regen.pending == set()
 
 
 async def test_regenerate_pending_blocks_in_flight_dupe(
@@ -426,7 +434,7 @@ async def test_regenerate_pending_blocks_in_flight_dupe(
 
     controller._schedule_storage_regenerate("kitchen.yaml")
     await asyncio.wait_for(in_flight.wait(), timeout=2.0)
-    assert controller.state.regenerate_pending == {"kitchen.yaml"}
+    assert controller.state.regen.pending == {"kitchen.yaml"}
 
     # Second schedule while the first is still inside ``communicate``.
     controller._schedule_storage_regenerate("kitchen.yaml")
@@ -435,7 +443,7 @@ async def test_regenerate_pending_blocks_in_flight_dupe(
 
     release.set()
     await _drain(controller)
-    assert controller.state.regenerate_pending == set()
+    assert controller.state.regen.pending == set()
 
 
 # ---------------------------------------------------------------------------
@@ -448,16 +456,17 @@ async def test_regenerate_persists_mtime_and_wallclock_on_failure(
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """Failure → YAML mtime + wall-clock stamped into the metadata sidecar.
+    """Budget-spent failure → YAML mtime + wall-clock stamped into the sidecar.
 
     The whole point of the cross-restart guard: a backend reboot
     that re-encounters the same broken YAML reads these stamps,
     sees the mtime hasn't moved AND the failure is fresh, and
     skips replaying the regen. The wall-clock side feeds the
-    TTL — without it, a transient external problem (git package
-    server flake) would never get re-checked.
+    TTL — without it, a persistent external problem would never
+    get re-checked.
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    _spend_retry_budget(controller, "kitchen.yaml")
     yaml_path = tmp_path / "kitchen.yaml"
     yaml_path.write_text("not: valid: yaml\n", encoding="utf-8")
     expected_mtime = yaml_path.stat().st_mtime
@@ -493,13 +502,14 @@ async def test_regenerate_persists_stamp_on_spawn_oserror(
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """Spawn-raises path also stamps the failure marker.
+    """Spawn-raises path also stamps the failure marker once the budget is spent.
 
     Both failure exits — non-zero returncode and ``OSError`` from
     the spawn itself — feed the same persistent guard. Catches
     regressions where one branch persists and the other doesn't.
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    _spend_retry_budget(controller, "kitchen.yaml")
     yaml_path = tmp_path / "kitchen.yaml"
     yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
     expected_mtime = yaml_path.stat().st_mtime
@@ -621,7 +631,7 @@ async def test_regenerate_skips_when_stamp_fresh_and_mtime_matches(
     # The skip path also seeds the in-memory set so subsequent
     # same-session schedules hit the cheaper guard instead of
     # re-reading the sidecar.
-    assert controller.state.regenerate_failed == {"kitchen.yaml"}
+    assert controller.state.regen.failed == {"kitchen.yaml"}
 
 
 async def test_regenerate_retries_when_stamp_older_than_ttl(
@@ -1032,3 +1042,127 @@ async def test_regenerate_success_clears_stamp_when_build_info_missing(
         "Could not read config_hash from build_info.json" in record.message
         for record in caplog.records
     )
+
+
+# ---------------------------------------------------------------------------
+# Bounded retry before the stamp
+# ---------------------------------------------------------------------------
+
+
+async def test_regenerate_failure_arms_retry_instead_of_stamp(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A first failure arms a backoff retry: no failed marker, no disk stamp."""
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+        return _FakeProc(returncode=2, stderr=b"fatal: could not clone")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        _fake_spawn,
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+
+    assert controller.state.regen.failed == set()
+    assert "regen_failed_at" not in _read_store(controller, "kitchen.yaml")
+    assert "kitchen.yaml" in controller.state.regen.retry_timers
+    assert controller.state.regen.retry_strikes == {"kitchen.yaml": 1}
+    controller.state.regen.cancel_all_retry_timers()
+
+
+async def test_regenerate_retry_fires_and_succeeds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """The armed retry re-runs the regen; a success clears the retry state."""
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.storage_regen._RETRY_BACKOFF_BASE_SECONDS",
+        0.0,
+    )
+    outcomes = [_FakeProc(returncode=2, stderr=b"fatal: clone interrupted"), _FakeProc()]
+
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+        return outcomes.pop(0)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        _fake_spawn,
+    )
+    monkeypatch.setattr(DevicesController, "_finalize_regen_success", AsyncMock())
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    # The success cycle's scanner reload is the last observable step.
+    await wait_until(
+        lambda: any(c[0] == "reload" for c in controller._scanner.calls), 1, "scanner reload"
+    )
+    await _drain(controller)
+
+    assert outcomes == []
+    assert controller.state.regen.failed == set()
+    assert controller.state.regen.retry_timers == {}
+    assert controller.state.regen.retry_strikes == {}
+    reload_calls = [c for c in controller._scanner.calls if c[0] == "reload"]
+    assert reload_calls == [("reload", "kitchen.yaml")]
+
+
+async def test_regenerate_retry_budget_exhausts_to_stamp(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Persistent failure spends the budget, then stamps and marks failed."""
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    (tmp_path / "kitchen.yaml").write_text("not: valid: yaml\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.storage_regen._RETRY_BACKOFF_BASE_SECONDS",
+        0.0,
+    )
+    spawns = 0
+
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+        nonlocal spawns
+        spawns += 1
+        return _FakeProc(returncode=1, stderr=b"YAML parse error")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        _fake_spawn,
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    # The disk stamp is the terminal step of the exhausted-budget path.
+    await wait_until(
+        lambda: "regen_failed_at" in _read_store(controller, "kitchen.yaml"),
+        1,
+        "failure stamp",
+    )
+    await _drain(controller)
+
+    assert spawns == 1 + storage_regen._MAX_REGEN_RETRIES
+    assert controller.state.regen.failed == {"kitchen.yaml"}
+    assert controller.state.regen.retry_timers == {}
+    assert "regen_failed_at" in _read_store(controller, "kitchen.yaml")
+
+
+async def test_cancel_all_retry_timers_cancels_pending_handles() -> None:
+    """``stop()``'s mass-cancel leaves no live retry timer or strike behind."""
+    state = RegenState()
+    loop = asyncio.get_running_loop()
+    handles = [loop.call_later(30.0, lambda: None) for _ in range(2)]
+    state.retry_timers = {"a.yaml": handles[0], "b.yaml": handles[1]}
+    state.retry_strikes = {"a.yaml": 2}
+
+    state.cancel_all_retry_timers()
+
+    assert all(handle.cancelled() for handle in handles)
+    assert state.retry_timers == {}
+    assert state.retry_strikes == {}

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -84,7 +84,7 @@ async def _drain(controller: DevicesController) -> None:
     regenerate coroutine fails the test instead of silently masking
     as ``None`` in the gather result. Production swallows the error
     branches in its own ``try/except`` (and asserts on
-    ``_regenerate_failed``); anything reaching the gather here is a
+    ``state.regen.failed``); anything reaching the gather here is a
     bug we want surfaced.
     """
     pending: list[asyncio.Task] = controller._spawned_tasks  # type: ignore[attr-defined]
@@ -208,7 +208,7 @@ def test_regenerate_skips_when_esphome_cmd_unset(
 
     Synchronous test — the guard is the very first check in the
     function and short-circuits before scheduling the
-    background task. No spawn, no _regenerate_pending mutation.
+    background task. No spawn, no ``state.regen.pending`` mutation.
     """
     # ``esphome_cmd=[]`` triggers the early-return guard.
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=[])
@@ -238,7 +238,7 @@ def test_regenerate_skips_secrets_yaml(
 def test_regenerate_skips_duplicate_schedule(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """Configuration already in ``_regenerate_pending`` → second schedule is a no-op.
+    """Configuration already in ``state.regen.pending`` → second schedule is a no-op.
 
     Without this, repeated saves while a regenerate is already
     in flight would queue N background tasks all racing on the
@@ -255,7 +255,7 @@ def test_regenerate_skips_duplicate_schedule(
 def test_regenerate_skips_after_failed_marker(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """Configuration in ``_regenerate_failed`` → no respin.
+    """Configuration in ``state.regen.failed`` → no respin.
 
     The marker is cleared by ``_on_scan_change`` when the YAML's
     cache key changes (i.e. the user actually edited it). Until
@@ -368,7 +368,7 @@ async def test_regenerate_dedupes_same_tick_calls(
 
     Pins the pre-yield window the in-flight test below can't
     reach; the second sync call has to see
-    ``_regenerate_pending`` populated before the spawned
+    ``state.regen.pending`` populated before the spawned
     coroutine runs.
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
@@ -592,9 +592,9 @@ async def test_regenerate_skips_when_stamp_fresh_and_mtime_matches(
     """Cross-restart skip: persisted stamp matches and is within TTL → no spawn.
 
     Simulates the "broken config + backend restart" case. The
-    in-memory ``_regenerate_failed`` set is empty (fresh process)
+    in-memory ``state.regen.failed`` set is empty (fresh process)
     but the sidecar carries the prior backend's failure stamp;
-    the schedule call must populate ``_regenerate_failed`` and
+    the schedule call must populate ``state.regen.failed`` and
     skip the spawn rather than burning another subprocess.
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])

--- a/tests/controllers/devices/test_subscribe_reachability.py
+++ b/tests/controllers/devices/test_subscribe_reachability.py
@@ -479,7 +479,7 @@ def test_scan_change_removed_clears_tracker(
     # don't have to hand-build an import_discovery. The tracker
     # clear is what we're pinning down.
     controller._state_monitor.importable.revisit_all_importables = MagicMock()
-    controller.state.regenerate_failed = set()
+    controller.state.regen.failed = set()
 
     controller._on_scan_change(ScanChange.REMOVED, device)
 


### PR DESCRIPTION
# What does this implement/fix?

A transient failure of the background `esphome compile --only-generate` used to stamp the one hour suppression immediately, so a fresh packages config hit by the cold start clone race sat with empty `loaded_integrations` and no config hash until the YAML changed. The race itself is fixed upstream, esphome 2026.7.4 locks the clone cache (esphome/esphome#17923) and this repo already floors that release; what remained here is the stamp behaviour.

Every regen failure now gets a bounded escalating retry (30s, 60s, 120s) before the session failure marker and the disk stamp. No stderr classification, a transient environment failure is indistinguishable from a broken YAML without parsing subprocess output, and the budget keeps broken config churn to a few fast runs. A retry success also heals the scanner side for free; the reload it triggers re-runs `load_device_yaml`, whose swallowed package resolve failure produced the degraded device row. The regen bookkeeping moved into a `RegenState` dataclass with the lockstep transitions as methods.

Known residuals are tracked in #2534: out of band edits still schedule no regen on their own, and the session failure marker has no TTL, so an outage outliving the retry window sticks until a YAML change or restart.

**Related issue or feature (if applicable):**

- fixes #2532

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
