### PR TITLE
Hoist a shared per-configuration TimerRegistry

### DIFF
--- a/esphome_device_builder/controllers/devices/_state.py
+++ b/esphome_device_builder/controllers/devices/_state.py
@@ -28,9 +28,9 @@ What lives here vs on the controller:
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass, field
 
+from ...helpers.timer_registry import TimerRegistry
 from ...models import AdoptableDevice
 
 
@@ -46,30 +46,20 @@ class RegenState:
 
     pending: set[str] = field(default_factory=set)
     failed: set[str] = field(default_factory=set)
-    retry_timers: dict[str, asyncio.TimerHandle] = field(default_factory=dict)
+    retry_timers: TimerRegistry[str] = field(default_factory=TimerRegistry)
     retry_strikes: dict[str, int] = field(default_factory=dict)
-
-    def arm_retry(self, configuration: str, handle: asyncio.TimerHandle) -> None:
-        """Install *handle* as the pending retry, cancelling any prior one."""
-        existing = self.retry_timers.pop(configuration, None)
-        if existing is not None:
-            existing.cancel()
-        self.retry_timers[configuration] = handle
 
     def reset(self, configuration: str) -> None:
         """Drop *configuration*'s failure marker, retry timer, and strikes."""
         self.failed.discard(configuration)
-        handle = self.retry_timers.pop(configuration, None)
-        if handle is not None:
-            handle.cancel()
+        self.retry_timers.discard(configuration)
         self.retry_strikes.pop(configuration, None)
 
-    def cancel_all_retry_timers(self) -> None:
-        """Cancel every pending retry timer and drop the strike counts."""
-        for handle in self.retry_timers.values():
-            handle.cancel()
-        self.retry_timers.clear()
+    def cancel_all_retry_timers(self) -> list[str]:
+        """Cancel every pending retry timer, drop the strikes; return the armed keys."""
+        armed = self.retry_timers.cancel_all()
         self.retry_strikes.clear()
+        return armed
 
 
 @dataclass
@@ -86,6 +76,10 @@ class DevicesState:
     # ``_regenerate_lock`` (kept on the controller) serialises the
     # actual subprocess.
     regen: RegenState = field(default_factory=RegenState)
+
+    # Post-flash Native-API version re-probe timers, armed and consumed
+    # by ``firmware_sync``; ``stop()`` mass-cancels.
+    reprobe_timers: TimerRegistry[str] = field(default_factory=TimerRegistry)
 
     # Discovery / import state. Keyed by ``device.name`` so the
     # WebSocket layer and ``devices/ignore`` can address entries

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -134,10 +134,6 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         self._unsub_job_completed: Any = None
         # Guards poll() from re-arming a torn-down scanner during the shutdown drain.
         self._stopped = False
-        # Pending post-flash version re-probe timers, keyed on
-        # configuration so a re-flash cancels its predecessor; cancelled
-        # en masse in stop().
-        self._reprobe_timers: dict[str, asyncio.TimerHandle] = {}
         self._refine_task: asyncio.Task[None] | None = None
         # Debounced scan-change → MQTT reconcile nudge (see
         # ``schedule_mqtt_reconcile``).
@@ -335,7 +331,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         if self._unsub_job_completed is not None:
             self._unsub_job_completed()
             self._unsub_job_completed = None
-        self._cancel_reprobe_timers()
+        self.state.reprobe_timers.cancel_all()
         await storage_regen.shutdown(self)
         if self._mqtt_reconcile_handle is not None:
             self._mqtt_reconcile_handle.cancel()
@@ -1307,12 +1303,6 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
 
     def _schedule_version_reprobe(self, configuration: str) -> None:
         firmware_sync.schedule_version_reprobe(self, configuration)
-
-    def _cancel_reprobe_timers(self) -> None:
-        """Cancel any pending post-flash re-probe timers."""
-        for handle in self._reprobe_timers.values():
-            handle.cancel()
-        self._reprobe_timers.clear()
 
     def _persist_build_size(self, configuration: str, result: BuildSizeRefreshResult) -> None:
         """Merge a fresh build-size triple into the metadata store."""

--- a/esphome_device_builder/controllers/devices/firmware_sync.py
+++ b/esphome_device_builder/controllers/devices/firmware_sync.py
@@ -208,9 +208,6 @@ def schedule_version_reprobe(controller: DevicesController, configuration: str) 
     tracked on the controller so ``stop`` can cancel anything still
     pending.
     """
-    existing = controller._reprobe_timers.pop(configuration, None)
-    if existing is not None:
-        existing.cancel()
     device = controller._scanner.get_by_configuration(configuration)
     loop = asyncio.get_running_loop()
     delay: float
@@ -224,8 +221,11 @@ def schedule_version_reprobe(controller: DevicesController, configuration: str) 
     else:
         delay = _POST_FLASH_VERSION_REPROBE_DELAY
         interval = deadline = None
-    controller._reprobe_timers[configuration] = loop.call_later(
-        delay, _fire_version_reprobe, controller, configuration, deadline, interval
+    controller.state.reprobe_timers.arm(
+        configuration,
+        loop.call_later(
+            delay, _fire_version_reprobe, controller, configuration, deadline, interval
+        ),
     )
 
 
@@ -276,7 +276,7 @@ def _fire_version_reprobe(
     once the device re-announces; and the api-info sweep serialises and
     caps probes, so this never fans out into concurrent dials.
     """
-    controller._reprobe_timers.pop(configuration, None)
+    controller.state.reprobe_timers.discard(configuration)
     device = controller._scanner.get_by_configuration(configuration)
     if device is None:
         return
@@ -285,8 +285,11 @@ def _fire_version_reprobe(
         return
     loop = asyncio.get_running_loop()
     if loop.time() + interval <= deadline:
-        controller._reprobe_timers[configuration] = loop.call_later(
-            interval, _fire_version_reprobe, controller, configuration, deadline, interval
+        controller.state.reprobe_timers.arm(
+            configuration,
+            loop.call_later(
+                interval, _fire_version_reprobe, controller, configuration, deadline, interval
+            ),
         )
 
 

--- a/esphome_device_builder/controllers/devices/storage_regen.py
+++ b/esphome_device_builder/controllers/devices/storage_regen.py
@@ -65,9 +65,7 @@ async def shutdown(controller: DevicesController) -> None:
     """Cancel every armed retry, stamping each so a restart remembers the failure."""
     # Cancel before the stamp's executor hop, or a timer expiring in
     # that window fires ``schedule`` after the task drain.
-    armed = list(controller.state.regen.retry_timers)
-    controller.state.regen.cancel_all_retry_timers()
-    for configuration in armed:
+    for configuration in controller.state.regen.cancel_all_retry_timers():
         await controller._stamp_regen_failure(configuration)
 
 
@@ -227,10 +225,12 @@ def _schedule_retry(controller: DevicesController, configuration: str) -> bool:
         _MAX_REGEN_RETRIES,
     )
     loop = asyncio.get_running_loop()
-    regen.arm_retry(configuration, loop.call_later(delay, _fire_retry, controller, configuration))
+    regen.retry_timers.arm(
+        configuration, loop.call_later(delay, _fire_retry, controller, configuration)
+    )
     return True
 
 
 def _fire_retry(controller: DevicesController, configuration: str) -> None:
-    controller.state.regen.retry_timers.pop(configuration, None)
+    controller.state.regen.retry_timers.discard(configuration)
     schedule(controller, configuration)

--- a/esphome_device_builder/helpers/timer_registry.py
+++ b/esphome_device_builder/helpers/timer_registry.py
@@ -1,0 +1,45 @@
+"""Per-key ``asyncio.TimerHandle`` bookkeeping with cancel-and-replace arming."""
+
+from __future__ import annotations
+
+import asyncio
+
+
+class TimerRegistry[K]:
+    """(key → timer handle) map; arming a held key cancels the prior handle."""
+
+    def __init__(self) -> None:
+        self._timers: dict[K, asyncio.TimerHandle] = {}
+
+    def __contains__(self, key: K) -> bool:
+        """Report whether *key* holds a handle."""
+        return key in self._timers
+
+    def __len__(self) -> int:
+        """Count of keys currently holding a handle."""
+        return len(self._timers)
+
+    def __getitem__(self, key: K) -> asyncio.TimerHandle:
+        """Return *key*'s handle; KeyError when absent."""
+        return self._timers[key]
+
+    def arm(self, key: K, handle: asyncio.TimerHandle) -> None:
+        """Install *handle* for *key*, cancelling any prior one."""
+        existing = self._timers.pop(key, None)
+        if existing is not None:
+            existing.cancel()
+        self._timers[key] = handle
+
+    def discard(self, key: K) -> None:
+        """Cancel and drop *key*'s handle, if any (cancelling a fired handle is inert)."""
+        handle = self._timers.pop(key, None)
+        if handle is not None:
+            handle.cancel()
+
+    def cancel_all(self) -> list[K]:
+        """Cancel every handle and clear; return the keys that were held."""
+        keys = list(self._timers)
+        for handle in self._timers.values():
+            handle.cancel()
+        self._timers.clear()
+        return keys

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -516,6 +516,11 @@ async def wait_until(
         await asyncio.sleep(interval)
 
 
+def make_timer_handle() -> asyncio.TimerHandle:
+    """Return a far-future no-op ``call_later`` handle for timer-registry seeding."""
+    return asyncio.get_running_loop().call_later(30.0, lambda: None)
+
+
 # ---------------------------------------------------------------------------
 # submit_job test helpers
 #

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -26,7 +26,6 @@ Grouped by surface:
 
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
 from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock
@@ -54,7 +53,7 @@ from esphome_device_builder.models import (
     JobType,
 )
 from tests._recording_scanner import RecordingScanner
-from tests.conftest import make_device
+from tests.conftest import make_device, make_timer_handle
 
 from .conftest import (
     CaptureDevicesEventsFactory,
@@ -1097,15 +1096,15 @@ async def test_on_scan_change_updated_resets_regen_state(
     controller = make_controller(tmp_path, with_state_monitor=True, with_regenerate_state=True)
     controller.state.regen.failed.add("kitchen.yaml")
     controller.state.regen.retry_strikes["kitchen.yaml"] = 1
-    handle = asyncio.get_running_loop().call_later(30.0, lambda: None)
-    controller.state.regen.retry_timers["kitchen.yaml"] = handle
+    handle = make_timer_handle()
+    controller.state.regen.retry_timers.arm("kitchen.yaml", handle)
     device = _device("kitchen")
 
     controller._on_scan_change(ScanChange.UPDATED, device)
 
     assert "kitchen.yaml" not in controller.state.regen.failed
     assert handle.cancelled()
-    assert controller.state.regen.retry_timers == {}
+    assert not controller.state.regen.retry_timers
     assert controller.state.regen.retry_strikes == {}
 
 
@@ -1121,15 +1120,16 @@ async def test_on_scan_change_reloaded_keeps_armed_retry(
     controller = make_controller(tmp_path, with_state_monitor=True, with_regenerate_state=True)
     controller.state.regen.failed.add("kitchen.yaml")
     controller.state.regen.retry_strikes["kitchen.yaml"] = 1
-    handle = asyncio.get_running_loop().call_later(30.0, lambda: None)
-    controller.state.regen.retry_timers["kitchen.yaml"] = handle
+    handle = make_timer_handle()
+    controller.state.regen.retry_timers.arm("kitchen.yaml", handle)
     device = _device("kitchen")
 
     controller._on_scan_change(ScanChange.RELOADED, device)
 
     assert "kitchen.yaml" not in controller.state.regen.failed
     assert not handle.cancelled()
-    assert controller.state.regen.retry_timers == {"kitchen.yaml": handle}
+    assert controller.state.regen.retry_timers["kitchen.yaml"] is handle
+    assert len(controller.state.regen.retry_timers) == 1
     assert controller.state.regen.retry_strikes == {"kitchen.yaml": 1}
     handle.cancel()
 

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -31,7 +31,7 @@ from esphome_device_builder.controllers._device_scanner import ScanChange
 from esphome_device_builder.controllers.devices import DevicesController, storage_regen
 from esphome_device_builder.controllers.devices._state import RegenState
 from tests._storage_fixtures import write_storage_json
-from tests.conftest import make_device, wait_until
+from tests.conftest import make_device, make_timer_handle, wait_until
 
 from .conftest import MakeControllerFactory, MakeDbFactory
 
@@ -1108,7 +1108,7 @@ async def test_regenerate_retry_fires_and_succeeds(
 
     assert outcomes == []
     assert controller.state.regen.failed == set()
-    assert controller.state.regen.retry_timers == {}
+    assert not controller.state.regen.retry_timers
     assert controller.state.regen.retry_strikes == {}
     reload_calls = [c for c in controller._scanner.calls if c[0] == "reload"]
     assert reload_calls == [("reload", "kitchen.yaml")]
@@ -1149,7 +1149,7 @@ async def test_regenerate_retry_budget_exhausts_to_stamp(
 
     assert spawns == 1 + storage_regen._MAX_REGEN_RETRIES
     assert controller.state.regen.failed == {"kitchen.yaml"}
-    assert controller.state.regen.retry_timers == {}
+    assert not controller.state.regen.retry_timers
     assert "regen_failed_at" in _read_store(controller, "kitchen.yaml")
 
 
@@ -1176,7 +1176,7 @@ async def test_shutdown_stamps_armed_retries(
 
     await storage_regen.shutdown(controller)
 
-    assert controller.state.regen.retry_timers == {}
+    assert not controller.state.regen.retry_timers
     assert "regen_failed_at" in _read_store(controller, "kitchen.yaml")
 
 
@@ -1185,9 +1185,7 @@ async def test_stop_stamps_armed_retries(tmp_path: Path, make_db: MakeDbFactory)
     controller = DevicesController(make_db(tmp_path))
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
     controller.state.regen.retry_strikes["kitchen.yaml"] = 1
-    controller.state.regen.retry_timers["kitchen.yaml"] = asyncio.get_running_loop().call_later(
-        30.0, lambda: None
-    )
+    controller.state.regen.retry_timers.arm("kitchen.yaml", make_timer_handle())
 
     with (
         patch.multiple(controller._state_monitor, stop=AsyncMock()),
@@ -1197,36 +1195,18 @@ async def test_stop_stamps_armed_retries(tmp_path: Path, make_db: MakeDbFactory)
     ):
         await controller.stop()
 
-    assert controller.state.regen.retry_timers == {}
+    assert not controller.state.regen.retry_timers
     assert "regen_failed_at" in controller._metadata_store.get("kitchen.yaml")
 
 
-async def test_arm_retry_replaces_and_cancels_prior_handle() -> None:
-    """Re-arming for the same configuration cancels the prior timer."""
+async def test_cancel_all_retry_timers_drops_strikes_and_reports_armed() -> None:
+    """The mass-cancel clears the strike counts and reports the armed keys."""
     state = RegenState()
-    loop = asyncio.get_running_loop()
-    first = loop.call_later(30.0, lambda: None)
-    second = loop.call_later(30.0, lambda: None)
+    state.retry_timers.arm("a.yaml", make_timer_handle())
+    state.retry_strikes = {"a.yaml": 2, "b.yaml": 1}
 
-    state.arm_retry("kitchen.yaml", first)
-    state.arm_retry("kitchen.yaml", second)
+    armed = state.cancel_all_retry_timers()
 
-    assert first.cancelled()
-    assert not second.cancelled()
-    assert state.retry_timers == {"kitchen.yaml": second}
-    state.cancel_all_retry_timers()
-
-
-async def test_cancel_all_retry_timers_cancels_pending_handles() -> None:
-    """``stop()``'s mass-cancel leaves no live retry timer or strike behind."""
-    state = RegenState()
-    loop = asyncio.get_running_loop()
-    handles = [loop.call_later(30.0, lambda: None) for _ in range(2)]
-    state.retry_timers = {"a.yaml": handles[0], "b.yaml": handles[1]}
-    state.retry_strikes = {"a.yaml": 2}
-
-    state.cancel_all_retry_timers()
-
-    assert all(handle.cancelled() for handle in handles)
-    assert state.retry_timers == {}
+    assert armed == ["a.yaml"]
+    assert not state.retry_timers
     assert state.retry_strikes == {}

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -40,6 +40,7 @@ from esphome_device_builder.controllers._device_scanner import (
 )
 from esphome_device_builder.controllers.devices import DevicesController, firmware_sync
 from esphome_device_builder.controllers.devices._metadata_store import DeviceMetadataStore
+from esphome_device_builder.controllers.devices._state import DevicesState
 from esphome_device_builder.helpers.event_bus import Event
 from esphome_device_builder.models import (
     Device,
@@ -376,13 +377,13 @@ async def test_refresh_after_upload_skips_hash_compute(tmp_path: Path, monkeypat
     controller._build_size = MagicMock()
     controller._state_monitor = MagicMock()
     # The flashed branch arms a post-flash re-probe timer.
-    controller._reprobe_timers = {}
+    controller.state = DevicesState()
 
     await controller._refresh_after_firmware_job("kitchen.yaml", recompute_hash=False, flashed=True)
 
     assert compute_calls == []
     assert controller._scanner.calls == [("reload", "kitchen.yaml")]
-    controller._cancel_reprobe_timers()
+    controller.state.reprobe_timers.cancel_all()
 
 
 # ----------------------------------------------------------------------
@@ -587,7 +588,7 @@ _INTERVAL = firmware_sync._DEEP_SLEEP_REPROBE_INTERVAL
 def _reprobe_controller(device: Device | None) -> Any:
     """Build a bare controller wired for the re-probe timer path."""
     controller = DevicesController.__new__(DevicesController)
-    controller._reprobe_timers = {}
+    controller.state = DevicesState()
     controller._scanner = MagicMock()
     controller._scanner.get_by_configuration = lambda cfg: (
         device if device is not None and device.configuration == cfg else None
@@ -606,7 +607,7 @@ async def test_schedule_version_reprobe_fires_and_requests(monkeypatch: Any) -> 
     await asyncio.sleep(0.01)  # let the call_later(0) timer fire
 
     controller._state_monitor.api_info.request_reprobe.assert_called_once_with(device.name)
-    assert controller._reprobe_timers == {}  # consumed
+    assert not controller.state.reprobe_timers  # consumed
 
 
 async def test_fire_version_reprobe_unknown_configuration_is_noop() -> None:
@@ -624,12 +625,12 @@ async def test_schedule_version_reprobe_reschedule_cancels_previous(monkeypatch:
     controller = _reprobe_controller(_device())
 
     controller._schedule_version_reprobe("kitchen.yaml")
-    first = controller._reprobe_timers["kitchen.yaml"]
+    first = controller.state.reprobe_timers["kitchen.yaml"]
     controller._schedule_version_reprobe("kitchen.yaml")
 
     assert first.cancelled()
-    assert controller._reprobe_timers["kitchen.yaml"] is not first
-    controller._cancel_reprobe_timers()
+    assert controller.state.reprobe_timers["kitchen.yaml"] is not first
+    controller.state.reprobe_timers.cancel_all()
 
 
 async def test_cancel_reprobe_timers_cancels_pending(monkeypatch: Any) -> None:
@@ -638,11 +639,11 @@ async def test_cancel_reprobe_timers_cancels_pending(monkeypatch: Any) -> None:
     controller = _reprobe_controller(_device())
 
     controller._schedule_version_reprobe("kitchen.yaml")
-    handle = controller._reprobe_timers["kitchen.yaml"]
-    controller._cancel_reprobe_timers()
+    handle = controller.state.reprobe_timers["kitchen.yaml"]
+    controller.state.reprobe_timers.cancel_all()
 
     assert handle.cancelled()
-    assert controller._reprobe_timers == {}
+    assert not controller.state.reprobe_timers
 
 
 async def test_deep_sleep_arms_burst_not_single_probe() -> None:
@@ -652,10 +653,10 @@ async def test_deep_sleep_arms_burst_not_single_probe() -> None:
 
     controller._schedule_version_reprobe("kitchen.yaml")
 
-    handle = controller._reprobe_timers["kitchen.yaml"]
+    handle = controller.state.reprobe_timers["kitchen.yaml"]
     expected = firmware_sync._DEEP_SLEEP_REPROBE_INTERVAL
     assert handle.when() - loop.time() == pytest.approx(expected, abs=1)
-    controller._cancel_reprobe_timers()
+    controller.state.reprobe_timers.cancel_all()
 
 
 async def test_non_deep_sleep_arms_single_probe(monkeypatch: Any) -> None:
@@ -666,9 +667,9 @@ async def test_non_deep_sleep_arms_single_probe(monkeypatch: Any) -> None:
 
     controller._schedule_version_reprobe("kitchen.yaml")
 
-    handle = controller._reprobe_timers["kitchen.yaml"]
+    handle = controller.state.reprobe_timers["kitchen.yaml"]
     assert handle.when() - loop.time() == pytest.approx(60, abs=1)
-    controller._cancel_reprobe_timers()
+    controller.state.reprobe_timers.cancel_all()
 
 
 async def test_burst_requests_and_rearms_until_deadline() -> None:
@@ -681,8 +682,8 @@ async def test_burst_requests_and_rearms_until_deadline() -> None:
     )
 
     controller._state_monitor.api_info.request_reprobe.assert_called_once_with("kitchen")
-    assert "kitchen.yaml" in controller._reprobe_timers  # re-armed
-    controller._cancel_reprobe_timers()
+    assert "kitchen.yaml" in controller.state.reprobe_timers  # re-armed
+    controller.state.reprobe_timers.cancel_all()
 
 
 async def test_burst_probes_despite_stale_online_reading() -> None:
@@ -695,8 +696,8 @@ async def test_burst_probes_despite_stale_online_reading() -> None:
     )
 
     controller._state_monitor.api_info.request_reprobe.assert_called_once_with("kitchen")
-    assert "kitchen.yaml" in controller._reprobe_timers  # re-armed, not aborted
-    controller._cancel_reprobe_timers()
+    assert "kitchen.yaml" in controller.state.reprobe_timers  # re-armed, not aborted
+    controller.state.reprobe_timers.cancel_all()
 
 
 async def test_burst_stops_at_deadline() -> None:
@@ -709,7 +710,7 @@ async def test_burst_stops_at_deadline() -> None:
     )
 
     controller._state_monitor.api_info.request_reprobe.assert_called_once_with("kitchen")
-    assert controller._reprobe_timers == {}  # deadline passed, not re-armed
+    assert not controller.state.reprobe_timers  # deadline passed, not re-armed
 
 
 async def test_burst_unknown_configuration_is_noop() -> None:
@@ -720,7 +721,7 @@ async def test_burst_unknown_configuration_is_noop() -> None:
     firmware_sync._fire_version_reprobe(controller, "kitchen.yaml", deadline=loop.time() + 1000)
 
     controller._state_monitor.api_info.request_reprobe.assert_not_called()
-    assert controller._reprobe_timers == {}
+    assert not controller.state.reprobe_timers
 
 
 # ----------------------------------------------------------------------

--- a/tests/helpers/test_timer_registry.py
+++ b/tests/helpers/test_timer_registry.py
@@ -1,0 +1,66 @@
+"""Coverage for ``helpers.timer_registry.TimerRegistry``."""
+
+from __future__ import annotations
+
+from esphome_device_builder.helpers.timer_registry import TimerRegistry
+from tests.conftest import make_timer_handle
+
+
+async def test_arm_installs_handle() -> None:
+    registry: TimerRegistry[str] = TimerRegistry()
+    handle = make_timer_handle()
+
+    registry.arm("a.yaml", handle)
+
+    assert "a.yaml" in registry
+    assert len(registry) == 1
+    assert registry["a.yaml"] is handle
+    registry.cancel_all()
+
+
+async def test_arm_replaces_and_cancels_prior_handle() -> None:
+    registry: TimerRegistry[str] = TimerRegistry()
+    first = make_timer_handle()
+    second = make_timer_handle()
+
+    registry.arm("a.yaml", first)
+    registry.arm("a.yaml", second)
+
+    assert first.cancelled()
+    assert not second.cancelled()
+    assert registry["a.yaml"] is second
+    assert len(registry) == 1
+    registry.cancel_all()
+
+
+async def test_discard_cancels_and_removes() -> None:
+    registry: TimerRegistry[str] = TimerRegistry()
+    handle = make_timer_handle()
+    registry.arm("a.yaml", handle)
+
+    registry.discard("a.yaml")
+
+    assert handle.cancelled()
+    assert "a.yaml" not in registry
+    assert len(registry) == 0
+
+
+async def test_discard_missing_key_is_a_noop() -> None:
+    registry: TimerRegistry[str] = TimerRegistry()
+
+    registry.discard("missing.yaml")
+
+    assert len(registry) == 0
+
+
+async def test_cancel_all_cancels_and_returns_held_keys() -> None:
+    registry: TimerRegistry[str] = TimerRegistry()
+    handles = {"a.yaml": make_timer_handle(), "b.yaml": make_timer_handle()}
+    for key, handle in handles.items():
+        registry.arm(key, handle)
+
+    cancelled = registry.cancel_all()
+
+    assert sorted(cancelled) == ["a.yaml", "b.yaml"]
+    assert all(handle.cancelled() for handle in handles.values())
+    assert len(registry) == 0


### PR DESCRIPTION
# What does this implement/fix?

`controllers/devices/` carried two per configuration timer maps with line for line the same machinery: `controller._reprobe_timers` (post flash version reprobe, firmware_sync) and `RegenState.retry_timers` (the storage regen retry from #2535). A fix to one, a missed cancel on stop or a pop on fire, did not reach the other, and the next timer surface would have made a third copy.

This hoists a `TimerRegistry` helper (arm with cancel and replace, discard, cancel_all returning the held keys) and migrates both maps onto it. The reprobe map also moves onto `DevicesState` as `state.reprobe_timers`, since `firmware_sync` is a sibling module and the state dataclass convention says cross module data reaches through `controller.state`; the pure pass through wrappers (`RegenState.arm_retry`, `_cancel_reprobe_timers`) are gone, while the genuinely composite transitions (`reset`, `cancel_all_retry_timers`) stay as methods. No behaviour change; the registry has its own unit tests and the existing suites were migrated to its API.

**Related issue or feature (if applicable):**

- fixes #2533

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
