### PR TITLE
Persist the regen attempt count so the failure ladder survives restarts

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -414,7 +414,7 @@ Two rules the refine established that every later caller inherits:
   failed `--only-generate` earns a bounded escalating retry (4 attempts,
   30/60/120s between them) — a transient environment failure (interrupted
   package clone, DNS) is indistinguishable from a broken YAML without
-  parsing subprocess stderr, so every failure retries. Every failure stamps
+  parsing subprocess output, so every failure retries. Every failure stamps
   the store (`regen_failed_mtime`/`_at`/`_attempts`), making the stamp the
   single source of truth: the ladder resumes across restarts at the recorded
   attempt (a restart inside a backoff window re-arms the *remainder*, not an

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -412,16 +412,22 @@ Two rules the refine established that every later caller inherits:
   regen deliberately skips `RELOADED` (it fires on `ADDED`/`UPDATED` to catch
   out-of-band edits), so a restart's refine burst can neither commit to git
   nor spawn `--only-generate` per device.
-- **Regen failures retry before they stamp** (#2532). A failed
-  `--only-generate` gets a bounded escalating retry (3 attempts, 30/60/120s)
-  before the session `regen.failed` marker and the one-hour disk stamp — a
-  transient environment failure (interrupted package clone, DNS) is
-  indistinguishable from a broken YAML without parsing subprocess stderr, so
-  every failure retries. The stamp is written only once the budget is spent;
-  a shutdown mid-window stamps any armed retries first so a restart loop
-  can't spend a fresh budget each cycle. Success at any attempt clears the
-  ladder and reloads the scanner, which also repairs an earlier swallowed
-  in-process package resolve.
+- **Regen failures ladder through the metadata store** (#2532, #2534). A
+  failed `--only-generate` earns a bounded escalating retry (4 attempts,
+  30/60/120s between them) — a transient environment failure (interrupted
+  package clone, DNS) is indistinguishable from a broken YAML without
+  parsing subprocess stderr, so every failure retries. Every failure stamps
+  the store (`regen_failed_mtime`/`_at`/`_attempts`), making the stamp the
+  single source of truth: the ladder resumes across restarts at the recorded
+  attempt (a restart inside a backoff window re-arms the *remainder*, not an
+  immediate spawn), a spent budget holds until the YAML's mtime moves or the
+  four-hour TTL expires (in-session too — there is no separate session
+  marker), and shutdown only cancels the in-RAM timers. An edit resets the
+  ladder by construction (the stamp's mtime no longer matches). Success at
+  any attempt clears the stamp triple and reloads the scanner, which also
+  repairs an earlier swallowed in-process package resolve; a run cancelled
+  mid-subprocess kills the child and records nothing (an interrupted clone
+  is not evidence of failure).
 
 ## Authentication
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -402,11 +402,9 @@ Two rules the refine established that every later caller inherits:
   reload-driven path (labels, build size, post-compile refresh) now means "the
   row changed", not "a reload ran". The gate suppresses every RELOADED side
   effect in `on_scan_change`, not just the frame — all are implied by row
-  equality except the regen failure marker: `RELOADED` discards it, while the
-  armed retry timer and strike count deliberately survive (the cold-start
-  refine's `RELOADED` burst must not cancel a pending recovery); the full
-  `regen.reset` runs only on `UPDATED`/`REMOVED`, whose real repair path is a
-  YAML edit anyway.
+  equality; RELOADED touches no regen state at all (an armed retry survives
+  the cold-start refine's RELOADED burst, and the failure stamp is repaired
+  by the fields a successful compile fills).
 - **The refine emits `RELOADED`, never `UPDATED`.** `DEVICE_YAML_UPDATED`
   (version-history commits) keys on `UPDATED`, and the network-fingerprint
   regen deliberately skips `RELOADED` (it fires on `ADDED`/`UPDATED` to catch
@@ -421,13 +419,15 @@ Two rules the refine established that every later caller inherits:
   single source of truth: the ladder resumes across restarts at the recorded
   attempt (a restart inside a backoff window re-arms the *remainder*, not an
   immediate spawn), a spent budget holds until the YAML's mtime moves or the
-  four-hour TTL expires (in-session too — there is no separate session
-  marker), and shutdown only cancels the in-RAM timers. An edit resets the
-  ladder by construction (the stamp's mtime no longer matches). Success at
-  any attempt clears the stamp triple and reloads the scanner, which also
+  four-hour TTL expires (a timer re-checks at expiry, so an untouched file
+  recovers without a scan event), and shutdown only cancels the in-RAM
+  timers. An edit resets the ladder by construction — failures stamp against
+  the pre-spawn mtime, so even an edit landing mid-run starts fresh. Success
+  at any attempt clears the stamp triple and reloads the scanner, which also
   repairs an earlier swallowed in-process package resolve; a run cancelled
   mid-subprocess kills the child and records nothing (an interrupted clone
-  is not evidence of failure).
+  is not evidence of failure), and the give-up warning carries the last
+  failure's summary.
 
 ## Authentication
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -426,8 +426,9 @@ Two rules the refine established that every later caller inherits:
   at any attempt clears the stamp triple and reloads the scanner, which also
   repairs an earlier swallowed in-process package resolve; a run cancelled
   mid-subprocess kills the child and records nothing (an interrupted clone
-  is not evidence of failure), and the give-up warning carries the last
-  failure's summary.
+  is not evidence of failure), a hung run is killed after five minutes and
+  counts as a failure, and the give-up warning carries the last failure's
+  summary.
 
 ## Authentication
 

--- a/esphome_device_builder/controllers/config/metadata.py
+++ b/esphome_device_builder/controllers/config/metadata.py
@@ -163,20 +163,11 @@ def set_device_metadata(
     startup, before the first mDNS probe response. Passing an
     empty string clears it.
 
-    ``regen_failed_mtime`` is the YAML's mtime when the last
-    ``--only-generate`` storage-regen attempt failed; pair it with
-    ``regen_failed_at`` (the wall-clock time the failure was
-    recorded). Together they let a backend restart skip retrying
-    the same broken config (missing ``!secret`` / ``!include`` /
-    unreachable git package) — the next attempt only runs when
-    the YAML's mtime has actually moved past the cached stamp,
-    OR when the cached stamp is older than the controller's
-    failure-TTL (so transient external problems eventually get
-    re-checked). The two fields are written together by
-    :meth:`DevicesController._stamp_regen_failure`; the
-    success / archive paths clear them by passing ``0.0`` to
-    *both* — clearing only one half leaves the other behind, so
-    callers should always touch the pair as a unit.
+    ``regen_failed_mtime`` / ``regen_failed_at`` are the legacy
+    shared-sidecar halves of the storage-regen failure stamp; the
+    live stamp (including ``regen_failed_attempts``) is owned by the
+    device metadata store and documented in
+    ``controllers/devices/storage_regen.py``.
 
     ``build_size_bytes`` caches the total size of the per-device
     ``.esphome/build/<name>/`` tree at the freshness pair

--- a/esphome_device_builder/controllers/config/metadata.py
+++ b/esphome_device_builder/controllers/config/metadata.py
@@ -131,8 +131,6 @@ def set_device_metadata(
     ip: str | None = None,
     expected_config_hash: str | None = None,
     mac_address: str | None = None,
-    regen_failed_mtime: float | None = None,
-    regen_failed_at: float | None = None,
     build_size_bytes: int | None = None,
     build_size_dir_mtime: int | None = None,
     build_size_info_mtime: int | None = None,
@@ -162,12 +160,6 @@ def set_device_metadata(
     Persisted so the dashboard renders the address immediately on
     startup, before the first mDNS probe response. Passing an
     empty string clears it.
-
-    ``regen_failed_mtime`` / ``regen_failed_at`` are the legacy
-    shared-sidecar halves of the storage-regen failure stamp; the
-    live stamp (including ``regen_failed_attempts``) is owned by the
-    device metadata store and documented in
-    ``controllers/devices/storage_regen.py``.
 
     ``build_size_bytes`` caches the total size of the per-device
     ``.esphome/build/<name>/`` tree at the freshness pair
@@ -207,10 +199,9 @@ def set_device_metadata(
                 entry.pop("labels", None)
         # Tri-state fields: ``None`` means "leave alone", a truthy
         # value writes, an explicit falsy (``""`` / ``0``) clears.
-        # The numeric stamps below (``regen_failed_*`` /
-        # ``build_size_*``) all carry timestamps or sizes whose
-        # legitimate values are strictly positive — ``0`` is
-        # therefore safe as the explicit-clear sentinel.
+        # The numeric ``build_size_*`` stamps carry timestamps or
+        # sizes whose legitimate values are strictly positive —
+        # ``0`` is therefore safe as the explicit-clear sentinel.
         # Loop over the (key, value) pairs so adding a new
         # tri-state field doesn't bump this function's branch
         # count (ruff PLR0912 caps at 12).
@@ -218,8 +209,6 @@ def set_device_metadata(
             ("board_id_user_set", board_id_user_set),
             ("expected_config_hash", expected_config_hash),
             ("mac_address", mac_address),
-            ("regen_failed_mtime", regen_failed_mtime),
-            ("regen_failed_at", regen_failed_at),
             ("build_size_bytes", build_size_bytes),
             ("build_size_dir_mtime", build_size_dir_mtime),
             ("build_size_info_mtime", build_size_info_mtime),

--- a/esphome_device_builder/controllers/devices/_metadata_store.py
+++ b/esphome_device_builder/controllers/devices/_metadata_store.py
@@ -34,6 +34,7 @@ STORE_FIELDS: frozenset[str] = frozenset(
         "build_size_info_mtime",
         "regen_failed_mtime",
         "regen_failed_at",
+        "regen_failed_attempts",
     }
 )
 

--- a/esphome_device_builder/controllers/devices/_state.py
+++ b/esphome_device_builder/controllers/devices/_state.py
@@ -64,11 +64,27 @@ class RegenState:
         handle.cancel()
         return True
 
+    def record_strike(self, configuration: str) -> int:
+        """Count one more stat failure against *configuration*; returns the streak."""
+        strikes = self.unreadable_strikes.get(configuration, 0) + 1
+        self.unreadable_strikes[configuration] = strikes
+        return strikes
+
+    def clear_strikes(self, configuration: str) -> None:
+        """Drop *configuration*'s stat-failure streak."""
+        self.unreadable_strikes.pop(configuration, None)
+
+    def forget(self, configuration: str) -> bool:
+        """Drop all in-RAM regen bookkeeping for *configuration*; True iff a retry was armed."""
+        self.clear_strikes(configuration)
+        return self.cancel_retry(configuration)
+
     def cancel_all_retry_timers(self) -> None:
-        """Cancel every pending retry timer."""
+        """Cancel every pending retry timer and drop the strike streaks."""
         for handle in self.retry_timers.values():
             handle.cancel()
         self.retry_timers.clear()
+        self.unreadable_strikes.clear()
 
 
 @dataclass

--- a/esphome_device_builder/controllers/devices/_state.py
+++ b/esphome_device_builder/controllers/devices/_state.py
@@ -41,11 +41,13 @@ class RegenState:
 
     ``pending`` dedupes in-flight schedules; ``retry_timers`` holds the
     armed backoff retries. Failure history (attempt count, stamp) lives
-    in the metadata store.
+    in the metadata store; ``unreadable_strikes`` counts stat failures
+    the stamp can't key (no mtime to record against).
     """
 
     pending: set[str] = field(default_factory=set)
     retry_timers: dict[str, asyncio.TimerHandle] = field(default_factory=dict)
+    unreadable_strikes: dict[str, int] = field(default_factory=dict)
 
     def arm_retry(self, configuration: str, handle: asyncio.TimerHandle) -> None:
         """Install *handle* as the pending retry, cancelling any prior one."""

--- a/esphome_device_builder/controllers/devices/_state.py
+++ b/esphome_device_builder/controllers/devices/_state.py
@@ -54,11 +54,13 @@ class RegenState:
             existing.cancel()
         self.retry_timers[configuration] = handle
 
-    def cancel_retry(self, configuration: str) -> None:
-        """Cancel and drop *configuration*'s pending retry timer, if any."""
+    def cancel_retry(self, configuration: str) -> bool:
+        """Cancel and drop *configuration*'s retry timer; True iff one was armed."""
         handle = self.retry_timers.pop(configuration, None)
-        if handle is not None:
-            handle.cancel()
+        if handle is None:
+            return False
+        handle.cancel()
+        return True
 
     def cancel_all_retry_timers(self) -> None:
         """Cancel every pending retry timer."""

--- a/esphome_device_builder/controllers/devices/_state.py
+++ b/esphome_device_builder/controllers/devices/_state.py
@@ -39,15 +39,13 @@ class RegenState:
     """
     Bookkeeping for background ``--only-generate`` runs.
 
-    ``pending`` dedupes in-flight schedules, ``failed`` blocks retries
-    until the YAML changes, and the retry fields drive the bounded
-    escalating retry between a failure and the disk stamp.
+    ``pending`` dedupes in-flight schedules; ``retry_timers`` holds the
+    armed backoff retries. Failure history (attempt count, stamp) lives
+    in the metadata store.
     """
 
     pending: set[str] = field(default_factory=set)
-    failed: set[str] = field(default_factory=set)
     retry_timers: dict[str, asyncio.TimerHandle] = field(default_factory=dict)
-    retry_strikes: dict[str, int] = field(default_factory=dict)
 
     def arm_retry(self, configuration: str, handle: asyncio.TimerHandle) -> None:
         """Install *handle* as the pending retry, cancelling any prior one."""
@@ -56,20 +54,17 @@ class RegenState:
             existing.cancel()
         self.retry_timers[configuration] = handle
 
-    def reset(self, configuration: str) -> None:
-        """Drop *configuration*'s failure marker, retry timer, and strikes."""
-        self.failed.discard(configuration)
+    def cancel_retry(self, configuration: str) -> None:
+        """Cancel and drop *configuration*'s pending retry timer, if any."""
         handle = self.retry_timers.pop(configuration, None)
         if handle is not None:
             handle.cancel()
-        self.retry_strikes.pop(configuration, None)
 
     def cancel_all_retry_timers(self) -> None:
-        """Cancel every pending retry timer and drop the strike counts."""
+        """Cancel every pending retry timer."""
         for handle in self.retry_timers.values():
             handle.cancel()
         self.retry_timers.clear()
-        self.retry_strikes.clear()
 
 
 @dataclass

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -903,8 +903,8 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
     async def _spawn_only_generate(self, configuration: str) -> str | None:
         return await storage_regen.spawn_only_generate(self, configuration)
 
-    async def _stamp_regen_failure(self, configuration: str, mtime: float) -> int:
-        return await storage_regen.stamp_failure(self, configuration, mtime)
+    def _stamp_regen_failure(self, configuration: str, mtime: float) -> int:
+        return storage_regen.stamp_failure(self, configuration, mtime)
 
     async def _finalize_regen_success(self, configuration: str) -> None:
         await storage_regen.finalize_success(self, configuration)

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -98,18 +98,6 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-# How long the persisted "regen failed" stamp is honoured before a
-# restart-time check is allowed to re-spawn ``--only-generate`` for
-# the same untouched YAML. The in-memory ``state.regen.failed`` set
-# blocks within a session until the user edits the YAML; the TTL
-# only applies cross-restart, so a transient external problem
-# (git package server flaky, DNS hiccup) eventually recovers
-# without forcing the user to touch the file. One hour is short
-# enough that "I'll come back to this in a bit and restart" works,
-# long enough that a debugger restarting the dashboard 10x in a
-# row doesn't churn through 10 spawns on the same broken config.
-_REGEN_FAILURE_TTL_SECONDS: float = 3600.0
-
 # Keeps the fleet-wide build-tree walk out of the cold-start window
 # where store loads and job restore need the disk.
 _BUILD_SIZE_SWEEP_DELAY_SECONDS: float = 20.0
@@ -176,18 +164,15 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
 
         # Background ``--only-generate`` bookkeeping. ``--only-generate``
         # validates a YAML and writes its ``StorageJSON`` without doing
-        # a real build; we trigger it whenever a YAML is saved or
-        # first-seen with no compile output. Four bounds stop us from
-        # spinning:
+        # a real build; we trigger it whenever a YAML is saved or seen
+        # with no compile output. Three bounds stop us from spinning:
         #   * ``state.regen.pending`` — configurations already in
         #     flight (scheduled but not yet finished). Skip duplicate
         #     schedules.
-        #   * a bounded escalating retry between a failure and giving
-        #     up (``storage_regen._MAX_REGEN_RETRIES`` attempts).
-        #   * ``state.regen.failed`` — YAMLs whose retry budget is
-        #     spent. Don't retry until the file changes (cleared on
-        #     ``UPDATED``/``REMOVED`` along with the retry ladder, and
-        #     on ``RELOADED`` on its own).
+        #   * the persisted failure stamp (metadata store: mtime,
+        #     wall clock, attempt count) — a bounded escalating retry
+        #     ladder that resumes across restarts; a spent budget holds
+        #     until the YAML changes or the stamp's TTL expires.
         #   * ``_regenerate_lock`` — serialises the actual subprocess
         #     so we don't spawn N esphome compiles in parallel.
         self._regenerate_lock = asyncio.Lock()
@@ -336,7 +321,9 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
             self._unsub_job_completed()
             self._unsub_job_completed = None
         self._cancel_reprobe_timers()
-        await storage_regen.shutdown(self)
+        # Cancel armed regen retries before the background-task drain —
+        # an expiring timer would otherwise schedule into the drained set.
+        self.state.regen.cancel_all_retry_timers()
         if self._mqtt_reconcile_handle is not None:
             self._mqtt_reconcile_handle.cancel()
             self._mqtt_reconcile_handle = None
@@ -921,11 +908,8 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
     async def _spawn_only_generate(self, configuration: str) -> bool:
         return await storage_regen.spawn_only_generate(self, configuration)
 
-    async def _regen_already_failed_recently_async(self, configuration: str) -> bool:
-        return await storage_regen.already_failed_recently_async(self, configuration)
-
-    async def _stamp_regen_failure(self, configuration: str) -> None:
-        await storage_regen.stamp_failure(self, configuration)
+    async def _stamp_regen_failure(self, configuration: str) -> int:
+        return await storage_regen.stamp_failure(self, configuration)
 
     async def _finalize_regen_success(self, configuration: str) -> None:
         await storage_regen.finalize_success(self, configuration)

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -321,8 +321,8 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
             self._unsub_job_completed()
             self._unsub_job_completed = None
         self._cancel_reprobe_timers()
-        # Cancel armed regen retries before the background-task drain —
-        # an expiring timer would otherwise schedule into the drained set.
+        # Idempotent with the pre-drain cancel in ``_stop_network``;
+        # kept for direct-stop callers.
         self.state.regen.cancel_all_retry_timers()
         if self._mqtt_reconcile_handle is not None:
             self._mqtt_reconcile_handle.cancel()
@@ -908,7 +908,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
     async def _spawn_only_generate(self, configuration: str) -> bool:
         return await storage_regen.spawn_only_generate(self, configuration)
 
-    async def _stamp_regen_failure(self, configuration: str) -> int:
+    async def _stamp_regen_failure(self, configuration: str) -> int | None:
         return await storage_regen.stamp_failure(self, configuration)
 
     async def _finalize_regen_success(self, configuration: str) -> None:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -166,15 +166,11 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         # validates a YAML and writes its ``StorageJSON`` without doing
         # a real build; we trigger it whenever a YAML is saved or seen
         # with no compile output. Three bounds stop us from spinning:
-        #   * ``state.regen.pending`` — configurations already in
-        #     flight (scheduled but not yet finished). Skip duplicate
-        #     schedules.
-        #   * the persisted failure stamp (metadata store: mtime,
-        #     wall clock, attempt count) — a bounded escalating retry
-        #     ladder that resumes across restarts; a spent budget holds
-        #     until the YAML changes or the stamp's TTL expires.
-        #   * ``_regenerate_lock`` — serialises the actual subprocess
-        #     so we don't spawn N esphome compiles in parallel.
+        #   * ``state.regen.pending`` — dedupes in-flight schedules.
+        #   * the persisted failure stamp (mtime, wall clock, attempt
+        #     count) — an escalating retry ladder resuming across
+        #     restarts; a spent budget holds until edit or TTL expiry.
+        #   * ``_regenerate_lock`` — serialises the actual subprocess.
         self._regenerate_lock = asyncio.Lock()
 
         # ``yaml/search`` per-file cache. The class owns its own
@@ -321,8 +317,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
             self._unsub_job_completed()
             self._unsub_job_completed = None
         self._cancel_reprobe_timers()
-        # Idempotent with the pre-drain cancel in ``_stop_network``;
-        # kept for direct-stop callers.
+        # Idempotent with the pre-drain cancel in ``_stop_network``.
         self.state.regen.cancel_all_retry_timers()
         if self._mqtt_reconcile_handle is not None:
             self._mqtt_reconcile_handle.cancel()

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -900,11 +900,11 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
     def _schedule_storage_regenerate(self, configuration: str) -> None:
         storage_regen.schedule(self, configuration)
 
-    async def _spawn_only_generate(self, configuration: str) -> bool:
+    async def _spawn_only_generate(self, configuration: str) -> str | None:
         return await storage_regen.spawn_only_generate(self, configuration)
 
-    async def _stamp_regen_failure(self, configuration: str) -> int | None:
-        return await storage_regen.stamp_failure(self, configuration)
+    async def _stamp_regen_failure(self, configuration: str, mtime: float) -> int:
+        return await storage_regen.stamp_failure(self, configuration, mtime)
 
     async def _finalize_regen_success(self, configuration: str) -> None:
         await storage_regen.finalize_success(self, configuration)

--- a/esphome_device_builder/controllers/devices/scan_change.py
+++ b/esphome_device_builder/controllers/devices/scan_change.py
@@ -73,9 +73,8 @@ def on_scan_change(
     # devices configured before build_info.json existed have a
     # working StorageJSON but no hash, and would otherwise show
     # a permanent em-dash for "Local config hash" until the user
-    # edits the YAML. UPDATED covers out-of-band edits (git pull,
-    # external editor) repairing a previously stamped YAML; the
-    # persisted stamp and the pending set absorb duplicates.
+    # edits the YAML. UPDATED covers out-of-band edits repairing a
+    # previously stamped YAML.
     needs_storage_regen = kind in (ScanChange.ADDED, ScanChange.UPDATED) and (
         not device.loaded_integrations or not device.expected_config_hash
     )
@@ -122,12 +121,9 @@ def _reconcile_regen_state(
 ) -> None:
     """Drop the armed retry when the YAML changed or the file is gone.
 
-    The persisted stamp needs no touch: an edit's mtime move invalidates
-    it and REMOVED's ``clear_volatile`` drops it with the entry. A
-    RELOADED deliberately leaves an armed retry alone — the cold-start
-    refine's RELOADED burst must not cancel a pending recovery — and
-    needs no stamp clearing either: a successful compile fills the very
-    fields the regen would have computed, making the stamp moot.
+    The stamp needs no touch (an edit's mtime move invalidates it;
+    ``clear_volatile`` drops it on REMOVED). RELOADED leaves the timer
+    alone — the refine burst must not cancel a pending recovery.
     """
     if kind in (ScanChange.UPDATED, ScanChange.REMOVED):
         controller.state.regen.cancel_retry(device.configuration)

--- a/esphome_device_builder/controllers/devices/scan_change.py
+++ b/esphome_device_builder/controllers/devices/scan_change.py
@@ -128,6 +128,7 @@ def _reconcile_regen_state(
     """
     if kind not in (ScanChange.UPDATED, ScanChange.REMOVED):
         return
+    controller.state.regen.unreadable_strikes.pop(device.configuration, None)
     had_timer = controller.state.regen.cancel_retry(device.configuration)
     if had_timer and kind is ScanChange.UPDATED:
         controller._schedule_storage_regenerate(device.configuration)

--- a/esphome_device_builder/controllers/devices/scan_change.py
+++ b/esphome_device_builder/controllers/devices/scan_change.py
@@ -119,14 +119,18 @@ def _reconcile_regen_state(
     kind: ScanChange,
     device: Device,
 ) -> None:
-    """Drop the armed retry when the YAML changed or the file is gone.
-
-    The stamp needs no touch (an edit's mtime move invalidates it;
-    ``clear_volatile`` drops it on REMOVED). RELOADED leaves the timer
-    alone — the refine burst must not cancel a pending recovery.
     """
-    if kind in (ScanChange.UPDATED, ScanChange.REMOVED):
-        controller.state.regen.cancel_retry(device.configuration)
+    Drop the armed retry when the YAML changed or the file is gone.
+
+    An UPDATED that cancelled one reschedules — the moved mtime
+    invalidates the stamp, so the edited YAML spawns fresh. RELOADED
+    leaves the timer alone.
+    """
+    if kind not in (ScanChange.UPDATED, ScanChange.REMOVED):
+        return
+    had_timer = controller.state.regen.cancel_retry(device.configuration)
+    if had_timer and kind is ScanChange.UPDATED:
+        controller._schedule_storage_regenerate(device.configuration)
 
 
 def _reconcile_rename(

--- a/esphome_device_builder/controllers/devices/scan_change.py
+++ b/esphome_device_builder/controllers/devices/scan_change.py
@@ -64,18 +64,19 @@ def on_scan_change(
     if kind in (ScanChange.ADDED, ScanChange.UPDATED, ScanChange.RELOADED):
         _sync_network_fingerprint(controller, kind, device)
     _nudge_mqtt(controller, kind, device, previous)
-    # First-sight devices with no compile output carry the
-    # ``<filename>.local`` address fallback and an empty
-    # ``loaded_integrations`` list. Schedule a background
-    # ``--only-generate`` so the next scan picks up the real
-    # StorageJSON-derived values without making the user wait
-    # for a real compile. Also fire when ``expected_config_hash``
+    # Devices with no compile output carry the ``<filename>.local``
+    # address fallback and an empty ``loaded_integrations`` list.
+    # Schedule a background ``--only-generate`` so the next scan picks
+    # up the real StorageJSON-derived values without making the user
+    # wait for a real compile. Also fire when ``expected_config_hash``
     # is empty even though ``loaded_integrations`` is populated:
     # devices configured before build_info.json existed have a
     # working StorageJSON but no hash, and would otherwise show
     # a permanent em-dash for "Local config hash" until the user
-    # edits the YAML.
-    needs_storage_regen = kind is ScanChange.ADDED and (
+    # edits the YAML. UPDATED covers out-of-band edits (git pull,
+    # external editor) repairing a previously stamped YAML; the
+    # persisted stamp and the pending set absorb duplicates.
+    needs_storage_regen = kind in (ScanChange.ADDED, ScanChange.UPDATED) and (
         not device.loaded_integrations or not device.expected_config_hash
     )
     if needs_storage_regen:
@@ -119,18 +120,17 @@ def _reconcile_regen_state(
     kind: ScanChange,
     device: Device,
 ) -> None:
-    """Reset or trim the regen failure state after a scan change."""
+    """Drop the armed retry when the YAML changed or the file is gone.
+
+    The persisted stamp needs no touch: an edit's mtime move invalidates
+    it and REMOVED's ``clear_volatile`` drops it with the entry. A
+    RELOADED deliberately leaves an armed retry alone — the cold-start
+    refine's RELOADED burst must not cancel a pending recovery — and
+    needs no stamp clearing either: a successful compile fills the very
+    fields the regen would have computed, making the stamp moot.
+    """
     if kind in (ScanChange.UPDATED, ScanChange.REMOVED):
-        # YAML cache key changed or the file is gone; drop the failure
-        # marker and any armed retry so the next sight starts fresh
-        # (re-creating a deleted file doesn't inherit the old failure).
-        controller.state.regen.reset(device.configuration)
-    elif kind is ScanChange.RELOADED:
-        # Metadata reload, YAML unchanged: a stale failure marker clears
-        # (a post-compile reload proves the YAML builds) but an armed
-        # retry survives — the cold-start refine's RELOADED must not
-        # cancel the only pending recovery.
-        controller.state.regen.failed.discard(device.configuration)
+        controller.state.regen.cancel_retry(device.configuration)
 
 
 def _reconcile_rename(

--- a/esphome_device_builder/controllers/devices/scan_change.py
+++ b/esphome_device_builder/controllers/devices/scan_change.py
@@ -60,36 +60,11 @@ def on_scan_change(
         # keeps pinging addresses resolved from the old one (#2486) or
         # waits out the remainder of the periodic interval.
         controller._state_monitor.address_retargeted(device.name)
-    _reconcile_regen_state(controller, kind, device)
+    dropped_retry = _reconcile_regen_state(controller, kind, device)
     if kind in (ScanChange.ADDED, ScanChange.UPDATED, ScanChange.RELOADED):
         _sync_network_fingerprint(controller, kind, device)
     _nudge_mqtt(controller, kind, device, previous)
-    # Devices with no compile output carry the ``<filename>.local``
-    # address fallback and an empty ``loaded_integrations`` list.
-    # Schedule a background ``--only-generate`` so the next scan picks
-    # up the real StorageJSON-derived values without making the user
-    # wait for a real compile. Also fire when ``expected_config_hash``
-    # is empty even though ``loaded_integrations`` is populated:
-    # devices configured before build_info.json existed have a
-    # working StorageJSON but no hash, and would otherwise show
-    # a permanent em-dash for "Local config hash" until the user
-    # edits the YAML. UPDATED covers out-of-band edits repairing a
-    # previously stamped YAML.
-    needs_storage_regen = kind in (ScanChange.ADDED, ScanChange.UPDATED) and (
-        not device.loaded_integrations or not device.expected_config_hash
-    )
-    if needs_storage_regen:
-        missing = []
-        if not device.loaded_integrations:
-            missing.append("loaded_integrations")
-        if not device.expected_config_hash:
-            missing.append("expected_config_hash")
-        _LOGGER.debug(
-            "Scheduling --only-generate for %s (missing: %s)",
-            device.configuration,
-            ", ".join(missing),
-        )
-        controller._schedule_storage_regenerate(device.configuration)
+    _schedule_regen_if_needed(controller, kind, device, dropped_retry=dropped_retry)
     if kind is ScanChange.REMOVED:
         # Upstream's DashboardImportDiscovery only fires
         # on_update on first sight; without a nudge a deleted
@@ -114,24 +89,59 @@ def on_scan_change(
         controller._metadata_store.clear_volatile(device.configuration)
 
 
+def _schedule_regen_if_needed(
+    controller: DevicesController,
+    kind: ScanChange,
+    device: Device,
+    *,
+    dropped_retry: bool,
+) -> None:
+    """Spawn a background ``--only-generate`` when the change warrants one."""
+    # Devices with no compile output carry the ``<filename>.local``
+    # address fallback and an empty ``loaded_integrations`` list.
+    # Schedule a background ``--only-generate`` so the next scan picks
+    # up the real StorageJSON-derived values without making the user
+    # wait for a real compile. Also fire when ``expected_config_hash``
+    # is empty even though ``loaded_integrations`` is populated:
+    # devices configured before build_info.json existed have a
+    # working StorageJSON but no hash, and would otherwise show
+    # a permanent em-dash for "Local config hash" until the user
+    # edits the YAML. UPDATED covers out-of-band edits repairing a
+    # previously stamped YAML; one that cancelled an armed retry
+    # respawns regardless — the edit invalidated the stamp the timer
+    # was waiting out.
+    if kind not in (ScanChange.ADDED, ScanChange.UPDATED):
+        return
+    reasons = []
+    if not device.loaded_integrations:
+        reasons.append("loaded_integrations missing")
+    if not device.expected_config_hash:
+        reasons.append("expected_config_hash missing")
+    if dropped_retry:
+        reasons.append("armed retry dropped")
+    if not reasons:
+        return
+    _LOGGER.debug(
+        "Scheduling --only-generate for %s (%s)",
+        device.configuration,
+        ", ".join(reasons),
+    )
+    controller._schedule_storage_regenerate(device.configuration)
+
+
 def _reconcile_regen_state(
     controller: DevicesController,
     kind: ScanChange,
     device: Device,
-) -> None:
+) -> bool:
     """
-    Drop the armed retry when the YAML changed or the file is gone.
+    Drop regen bookkeeping when the YAML changed or is gone; True iff a retry was armed.
 
-    An UPDATED that cancelled one reschedules — the moved mtime
-    invalidates the stamp, so the edited YAML spawns fresh. RELOADED
-    leaves the timer alone.
+    RELOADED leaves everything alone.
     """
     if kind not in (ScanChange.UPDATED, ScanChange.REMOVED):
-        return
-    controller.state.regen.unreadable_strikes.pop(device.configuration, None)
-    had_timer = controller.state.regen.cancel_retry(device.configuration)
-    if had_timer and kind is ScanChange.UPDATED:
-        controller._schedule_storage_regenerate(device.configuration)
+        return False
+    return controller.state.regen.forget(device.configuration)
 
 
 def _reconcile_rename(

--- a/esphome_device_builder/controllers/devices/storage_regen.py
+++ b/esphome_device_builder/controllers/devices/storage_regen.py
@@ -65,10 +65,13 @@ async def _run(controller: DevicesController, configuration: str) -> None:
             return
         except OSError:
             _LOGGER.warning(
-                "Storage regenerate for %s: config unreadable; skipping",
+                "Storage regenerate for %s: config unreadable; retrying",
                 configuration,
                 exc_info=True,
             )
+            # A transient errno (EACCES, EIO on a network mount) must not
+            # strand the ladder: the firing timer already popped itself.
+            _arm_retry(controller, configuration, _RETRY_BACKOFF_BASE_SECONDS)
             return
         stamp = _fresh_stamp(
             controller._metadata_store.get(configuration), current_mtime, time.time()

--- a/esphome_device_builder/controllers/devices/storage_regen.py
+++ b/esphome_device_builder/controllers/devices/storage_regen.py
@@ -62,17 +62,25 @@ async def _run(controller: DevicesController, configuration: str) -> None:
             current_mtime = await run_in_executor(lambda: config_path.stat().st_mtime)
         except FileNotFoundError:
             _LOGGER.debug("Storage regenerate for %s: config vanished; skipping", configuration)
+            controller.state.regen.unreadable_strikes.pop(configuration, None)
             return
         except OSError:
+            # A transient errno (EACCES, EIO on a network mount) must not
+            # strand the ladder: the firing timer already popped itself.
+            # Without an mtime the stamp can't key the failure, so a RAM
+            # strike escalates the re-arm up to the TTL.
+            strikes = controller.state.regen.unreadable_strikes.get(configuration, 0) + 1
+            controller.state.regen.unreadable_strikes[configuration] = strikes
             _LOGGER.warning(
                 "Storage regenerate for %s: config unreadable; retrying",
                 configuration,
                 exc_info=True,
             )
-            # A transient errno (EACCES, EIO on a network mount) must not
-            # strand the ladder: the firing timer already popped itself.
-            _arm_retry(controller, configuration, _RETRY_BACKOFF_BASE_SECONDS)
+            _arm_retry(
+                controller, configuration, min(_delay_for(strikes), _REGEN_FAILURE_TTL_SECONDS)
+            )
             return
+        controller.state.regen.unreadable_strikes.pop(configuration, None)
         stamp = _fresh_stamp(
             controller._metadata_store.get(configuration), current_mtime, time.time()
         )
@@ -129,16 +137,18 @@ async def spawn_only_generate(controller: DevicesController, configuration: str)
     config_path = str(controller._db.settings.rel_path(configuration))
     cmd = [*controller.state.esphome_cmd, "--dashboard", "compile", "--only-generate", config_path]
     try:
+        # Merged streams: esphome safe_prints validation errors to stdout
+        # while load errors log to stderr; the summary needs both.
         proc = await create_subprocess_exec(
             *cmd,
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
         )
     except Exception as err:
         _LOGGER.debug("Storage regenerate spawn failed for %s", configuration, exc_info=True)
         return f"spawn failed: {err!r}"
     try:
-        _, stderr = await proc.communicate()
+        output, _ = await proc.communicate()
     except asyncio.CancelledError:
         # Signals the direct esphome child only, not a git grandchild.
         kill_quietly(proc)
@@ -148,7 +158,7 @@ async def spawn_only_generate(controller: DevicesController, configuration: str)
         _LOGGER.debug("Storage regenerate failed for %s", configuration, exc_info=True)
         return f"communicate failed: {err!r}"
     if proc.returncode != 0:
-        text = stderr.decode(errors="replace").strip()
+        text = output.decode(errors="replace").strip()
         _LOGGER.debug(
             "Storage regenerate for %s exited %s: %s",
             configuration,

--- a/esphome_device_builder/controllers/devices/storage_regen.py
+++ b/esphome_device_builder/controllers/devices/storage_regen.py
@@ -235,7 +235,7 @@ def _fresh_stamp(
 
 def _delay_for(attempts: int) -> float:
     """Backoff delay after failed attempt number *attempts* (1-based)."""
-    return _RETRY_BACKOFF_BASE_SECONDS * 2 ** (attempts - 1)
+    return _RETRY_BACKOFF_BASE_SECONDS * 2.0 ** (attempts - 1)
 
 
 def _arm_retry(controller: DevicesController, configuration: str, delay: float) -> None:

--- a/esphome_device_builder/controllers/devices/storage_regen.py
+++ b/esphome_device_builder/controllers/devices/storage_regen.py
@@ -20,17 +20,13 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 # How long a failure stamp is honoured before the same untouched YAML
-# earns a fresh attempt budget. Four hours: transient problems are the
-# in-window retry ladder's job, so the TTL only paces re-checks (and
-# the give-up warning) for a genuinely broken config; an edit resets
-# the ladder immediately either way.
+# earns a fresh attempt budget.
 _REGEN_FAILURE_TTL_SECONDS: float = 4 * 3600.0
 
-# Every failure gets a bounded escalating retry before the terminal
-# stamp: a transient environment failure (interrupted package clone,
-# DNS, network) is indistinguishable from a broken YAML without parsing
-# stderr, and parsing is brittle. The attempt count persists in the
-# metadata store, so the ladder resumes across restarts.
+# A transient environment failure (interrupted clone, DNS) is
+# indistinguishable from a broken YAML without parsing stderr, so every
+# failure earns a bounded escalating retry; the attempt count persists
+# in the metadata store, resuming the ladder across restarts.
 _RETRY_BACKOFF_BASE_SECONDS: float = 30.0
 _MAX_REGEN_ATTEMPTS: int = 4
 
@@ -65,7 +61,6 @@ async def _run(controller: DevicesController, configuration: str) -> None:
         try:
             current_mtime = await run_in_executor(lambda: config_path.stat().st_mtime)
         except OSError:
-            # Unreadable or vanished config; a spawn would fail against it.
             _LOGGER.debug("Storage regenerate for %s: config unreadable; skipping", configuration)
             return
         stamp = _fresh_stamp(
@@ -82,12 +77,10 @@ async def _run(controller: DevicesController, configuration: str) -> None:
                 return
             remaining = _delay_for(attempts) - age
             if remaining > 0:
-                # Resume an interrupted backoff (a restart mid-window)
-                # with the remainder rather than spawning early.
+                # A restart mid-window resumes the remainder, not an early spawn.
                 _arm_retry(controller, configuration, remaining)
                 return
-        # The spawn/stamp/finalize steps route through the controller's
-        # bound delegates so tests patching them on the class intercept.
+        # Delegates so tests patching the class intercept.
         async with controller._regenerate_lock:
             success = await controller._spawn_only_generate(configuration)
         if success:
@@ -137,8 +130,7 @@ async def spawn_only_generate(controller: DevicesController, configuration: str)
     try:
         _, stderr = await proc.communicate()
     except asyncio.CancelledError:
-        # The shutdown drain cancels the run mid-subprocess; don't
-        # orphan the esphome/git child.
+        # Don't orphan the esphome/git child on the shutdown drain's cancel.
         kill_quietly(proc)
         raise
     except Exception:
@@ -218,10 +210,8 @@ def _fresh_stamp(
     """
     Return ``(attempts, age)`` for an unexpired stamp matching *current_mtime*.
 
-    A stamp without a parseable attempt count reads as terminal (a
-    pre-attempts stamp was only written once the budget was spent).
-    Future-dated stamps clamp to age 0 so clock skew can't lock the
-    regen out indefinitely.
+    A missing or unparseable attempt count reads as terminal;
+    future-dated stamps clamp to age 0.
     """
     cached_mtime = md.get("regen_failed_mtime")
     cached_at = md.get("regen_failed_at")

--- a/esphome_device_builder/controllers/devices/storage_regen.py
+++ b/esphome_device_builder/controllers/devices/storage_regen.py
@@ -62,15 +62,15 @@ def schedule(controller: DevicesController, configuration: str) -> None:
 async def _run(controller: DevicesController, configuration: str) -> None:
     try:
         config_path = controller._db.settings.rel_path(configuration)
-        stamp = None
         try:
             current_mtime = await run_in_executor(lambda: config_path.stat().st_mtime)
         except OSError:
-            pass
-        else:
-            stamp = _fresh_stamp(
-                controller._metadata_store.get(configuration), current_mtime, time.time()
-            )
+            # Unreadable or vanished config; a spawn would fail against it.
+            _LOGGER.debug("Storage regenerate for %s: config unreadable; skipping", configuration)
+            return
+        stamp = _fresh_stamp(
+            controller._metadata_store.get(configuration), current_mtime, time.time()
+        )
         if stamp is not None:
             attempts, age = stamp
             if attempts >= _MAX_REGEN_ATTEMPTS:
@@ -95,15 +95,21 @@ async def _run(controller: DevicesController, configuration: str) -> None:
             await controller._finalize_regen_success(configuration)
             await controller._scanner.reload(configuration)
             return
-        attempts = await controller._stamp_regen_failure(configuration)
-        if attempts < _MAX_REGEN_ATTEMPTS:
-            _arm_retry(controller, configuration, _delay_for(attempts))
+        recorded = await controller._stamp_regen_failure(configuration)
+        if recorded is None:
+            _LOGGER.debug(
+                "Storage regenerate for %s: config vanished mid-run; nothing recorded",
+                configuration,
+            )
+            return
+        if recorded < _MAX_REGEN_ATTEMPTS:
+            _arm_retry(controller, configuration, _delay_for(recorded))
             return
         _LOGGER.warning(
             "Storage regenerate for %s failed %d times; retrying after the "
             "YAML changes or the failure stamp expires",
             configuration,
-            attempts,
+            recorded,
         )
     finally:
         controller.state.regen.pending.discard(configuration)
@@ -136,6 +142,7 @@ async def spawn_only_generate(controller: DevicesController, configuration: str)
         kill_quietly(proc)
         raise
     except Exception:
+        kill_quietly(proc)
         _LOGGER.debug("Storage regenerate failed for %s", configuration, exc_info=True)
         return False
     if proc.returncode != 0:
@@ -149,19 +156,19 @@ async def spawn_only_generate(controller: DevicesController, configuration: str)
     return True
 
 
-async def stamp_failure(controller: DevicesController, configuration: str) -> int:
+async def stamp_failure(controller: DevicesController, configuration: str) -> int | None:
     """
     Record one more failed attempt against the YAML's current mtime.
 
     Returns the attempt count now on record. An edit or TTL expiry
     since the prior failure resets the count to 1; a vanished file
-    stamps nothing and reports the budget spent.
+    stamps nothing and returns None.
     """
     config_path = controller._db.settings.rel_path(configuration)
     try:
         mtime = await run_in_executor(lambda: config_path.stat().st_mtime)
     except OSError:
-        return _MAX_REGEN_ATTEMPTS
+        return None
     now = time.time()
     prior = _fresh_stamp(controller._metadata_store.get(configuration), mtime, now)
     attempts = (prior[0] if prior is not None else 0) + 1

--- a/esphome_device_builder/controllers/devices/storage_regen.py
+++ b/esphome_device_builder/controllers/devices/storage_regen.py
@@ -60,8 +60,15 @@ async def _run(controller: DevicesController, configuration: str) -> None:
         config_path = controller._db.settings.rel_path(configuration)
         try:
             current_mtime = await run_in_executor(lambda: config_path.stat().st_mtime)
+        except FileNotFoundError:
+            _LOGGER.debug("Storage regenerate for %s: config vanished; skipping", configuration)
+            return
         except OSError:
-            _LOGGER.debug("Storage regenerate for %s: config unreadable; skipping", configuration)
+            _LOGGER.warning(
+                "Storage regenerate for %s: config unreadable; skipping",
+                configuration,
+                exc_info=True,
+            )
             return
         stamp = _fresh_stamp(
             controller._metadata_store.get(configuration), current_mtime, time.time()
@@ -74,6 +81,8 @@ async def _run(controller: DevicesController, configuration: str) -> None:
                     "waiting for a YAML change or the stamp TTL",
                     configuration,
                 )
+                # No scan event fires for an untouched file; re-check at expiry.
+                _arm_retry(controller, configuration, _REGEN_FAILURE_TTL_SECONDS - age)
                 return
             remaining = _delay_for(attempts) - age
             if remaining > 0:
@@ -82,39 +91,37 @@ async def _run(controller: DevicesController, configuration: str) -> None:
                 return
         # Delegates so tests patching the class intercept.
         async with controller._regenerate_lock:
-            success = await controller._spawn_only_generate(configuration)
-        if success:
+            failure = await controller._spawn_only_generate(configuration)
+        if failure is None:
             controller.state.regen.cancel_retry(configuration)
             await controller._finalize_regen_success(configuration)
             await controller._scanner.reload(configuration)
             return
-        recorded = await controller._stamp_regen_failure(configuration)
-        if recorded is None:
-            _LOGGER.debug(
-                "Storage regenerate for %s: config vanished mid-run; nothing recorded",
-                configuration,
-            )
-            return
+        # Stamp against the pre-spawn mtime: an edit landing mid-run must
+        # not have the old content's failure charged to the new file.
+        recorded = await controller._stamp_regen_failure(configuration, current_mtime)
         if recorded < _MAX_REGEN_ATTEMPTS:
             _arm_retry(controller, configuration, _delay_for(recorded))
             return
         _LOGGER.warning(
-            "Storage regenerate for %s failed %d times; retrying after the "
-            "YAML changes or the failure stamp expires",
+            "Storage regenerate for %s failed %d times (%s); retrying after "
+            "the YAML changes or the failure stamp expires",
             configuration,
             recorded,
+            failure,
         )
+        # No scan event fires for an untouched file; re-check at expiry.
+        _arm_retry(controller, configuration, _REGEN_FAILURE_TTL_SECONDS)
     finally:
         controller.state.regen.pending.discard(configuration)
 
 
-async def spawn_only_generate(controller: DevicesController, configuration: str) -> bool:
+async def spawn_only_generate(controller: DevicesController, configuration: str) -> str | None:
     """
-    Run ``esphome compile --only-generate`` once. Return True iff exit code 0.
+    Run ``esphome compile --only-generate`` once.
 
-    Exceptions during spawn and non-zero exit codes both
-    produce False so the caller takes the same
-    retry-then-stamp branch.
+    Returns None on success, else a short failure summary the
+    give-up warning can carry.
     """
     config_path = str(controller._db.settings.rel_path(configuration))
     cmd = [*controller.state.esphome_cmd, "--dashboard", "compile", "--only-generate", config_path]
@@ -124,43 +131,38 @@ async def spawn_only_generate(controller: DevicesController, configuration: str)
             stdout=asyncio.subprocess.DEVNULL,
             stderr=asyncio.subprocess.PIPE,
         )
-    except Exception:
+    except Exception as err:
         _LOGGER.debug("Storage regenerate spawn failed for %s", configuration, exc_info=True)
-        return False
+        return f"spawn failed: {err!r}"
     try:
         _, stderr = await proc.communicate()
     except asyncio.CancelledError:
-        # Don't orphan the esphome/git child on the shutdown drain's cancel.
+        # Signals the direct esphome child only, not a git grandchild.
         kill_quietly(proc)
         raise
-    except Exception:
+    except Exception as err:
         kill_quietly(proc)
         _LOGGER.debug("Storage regenerate failed for %s", configuration, exc_info=True)
-        return False
+        return f"communicate failed: {err!r}"
     if proc.returncode != 0:
+        text = stderr.decode(errors="replace").strip()
         _LOGGER.debug(
             "Storage regenerate for %s exited %s: %s",
             configuration,
             proc.returncode,
-            stderr.decode(errors="replace").strip()[:500],
+            text[:500],
         )
-        return False
-    return True
+        return f"exit {proc.returncode}: {text[-200:]}" if text else f"exit {proc.returncode}"
+    return None
 
 
-async def stamp_failure(controller: DevicesController, configuration: str) -> int | None:
+async def stamp_failure(controller: DevicesController, configuration: str, mtime: float) -> int:
     """
-    Record one more failed attempt against the YAML's current mtime.
+    Record one more failed attempt against *mtime*.
 
     Returns the attempt count now on record. An edit or TTL expiry
-    since the prior failure resets the count to 1; a vanished file
-    stamps nothing and returns None.
+    since the prior failure resets the count to 1.
     """
-    config_path = controller._db.settings.rel_path(configuration)
-    try:
-        mtime = await run_in_executor(lambda: config_path.stat().st_mtime)
-    except OSError:
-        return None
     now = time.time()
     prior = _fresh_stamp(controller._metadata_store.get(configuration), mtime, now)
     attempts = (prior[0] if prior is not None else 0) + 1

--- a/esphome_device_builder/controllers/devices/storage_regen.py
+++ b/esphome_device_builder/controllers/devices/storage_regen.py
@@ -12,7 +12,7 @@ from ...constants import is_secrets_file
 from ...helpers.async_ import run_in_executor
 from ...helpers.build_size import coerce_sidecar_int
 from ...helpers.config_hash import read_build_info_hash
-from ...helpers.subprocess import create_subprocess_exec, kill_quietly
+from ...helpers.subprocess import run_subprocess_capture
 
 if TYPE_CHECKING:
     from .controller import DevicesController
@@ -29,6 +29,10 @@ _REGEN_FAILURE_TTL_SECONDS: float = 4 * 3600.0
 # in the metadata store, resuming the ladder across restarts.
 _RETRY_BACKOFF_BASE_SECONDS: float = 30.0
 _MAX_REGEN_ATTEMPTS: int = 4
+
+# A hung run (stalled package fetch) would hold ``_regenerate_lock``
+# indefinitely; matches the config-bundle build timeout.
+_ONLY_GENERATE_TIMEOUT_SECONDS: float = 300.0
 
 
 def schedule(controller: DevicesController, configuration: str) -> None:
@@ -58,19 +62,19 @@ def schedule(controller: DevicesController, configuration: str) -> None:
 async def _run(controller: DevicesController, configuration: str) -> None:
     try:
         config_path = controller._db.settings.rel_path(configuration)
+        regen = controller.state.regen
         try:
-            current_mtime = await run_in_executor(lambda: config_path.stat().st_mtime)
+            current_mtime = (await run_in_executor(config_path.stat)).st_mtime
         except FileNotFoundError:
             _LOGGER.debug("Storage regenerate for %s: config vanished; skipping", configuration)
-            controller.state.regen.unreadable_strikes.pop(configuration, None)
+            regen.clear_strikes(configuration)
             return
         except OSError:
             # A transient errno (EACCES, EIO on a network mount) must not
             # strand the ladder: the firing timer already popped itself.
             # Without an mtime the stamp can't key the failure, so a RAM
             # strike escalates the re-arm up to the TTL.
-            strikes = controller.state.regen.unreadable_strikes.get(configuration, 0) + 1
-            controller.state.regen.unreadable_strikes[configuration] = strikes
+            strikes = regen.record_strike(configuration)
             _LOGGER.warning(
                 "Storage regenerate for %s: config unreadable; retrying",
                 configuration,
@@ -80,7 +84,7 @@ async def _run(controller: DevicesController, configuration: str) -> None:
                 controller, configuration, min(_delay_for(strikes), _REGEN_FAILURE_TTL_SECONDS)
             )
             return
-        controller.state.regen.unreadable_strikes.pop(configuration, None)
+        regen.clear_strikes(configuration)
         stamp = _fresh_stamp(
             controller._metadata_store.get(configuration), current_mtime, time.time()
         )
@@ -92,8 +96,7 @@ async def _run(controller: DevicesController, configuration: str) -> None:
                     "waiting for a YAML change or the stamp TTL",
                     configuration,
                 )
-                # No scan event fires for an untouched file; re-check at expiry.
-                _arm_retry(controller, configuration, _REGEN_FAILURE_TTL_SECONDS - age)
+                _arm_ttl_recheck(controller, configuration, age)
                 return
             remaining = _delay_for(attempts) - age
             if remaining > 0:
@@ -104,13 +107,13 @@ async def _run(controller: DevicesController, configuration: str) -> None:
         async with controller._regenerate_lock:
             failure = await controller._spawn_only_generate(configuration)
         if failure is None:
-            controller.state.regen.cancel_retry(configuration)
+            regen.cancel_retry(configuration)
             await controller._finalize_regen_success(configuration)
             await controller._scanner.reload(configuration)
             return
         # Stamp against the pre-spawn mtime: an edit landing mid-run must
         # not have the old content's failure charged to the new file.
-        recorded = await controller._stamp_regen_failure(configuration, current_mtime)
+        recorded = controller._stamp_regen_failure(configuration, current_mtime)
         if recorded < _MAX_REGEN_ATTEMPTS:
             _arm_retry(controller, configuration, _delay_for(recorded))
             return
@@ -121,8 +124,7 @@ async def _run(controller: DevicesController, configuration: str) -> None:
             recorded,
             failure,
         )
-        # No scan event fires for an untouched file; re-check at expiry.
-        _arm_retry(controller, configuration, _REGEN_FAILURE_TTL_SECONDS)
+        _arm_ttl_recheck(controller, configuration)
     finally:
         controller.state.regen.pending.discard(configuration)
 
@@ -137,39 +139,29 @@ async def spawn_only_generate(controller: DevicesController, configuration: str)
     config_path = str(controller._db.settings.rel_path(configuration))
     cmd = [*controller.state.esphome_cmd, "--dashboard", "compile", "--only-generate", config_path]
     try:
-        # Merged streams: esphome safe_prints validation errors to stdout
-        # while load errors log to stderr; the summary needs both.
-        proc = await create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-        )
+        # Merged streams (the helper's default): esphome safe_prints
+        # validation errors to stdout while load errors log to stderr;
+        # the summary needs both.
+        result = await run_subprocess_capture(*cmd, timeout=_ONLY_GENERATE_TIMEOUT_SECONDS)
     except Exception as err:
-        _LOGGER.debug("Storage regenerate spawn failed for %s", configuration, exc_info=True)
-        return f"spawn failed: {err!r}"
-    try:
-        output, _ = await proc.communicate()
-    except asyncio.CancelledError:
-        # Signals the direct esphome child only, not a git grandchild.
-        kill_quietly(proc)
-        raise
-    except Exception as err:
-        kill_quietly(proc)
         _LOGGER.debug("Storage regenerate failed for %s", configuration, exc_info=True)
-        return f"communicate failed: {err!r}"
-    if proc.returncode != 0:
-        text = output.decode(errors="replace").strip()
-        _LOGGER.debug(
-            "Storage regenerate for %s exited %s: %s",
-            configuration,
-            proc.returncode,
-            text[:500],
-        )
-        return f"exit {proc.returncode}: {text[-200:]}" if text else f"exit {proc.returncode}"
-    return None
+        return f"subprocess error: {err!r}"
+    if result.timed_out:
+        return f"timed out after {_ONLY_GENERATE_TIMEOUT_SECONDS:.0f}s"
+    if result.returncode == 0:
+        return None
+    text = result.stdout[-4096:].decode(errors="replace").strip()
+    _LOGGER.debug(
+        "Storage regenerate for %s exited %s: %s",
+        configuration,
+        result.returncode,
+        text[-500:],
+    )
+    summary = f"exit {result.returncode}"
+    return f"{summary}: {text[-200:]}" if text else summary
 
 
-async def stamp_failure(controller: DevicesController, configuration: str, mtime: float) -> int:
+def stamp_failure(controller: DevicesController, configuration: str, mtime: float) -> int:
     """
     Record one more failed attempt against *mtime*.
 
@@ -248,6 +240,15 @@ def _fresh_stamp(
 def _delay_for(attempts: int) -> float:
     """Backoff delay after failed attempt number *attempts* (1-based)."""
     return _RETRY_BACKOFF_BASE_SECONDS * 2.0 ** (attempts - 1)
+
+
+def _arm_ttl_recheck(controller: DevicesController, configuration: str, age: float = 0.0) -> None:
+    """Arm the stamp-expiry re-check unless one is already pending."""
+    # No scan event fires for an untouched file, and the deadline never
+    # moves for the same stamp — re-arming would only churn the timer.
+    if configuration in controller.state.regen.retry_timers:
+        return
+    _arm_retry(controller, configuration, _REGEN_FAILURE_TTL_SECONDS - age)
 
 
 def _arm_retry(controller: DevicesController, configuration: str, delay: float) -> None:

--- a/esphome_device_builder/controllers/devices/storage_regen.py
+++ b/esphome_device_builder/controllers/devices/storage_regen.py
@@ -5,42 +5,43 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from ...constants import is_secrets_file
 from ...helpers.async_ import run_in_executor
+from ...helpers.build_size import coerce_sidecar_int
 from ...helpers.config_hash import read_build_info_hash
-from ...helpers.subprocess import create_subprocess_exec
+from ...helpers.subprocess import create_subprocess_exec, kill_quietly
 
 if TYPE_CHECKING:
     from .controller import DevicesController
 
 _LOGGER = logging.getLogger(__name__)
 
-# How long the persisted "regen failed" stamp is honoured before
-# a restart-time check is allowed to re-spawn ``--only-generate``
-# for the same untouched YAML. One hour: short enough that a
-# debugger restart-loop doesn't churn through 10 spawns on the
-# same broken config, long enough that the user can come back
-# later without having to touch the file.
-_REGEN_FAILURE_TTL_SECONDS: float = 3600.0
+# How long a failure stamp is honoured before the same untouched YAML
+# earns a fresh attempt budget. Four hours: transient problems are the
+# in-window retry ladder's job, so the TTL only paces re-checks (and
+# the give-up warning) for a genuinely broken config; an edit resets
+# the ladder immediately either way.
+_REGEN_FAILURE_TTL_SECONDS: float = 4 * 3600.0
 
-# Every failure gets a bounded escalating retry before the stamp:
-# a transient environment failure (interrupted package clone, DNS,
-# network) is indistinguishable from a broken YAML without parsing
-# stderr, and parsing is brittle.
+# Every failure gets a bounded escalating retry before the terminal
+# stamp: a transient environment failure (interrupted package clone,
+# DNS, network) is indistinguishable from a broken YAML without parsing
+# stderr, and parsing is brittle. The attempt count persists in the
+# metadata store, so the ladder resumes across restarts.
 _RETRY_BACKOFF_BASE_SECONDS: float = 30.0
-_MAX_REGEN_RETRIES: int = 3
+_MAX_REGEN_ATTEMPTS: int = 4
 
 
 def schedule(controller: DevicesController, configuration: str) -> None:
     """
     Run ``esphome compile --only-generate <yaml>`` in the background.
 
-    Spawn rate is bounded four ways: the in-memory pending + failed
-    sets (per-session), a bounded escalating retry between a failure
-    and the failed marker, an on-disk failure stamp (cross-restart,
-    TTL-gated), and ``_regenerate_lock`` serialising the subprocess.
+    Spawn rate is bounded three ways: the in-memory pending set, the
+    persisted failure stamp ``_run`` consults (attempt budget, backoff
+    min-age, TTL), and ``_regenerate_lock`` serialising the subprocess.
     """
     if is_secrets_file(configuration):
         # Shared credentials, not a buildable config: no build dir to
@@ -50,9 +51,6 @@ def schedule(controller: DevicesController, configuration: str) -> None:
         return  # ``start()`` hasn't run yet.
     if configuration in controller.state.regen.pending:
         return  # already scheduled.
-    if configuration in controller.state.regen.failed:
-        # Same-session retry would replay the same error.
-        return
 
     # Mark synchronously so a second same-tick call sees the
     # marker before the coroutine yields. ``_run``'s finally
@@ -61,42 +59,52 @@ def schedule(controller: DevicesController, configuration: str) -> None:
     controller._db.create_background_task(_run(controller, configuration))
 
 
-async def shutdown(controller: DevicesController) -> None:
-    """Cancel every armed retry, stamping each so a restart remembers the failure."""
-    # Cancel before the stamp's executor hop, or a timer expiring in
-    # that window fires ``schedule`` after the task drain.
-    armed = list(controller.state.regen.retry_timers)
-    controller.state.regen.cancel_all_retry_timers()
-    for configuration in armed:
-        await controller._stamp_regen_failure(configuration)
-
-
 async def _run(controller: DevicesController, configuration: str) -> None:
     try:
-        # Routed through the controller's bound delegates so
-        # tests patching any of the four async helpers on the
-        # class still intercept.
-        if await controller._regen_already_failed_recently_async(configuration):
-            controller.state.regen.failed.add(configuration)
-            return
+        config_path = controller._db.settings.rel_path(configuration)
+        stamp = None
+        try:
+            current_mtime = await run_in_executor(lambda: config_path.stat().st_mtime)
+        except OSError:
+            pass
+        else:
+            stamp = _fresh_stamp(
+                controller._metadata_store.get(configuration), current_mtime, time.time()
+            )
+        if stamp is not None:
+            attempts, age = stamp
+            if attempts >= _MAX_REGEN_ATTEMPTS:
+                _LOGGER.debug(
+                    "Storage regenerate for %s spent its attempt budget; "
+                    "waiting for a YAML change or the stamp TTL",
+                    configuration,
+                )
+                return
+            remaining = _delay_for(attempts) - age
+            if remaining > 0:
+                # Resume an interrupted backoff (a restart mid-window)
+                # with the remainder rather than spawning early.
+                _arm_retry(controller, configuration, remaining)
+                return
+        # The spawn/stamp/finalize steps route through the controller's
+        # bound delegates so tests patching them on the class intercept.
         async with controller._regenerate_lock:
             success = await controller._spawn_only_generate(configuration)
         if success:
-            controller.state.regen.reset(configuration)
+            controller.state.regen.cancel_retry(configuration)
             await controller._finalize_regen_success(configuration)
             await controller._scanner.reload(configuration)
             return
-        if _schedule_retry(controller, configuration):
+        attempts = await controller._stamp_regen_failure(configuration)
+        if attempts < _MAX_REGEN_ATTEMPTS:
+            _arm_retry(controller, configuration, _delay_for(attempts))
             return
-        attempts = controller.state.regen.retry_strikes.get(configuration, 0) + 1
-        controller.state.regen.reset(configuration)
-        controller.state.regen.failed.add(configuration)
         _LOGGER.warning(
-            "Storage regenerate for %s failed %d times; giving up until the YAML changes",
+            "Storage regenerate for %s failed %d times; retrying after the "
+            "YAML changes or the failure stamp expires",
             configuration,
             attempts,
         )
-        await controller._stamp_regen_failure(configuration)
     finally:
         controller.state.regen.pending.discard(configuration)
 
@@ -117,9 +125,18 @@ async def spawn_only_generate(controller: DevicesController, configuration: str)
             stdout=asyncio.subprocess.DEVNULL,
             stderr=asyncio.subprocess.PIPE,
         )
-        _, stderr = await proc.communicate()
     except Exception:
         _LOGGER.debug("Storage regenerate spawn failed for %s", configuration, exc_info=True)
+        return False
+    try:
+        _, stderr = await proc.communicate()
+    except asyncio.CancelledError:
+        # The shutdown drain cancels the run mid-subprocess; don't
+        # orphan the esphome/git child.
+        kill_quietly(proc)
+        raise
+    except Exception:
+        _LOGGER.debug("Storage regenerate failed for %s", configuration, exc_info=True)
         return False
     if proc.returncode != 0:
         _LOGGER.debug(
@@ -132,53 +149,29 @@ async def spawn_only_generate(controller: DevicesController, configuration: str)
     return True
 
 
-async def already_failed_recently_async(controller: DevicesController, configuration: str) -> bool:
+async def stamp_failure(controller: DevicesController, configuration: str) -> int:
     """
-    Return True iff the persisted failure stamp is unchanged-and-fresh.
+    Record one more failed attempt against the YAML's current mtime.
 
-    Both halves must hold: the YAML's ``stat.st_mtime`` equals
-    the cached ``regen_failed_mtime``, and the cached
-    ``regen_failed_at`` is within ``_REGEN_FAILURE_TTL_SECONDS``
-    (clamped against future-dated stamps so clock skew can't
-    lock the regen out indefinitely).
-    """
-    config_path = controller._db.settings.rel_path(configuration)
-
-    try:
-        current_mtime = await run_in_executor(lambda: config_path.stat().st_mtime)
-    except OSError:
-        return False
-    md = controller._metadata_store.get(configuration)
-    cached_mtime = md.get("regen_failed_mtime")
-    cached_at = md.get("regen_failed_at")
-    if not cached_mtime or not cached_at:
-        return False
-    try:
-        mtime_matches = float(cached_mtime) == current_mtime
-        age = max(0.0, time.time() - float(cached_at))
-    except (TypeError, ValueError):
-        return False
-    return mtime_matches and age < _REGEN_FAILURE_TTL_SECONDS
-
-
-async def stamp_failure(controller: DevicesController, configuration: str) -> None:
-    """
-    Persist the cross-restart "we already tried, gave up" marker.
-
-    Reads the YAML's mtime on the executor and samples
-    wall-clock alongside it so the stamp captures the same
-    instant the file's mtime was observed.
+    Returns the attempt count now on record. An edit or TTL expiry
+    since the prior failure resets the count to 1; a vanished file
+    stamps nothing and reports the budget spent.
     """
     config_path = controller._db.settings.rel_path(configuration)
     try:
         mtime = await run_in_executor(lambda: config_path.stat().st_mtime)
     except OSError:
-        return  # file vanished mid-regen; nothing to stamp.
+        return _MAX_REGEN_ATTEMPTS
+    now = time.time()
+    prior = _fresh_stamp(controller._metadata_store.get(configuration), mtime, now)
+    attempts = (prior[0] if prior is not None else 0) + 1
     controller._metadata_store.update(
         configuration,
         regen_failed_mtime=mtime,
-        regen_failed_at=time.time(),
+        regen_failed_at=now,
+        regen_failed_attempts=attempts,
     )
+    return attempts
 
 
 async def finalize_success(controller: DevicesController, configuration: str) -> None:
@@ -194,6 +187,7 @@ async def finalize_success(controller: DevicesController, configuration: str) ->
     fields: dict[str, Any] = {
         "regen_failed_mtime": 0.0,
         "regen_failed_at": 0.0,
+        "regen_failed_attempts": 0,
     }
     if new_hash:
         fields["expected_config_hash"] = new_hash
@@ -211,24 +205,45 @@ async def finalize_success(controller: DevicesController, configuration: str) ->
     _LOGGER.debug("Stored expected_config_hash for %s: %s", configuration, new_hash)
 
 
-def _schedule_retry(controller: DevicesController, configuration: str) -> bool:
-    """Arm one escalating-backoff retry; False once the budget is spent."""
-    regen = controller.state.regen
-    strikes = regen.retry_strikes.get(configuration, 0)
-    if strikes >= _MAX_REGEN_RETRIES:
-        return False
-    regen.retry_strikes[configuration] = strikes + 1
-    delay = _RETRY_BACKOFF_BASE_SECONDS * 2**strikes
-    _LOGGER.debug(
-        "Storage regenerate for %s failed; retrying in %.0fs (attempt %d/%d)",
-        configuration,
-        delay,
-        strikes + 1,
-        _MAX_REGEN_RETRIES,
-    )
+def _fresh_stamp(
+    md: Mapping[str, Any], current_mtime: float, now: float
+) -> tuple[int, float] | None:
+    """
+    Return ``(attempts, age)`` for an unexpired stamp matching *current_mtime*.
+
+    A stamp without a parseable attempt count reads as terminal (a
+    pre-attempts stamp was only written once the budget was spent).
+    Future-dated stamps clamp to age 0 so clock skew can't lock the
+    regen out indefinitely.
+    """
+    cached_mtime = md.get("regen_failed_mtime")
+    cached_at = md.get("regen_failed_at")
+    if not cached_mtime or not cached_at:
+        return None
+    try:
+        if float(cached_mtime) != current_mtime:
+            return None
+        age = max(0.0, now - float(cached_at))
+    except (TypeError, ValueError):
+        return None
+    if age >= _REGEN_FAILURE_TTL_SECONDS:
+        return None
+    attempts = coerce_sidecar_int(md.get("regen_failed_attempts"))
+    # Missing, unparseable, or non-positive reads as terminal.
+    return (attempts if attempts >= 1 else _MAX_REGEN_ATTEMPTS), age
+
+
+def _delay_for(attempts: int) -> float:
+    """Backoff delay after failed attempt number *attempts* (1-based)."""
+    return _RETRY_BACKOFF_BASE_SECONDS * 2 ** (attempts - 1)
+
+
+def _arm_retry(controller: DevicesController, configuration: str, delay: float) -> None:
+    _LOGGER.debug("Storage regenerate retry for %s in %.0fs", configuration, delay)
     loop = asyncio.get_running_loop()
-    regen.arm_retry(configuration, loop.call_later(delay, _fire_retry, controller, configuration))
-    return True
+    controller.state.regen.arm_retry(
+        configuration, loop.call_later(delay, _fire_retry, controller, configuration)
+    )
 
 
 def _fire_retry(controller: DevicesController, configuration: str) -> None:

--- a/esphome_device_builder/controllers/devices/storage_regen.py
+++ b/esphome_device_builder/controllers/devices/storage_regen.py
@@ -91,10 +91,14 @@ async def _run(controller: DevicesController, configuration: str) -> None:
         if stamp is not None:
             attempts, age = stamp
             if attempts >= _MAX_REGEN_ATTEMPTS:
-                _LOGGER.debug(
-                    "Storage regenerate for %s spent its attempt budget; "
-                    "waiting for a YAML change or the stamp TTL",
+                # The give-up warning fired in the session that spent the
+                # budget; without this one a restarted dashboard shows a
+                # hashless device with nothing in the log to explain it.
+                _LOGGER.warning(
+                    "Storage regenerate for %s failed %d times previously; "
+                    "retrying after the YAML changes or the failure stamp expires",
                     configuration,
+                    attempts,
                 )
                 _arm_ttl_recheck(controller, configuration, age)
                 return
@@ -146,11 +150,17 @@ async def spawn_only_generate(controller: DevicesController, configuration: str)
     except Exception as err:
         _LOGGER.debug("Storage regenerate failed for %s", configuration, exc_info=True)
         return f"subprocess error: {err!r}"
+    text = result.stdout[-4096:].decode(errors="replace").strip()
     if result.timed_out:
+        _LOGGER.warning(
+            "Storage regenerate for %s timed out after %.0fs; output tail: %s",
+            configuration,
+            _ONLY_GENERATE_TIMEOUT_SECONDS,
+            text[-500:],
+        )
         return f"timed out after {_ONLY_GENERATE_TIMEOUT_SECONDS:.0f}s"
     if result.returncode == 0:
         return None
-    text = result.stdout[-4096:].decode(errors="replace").strip()
     _LOGGER.debug(
         "Storage regenerate for %s exited %s: %s",
         configuration,

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -610,8 +610,7 @@ class DeviceBuilder:
         if self._bg_poll is not None:
             self._bg_poll.unsubscribe()
         if self.devices is not None:
-            # Cancel armed regen retries before the drain — an expiring
-            # timer would otherwise schedule a task into the drained set.
+            # An expiring regen retry would schedule into the drained set.
             self.devices.state.regen.cancel_all_retry_timers()
         await drain_tasks(self._background_tasks)
         # Tear down the remote-build listener (if it was bound)

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -609,6 +609,10 @@ class DeviceBuilder:
             await drain_tasks((self._bg_task,), log_exceptions=True)
         if self._bg_poll is not None:
             self._bg_poll.unsubscribe()
+        if self.devices is not None:
+            # Cancel armed regen retries before the drain — an expiring
+            # timer would otherwise schedule a task into the drained set.
+            self.devices.state.regen.cancel_all_retry_timers()
         await drain_tasks(self._background_tasks)
         # Tear down the remote-build listener (if it was bound)
         # before the controller it depends on. Order matters less

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -454,7 +454,7 @@ class MakeControllerFactory(Protocol):
 
 
 @pytest.fixture
-def make_controller() -> MakeControllerFactory:
+def make_controller() -> Iterator[MakeControllerFactory]:
     """Return a factory that builds a bypass-init ``DevicesController``.
 
     Most ``tests/controllers/devices/`` files exercise a single
@@ -598,9 +598,15 @@ def make_controller() -> MakeControllerFactory:
 
         controller.state.esphome_cmd = esphome_cmd if esphome_cmd is not None else []
 
+        controllers.append(controller)
         return controller
 
-    return _make
+    controllers: list[DevicesController] = []
+    yield _make
+    # Regen retry timers survive the test body otherwise; central
+    # teardown replaces a per-test cancel epilogue.
+    for controller in controllers:
+        controller.state.regen.cancel_all_retry_timers()
 
 
 CaptureDevicesEventsFactory = Callable[..., list[Event]]

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -1316,6 +1316,30 @@ async def test_on_scan_change_reloaded_missing_fields_skips_regen(
     assert regenerated == []
 
 
+async def test_on_scan_change_updated_reschedules_cancelled_retry(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An edit that cancels an armed retry respawns the ladder for the new content."""
+    controller, regenerated = _fingerprint_rig(tmp_path, make_controller, monkeypatch, "same")
+    handle = asyncio.get_running_loop().call_later(30.0, lambda: None)
+    controller.state.regen.retry_timers["kitchen.yaml"] = handle
+
+    controller._on_scan_change(
+        ScanChange.UPDATED,
+        make_device(
+            name="kitchen",
+            network_fingerprint="same",
+            loaded_integrations=["wifi"],
+            expected_config_hash="abcd1234",
+        ),
+    )
+
+    assert handle.cancelled()
+    assert regenerated == ["kitchen.yaml"]
+
+
 async def test_on_scan_change_updated_same_network_skips_regen(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -1083,54 +1083,39 @@ def test_get_devices_bridge_returns_scanner_property(
 # ---------------------------------------------------------------------------
 
 
-async def test_on_scan_change_updated_resets_regen_state(
+async def test_on_scan_change_updated_cancels_armed_retry(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """A YAML edit clears the prior storage-regenerate failure marker.
-
-    The marker is sticky to spare us spamming a known-broken YAML
-    with retried ``--only-generate`` calls. An UPDATED / REMOVED
-    scan change is the user's signal that the file might be
-    fixed, so the marker has to clear or the device sits with no
-    storage refresh forever.
-    """
+    """A YAML edit drops the armed retry; the edit's mtime invalidates the stamp."""
     controller = make_controller(tmp_path, with_state_monitor=True, with_regenerate_state=True)
-    controller.state.regen.failed.add("kitchen.yaml")
-    controller.state.regen.retry_strikes["kitchen.yaml"] = 1
     handle = asyncio.get_running_loop().call_later(30.0, lambda: None)
     controller.state.regen.retry_timers["kitchen.yaml"] = handle
     device = _device("kitchen")
 
     controller._on_scan_change(ScanChange.UPDATED, device)
 
-    assert "kitchen.yaml" not in controller.state.regen.failed
     assert handle.cancelled()
     assert controller.state.regen.retry_timers == {}
-    assert controller.state.regen.retry_strikes == {}
 
 
 async def test_on_scan_change_reloaded_keeps_armed_retry(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """A metadata reload clears the failure marker but not the armed retry.
+    """A metadata reload leaves the armed retry alone.
 
     The cold-start refine emits RELOADED for every device; cancelling
     the retry there would drop the only pending recovery for a config
     whose first regen failed.
     """
     controller = make_controller(tmp_path, with_state_monitor=True, with_regenerate_state=True)
-    controller.state.regen.failed.add("kitchen.yaml")
-    controller.state.regen.retry_strikes["kitchen.yaml"] = 1
     handle = asyncio.get_running_loop().call_later(30.0, lambda: None)
     controller.state.regen.retry_timers["kitchen.yaml"] = handle
     device = _device("kitchen")
 
     controller._on_scan_change(ScanChange.RELOADED, device)
 
-    assert "kitchen.yaml" not in controller.state.regen.failed
     assert not handle.cancelled()
     assert controller.state.regen.retry_timers == {"kitchen.yaml": handle}
-    assert controller.state.regen.retry_strikes == {"kitchen.yaml": 1}
     handle.cancel()
 
 
@@ -1267,7 +1252,13 @@ async def test_on_scan_change_updated_network_change_schedules_regen(
     controller, regenerated = _fingerprint_rig(tmp_path, make_controller, monkeypatch, "old")
 
     controller._on_scan_change(
-        ScanChange.UPDATED, make_device(name="kitchen", network_fingerprint="new")
+        ScanChange.UPDATED,
+        make_device(
+            name="kitchen",
+            network_fingerprint="new",
+            loaded_integrations=["wifi"],
+            expected_config_hash="abcd1234",
+        ),
     )
 
     assert regenerated == ["kitchen.yaml"]
@@ -1295,6 +1286,36 @@ async def test_on_scan_change_added_network_change_schedules_regen(
     assert regenerated == ["kitchen.yaml"]
 
 
+async def test_on_scan_change_updated_missing_fields_schedules_regen(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An out-of-band edit of a config with missing fields schedules a regen."""
+    controller, regenerated = _fingerprint_rig(tmp_path, make_controller, monkeypatch, "same")
+
+    controller._on_scan_change(
+        ScanChange.UPDATED, make_device(name="kitchen", network_fingerprint="same")
+    )
+
+    assert regenerated == ["kitchen.yaml"]
+
+
+async def test_on_scan_change_reloaded_missing_fields_skips_regen(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A metadata reload never schedules a regen, missing fields or not."""
+    controller, regenerated = _fingerprint_rig(tmp_path, make_controller, monkeypatch, "same")
+
+    controller._on_scan_change(
+        ScanChange.RELOADED, make_device(name="kitchen", network_fingerprint="same")
+    )
+
+    assert regenerated == []
+
+
 async def test_on_scan_change_updated_same_network_skips_regen(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -1304,7 +1325,13 @@ async def test_on_scan_change_updated_same_network_skips_regen(
     controller, regenerated = _fingerprint_rig(tmp_path, make_controller, monkeypatch, "same")
 
     controller._on_scan_change(
-        ScanChange.UPDATED, make_device(name="kitchen", network_fingerprint="same")
+        ScanChange.UPDATED,
+        make_device(
+            name="kitchen",
+            network_fingerprint="same",
+            loaded_integrations=["wifi"],
+            expected_config_hash="abcd1234",
+        ),
     )
 
     assert regenerated == []
@@ -1319,7 +1346,13 @@ async def test_on_scan_change_empty_fingerprint_is_no_information(
     controller, regenerated = _fingerprint_rig(tmp_path, make_controller, monkeypatch, "old")
 
     controller._on_scan_change(
-        ScanChange.UPDATED, make_device(name="kitchen", network_fingerprint="")
+        ScanChange.UPDATED,
+        make_device(
+            name="kitchen",
+            network_fingerprint="",
+            loaded_integrations=["wifi"],
+            expected_config_hash="abcd1234",
+        ),
     )
 
     assert regenerated == []

--- a/tests/controllers/devices/test_metadata_resolver.py
+++ b/tests/controllers/devices/test_metadata_resolver.py
@@ -279,7 +279,6 @@ def test_added_device_without_hash_triggers_regenerate(
     controller = DevicesController.__new__(DevicesController)
     controller._db = MagicMock()
     controller.state = DevicesState()
-    controller.state.regen.failed = set()
     controller._state_monitor = RecordingStateMonitor()
     controller._metadata_store = MagicMock(**{"get.return_value": {}})
     regenerated: list[str] = []
@@ -325,7 +324,6 @@ def test_added_device_fully_populated_does_not_regenerate(
     controller = DevicesController.__new__(DevicesController)
     controller._db = MagicMock()
     controller.state = DevicesState()
-    controller.state.regen.failed = set()
     controller._state_monitor = MagicMock()
     controller._metadata_store = MagicMock(**{"get.return_value": {}})
     regenerated: list[str] = []

--- a/tests/controllers/devices/test_metadata_store.py
+++ b/tests/controllers/devices/test_metadata_store.py
@@ -610,6 +610,7 @@ def test_store_fields_pinned() -> None:
                 "build_size_info_mtime",
                 "regen_failed_mtime",
                 "regen_failed_at",
+                "regen_failed_attempts",
             }
         )
         == STORE_FIELDS

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -184,6 +184,7 @@ async def test_out_of_band_network_edit_spawns_only_generate(
         _fake_spawn,
     )
     monkeypatch.setattr(DevicesController, "_finalize_regen_success", AsyncMock())
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
     _seed_store(controller, "kitchen.yaml", network_fingerprint="pre-edit-digest")
 
     controller._on_scan_change(
@@ -440,6 +441,7 @@ async def test_regenerate_pending_blocks_in_flight_dupe(
     guard fires and no second task lands.
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
     in_flight = asyncio.Event()
     release = asyncio.Event()
 
@@ -713,30 +715,19 @@ async def test_regenerate_runs_when_yaml_mtime_moves_past_stamp(
     assert len(spawn_calls) == 1
 
 
-async def test_regenerate_runs_when_yaml_missing_for_stamp_check(
+async def test_regenerate_skips_when_yaml_unreadable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """YAML file vanished between scan and schedule → guard is permissive.
+    """YAML vanished between scan and schedule → no spawn against it.
 
     A torn ``stat()`` (file removed mid-flight by an editor or
-    archive) returns ``OSError``; the guard treats that as "we
-    can't verify, let the spawn try" rather than silently
-    skipping. The spawn itself will then fail and re-stamp; the
-    important thing is we don't dead-end on a missing file.
+    archive) returns ``OSError``; a spawn would just fail against
+    the missing file, so the run skips and the next scan event
+    for the path retriggers.
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
-    # Persist a stamp without ever creating the YAML — simulates the
-    # race window. The metadata sidecar's entry is keyed by filename,
-    # not file-existence.
-    _seed_store(
-        controller,
-        "kitchen.yaml",
-        regen_failed_mtime=12345.0,
-        regen_failed_at=1700000000.0,
-    )
-
     spawn_calls: list[tuple[str, ...]] = []
 
     async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
@@ -751,8 +742,8 @@ async def test_regenerate_runs_when_yaml_missing_for_stamp_check(
     controller._schedule_storage_regenerate("kitchen.yaml")
     await _drain(controller)
 
-    # The spawn ran (the stat() failed → guard didn't short-circuit).
-    assert len(spawn_calls) == 1
+    assert spawn_calls == []
+    assert controller.state.regen.pending == set()
 
 
 async def test_regenerate_clamps_negative_stamp_age(
@@ -1218,6 +1209,71 @@ async def test_cancelled_run_kills_subprocess_without_stamp(
     assert proc.killed
     assert _read_store(controller, "kitchen.yaml") == {}
     assert controller.state.regen.pending == set()
+
+
+async def test_communicate_failure_kills_child_and_counts_the_attempt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A pipe error mid-communicate kills the child and feeds the ladder."""
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    class _BrokenPipeProc:
+        returncode: int | None = None
+
+        def __init__(self) -> None:
+            self.killed = False
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            raise OSError("broken pipe")
+
+        def kill(self) -> None:
+            self.killed = True
+
+    proc = _BrokenPipeProc()
+
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _BrokenPipeProc:
+        return proc
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        _fake_spawn,
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+
+    assert proc.killed
+    assert _read_store(controller, "kitchen.yaml")["regen_failed_attempts"] == 1
+    controller.state.regen.cancel_all_retry_timers()
+
+
+async def test_vanished_mid_run_records_nothing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A YAML deleted during the run stamps nothing and arms no retry."""
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+        yaml_path.unlink()
+        return _FakeProc(returncode=1, stderr=b"gone")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        _fake_spawn,
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+
+    assert _read_store(controller, "kitchen.yaml") == {}
+    assert controller.state.regen.retry_timers == {}
 
 
 async def test_edit_between_failures_resets_attempts(

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -1301,7 +1301,7 @@ async def test_regenerate_warns_when_yaml_unreadable(
     make_controller: MakeControllerFactory,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A non-vanish stat error skips loudly instead of masquerading as a vanish."""
+    """A non-vanish stat error re-arms the ladder loudly instead of stranding it."""
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
     spawn_calls: list[tuple[str, ...]] = []
 
@@ -1327,6 +1327,9 @@ async def test_regenerate_warns_when_yaml_unreadable(
 
     assert spawn_calls == []
     assert any("config unreadable" in record.message for record in caplog.records)
+    # A transient errno keeps the ladder alive: the base backoff re-arms.
+    assert set(controller.state.regen.retry_timers) == {"kitchen.yaml"}
+    controller.state.regen.cancel_all_retry_timers()
     assert controller.state.regen.pending == set()
 
 

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -289,7 +289,13 @@ async def test_regenerate_skips_when_stamp_terminal(
     await _drain(controller)
 
     assert spawn_calls == []
-    assert controller.state.regen.retry_timers == {}
+    # Only a TTL re-check timer is armed: no scan event fires for an
+    # untouched file, so expiry is the re-arm signal.
+    handle = controller.state.regen.retry_timers["kitchen.yaml"]
+    remaining = handle.when() - asyncio.get_running_loop().time()
+    ttl = storage_regen._REGEN_FAILURE_TTL_SECONDS
+    assert ttl - 301.0 < remaining <= ttl - 299.0
+    controller.state.regen.cancel_all_retry_timers()
 
 
 # ---------------------------------------------------------------------------
@@ -335,7 +341,9 @@ async def test_regenerate_marks_failed_on_nonzero_exit(
     assert persist_calls == []
     md = _read_store(controller, "kitchen.yaml")
     assert md["regen_failed_attempts"] == storage_regen._MAX_REGEN_ATTEMPTS
-    assert controller.state.regen.retry_timers == {}
+    # Terminal → only the TTL re-check timer remains.
+    assert set(controller.state.regen.retry_timers) == {"kitchen.yaml"}
+    controller.state.regen.cancel_all_retry_timers()
     # Pending cleared via the ``finally``.
     assert controller.state.regen.pending == set()
 
@@ -376,7 +384,8 @@ async def test_regenerate_marks_failed_on_spawn_oserror(
     assert not any(c[0] == "reload" for c in controller._scanner.calls)
     md = _read_store(controller, "kitchen.yaml")
     assert md["regen_failed_attempts"] == storage_regen._MAX_REGEN_ATTEMPTS
-    assert controller.state.regen.retry_timers == {}
+    assert set(controller.state.regen.retry_timers) == {"kitchen.yaml"}
+    controller.state.regen.cancel_all_retry_timers()
     assert controller.state.regen.pending == set()
 
 
@@ -1250,15 +1259,16 @@ async def test_communicate_failure_kills_child_and_counts_the_attempt(
     controller.state.regen.cancel_all_retry_timers()
 
 
-async def test_vanished_mid_run_records_nothing(
+async def test_vanished_mid_run_stamps_prespawn_mtime(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """A YAML deleted during the run stamps nothing and arms no retry."""
+    """A YAML deleted during the run stamps the pre-spawn mtime; the retry skips."""
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
     yaml_path = tmp_path / "kitchen.yaml"
     yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    prespawn_mtime = yaml_path.stat().st_mtime
 
     async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
         # Off-loop: blockbuster flags blocking unlink on the loop (Linux CI).
@@ -1273,8 +1283,51 @@ async def test_vanished_mid_run_records_nothing(
     controller._schedule_storage_regenerate("kitchen.yaml")
     await _drain(controller)
 
-    assert _read_store(controller, "kitchen.yaml") == {}
+    md = _read_store(controller, "kitchen.yaml")
+    assert md["regen_failed_attempts"] == 1
+    assert md["regen_failed_mtime"] == prespawn_mtime
+
+    # The armed retry finds the file gone and skips without counting.
+    storage_regen._fire_retry(controller, "kitchen.yaml")
+    await _drain(controller)
+
+    assert _read_store(controller, "kitchen.yaml")["regen_failed_attempts"] == 1
     assert controller.state.regen.retry_timers == {}
+
+
+async def test_regenerate_warns_when_yaml_unreadable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A non-vanish stat error skips loudly instead of masquerading as a vanish."""
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    spawn_calls: list[tuple[str, ...]] = []
+
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+        spawn_calls.append(args)
+        return _FakeProc(returncode=0)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        _fake_spawn,
+    )
+
+    async def _denied(_fn: Any) -> float:
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.storage_regen.run_in_executor", _denied
+    )
+
+    with caplog.at_level(logging.WARNING):
+        controller._schedule_storage_regenerate("kitchen.yaml")
+        await _drain(controller)
+
+    assert spawn_calls == []
+    assert any("config unreadable" in record.message for record in caplog.records)
+    assert controller.state.regen.pending == set()
 
 
 async def test_edit_between_failures_resets_attempts(
@@ -1377,6 +1430,7 @@ async def test_regenerate_retry_budget_exhausts_to_stamp(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Persistent failure spends the budget, then stamps and marks failed."""
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
@@ -1397,20 +1451,26 @@ async def test_regenerate_retry_budget_exhausts_to_stamp(
         _fake_spawn,
     )
 
-    controller._schedule_storage_regenerate("kitchen.yaml")
-    # The terminal attempt count is the last step of the exhausted path.
-    await wait_until(
-        lambda: (
-            _read_store(controller, "kitchen.yaml").get("regen_failed_attempts", 0)
-            >= storage_regen._MAX_REGEN_ATTEMPTS
-        ),
-        1,
-        "terminal stamp",
-    )
-    await _drain(controller)
+    with caplog.at_level(logging.WARNING):
+        controller._schedule_storage_regenerate("kitchen.yaml")
+        # The terminal attempt count is the last step of the exhausted path.
+        await wait_until(
+            lambda: (
+                _read_store(controller, "kitchen.yaml").get("regen_failed_attempts", 0)
+                >= storage_regen._MAX_REGEN_ATTEMPTS
+            ),
+            1,
+            "terminal stamp",
+        )
+        await _drain(controller)
 
     assert spawns == storage_regen._MAX_REGEN_ATTEMPTS
-    assert controller.state.regen.retry_timers == {}
+    # The give-up warning carries the failure summary.
+    giveup = [r for r in caplog.records if "failed 4 times" in r.getMessage()]
+    assert giveup and "exit 1: YAML parse error" in giveup[0].getMessage()
+    # A TTL re-check timer covers in-session expiry.
+    assert set(controller.state.regen.retry_timers) == {"kitchen.yaml"}
+    controller.state.regen.cancel_all_retry_timers()
 
 
 async def test_stop_cancels_armed_retries_without_stamping(

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -291,6 +291,14 @@ async def test_regenerate_skips_when_stamp_terminal(
         storage_regen._REGEN_FAILURE_TTL_SECONDS - 300.0, abs=1
     )
 
+    # A redundant schedule keeps the pending timer instead of churning it.
+    handle = controller.state.regen.retry_timers["kitchen.yaml"]
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+
+    assert spawn_calls == []
+    assert controller.state.regen.retry_timers["kitchen.yaml"] is handle
+
 
 # ---------------------------------------------------------------------------
 # Failure paths
@@ -1189,6 +1197,30 @@ async def test_cancelled_run_records_nothing(
 
     assert _read_store(controller, "kitchen.yaml") == {}
     assert controller.state.regen.pending == set()
+
+
+async def test_timed_out_run_counts_the_attempt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A run the capture helper timed out feeds the ladder."""
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    async def _timed_out_capture(*_args: str, **_kwargs: Any) -> CapturedSubprocess:
+        return CapturedSubprocess(returncode=None, stdout=b"", timed_out=True)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
+        _timed_out_capture,
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+
+    assert _read_store(controller, "kitchen.yaml")["regen_failed_attempts"] == 1
+    assert _armed_delay(controller) == pytest.approx(30.0, abs=1)
 
 
 async def test_capture_error_counts_the_attempt(

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -1261,7 +1261,8 @@ async def test_vanished_mid_run_records_nothing(
     yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
 
     async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
-        yaml_path.unlink()
+        # Off-loop: blockbuster flags blocking unlink on the loop (Linux CI).
+        await asyncio.to_thread(yaml_path.unlink)
         return _FakeProc(returncode=1, stderr=b"gone")
 
     monkeypatch.setattr(

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -5,13 +5,13 @@ Most callers of the regenerate path mock it as a ``MagicMock``
 fire-and-forget spawn doesn't run. That leaves the body of
 ``_schedule_storage_regenerate`` itself uncovered: the
 duplicate-schedule guard, the persisted-stamp consult (attempt
-budget, backoff min-age, TTL), the ``create_subprocess_exec``
+budget, backoff min-age, TTL), the ``run_subprocess_capture``
 call, the failure stamping and retry arming, and the post-success
 ``_persist_expected_config_hash`` + ``_scanner.reload`` chain.
 
 These tests let ``_schedule_storage_regenerate`` execute for real,
-with a patched ``create_subprocess_exec`` returning a configurable
-``FakeProc``. Background-task settling uses the same
+with a patched ``run_subprocess_capture`` returning a configurable
+``CapturedSubprocess``. Background-task settling uses the same
 ``create_background_task`` plumbing the controller uses, so the
 tests exercise the actual coroutine the production code spawns.
 """
@@ -31,6 +31,7 @@ import pytest
 from esphome_device_builder.controllers._device_scanner import ScanChange
 from esphome_device_builder.controllers.devices import DevicesController, storage_regen
 from esphome_device_builder.controllers.devices._state import RegenState
+from esphome_device_builder.helpers.subprocess import CapturedSubprocess
 from tests._storage_fixtures import write_storage_json
 from tests.conftest import make_device, wait_until
 
@@ -57,20 +58,15 @@ def _read_store(controller: DevicesController, filename: str) -> dict[str, Any]:
     return controller._metadata_store.get(filename)
 
 
-class _FakeProc:
-    """Minimal ``asyncio.subprocess.Process`` stand-in.
+def _capture_result(returncode: int = 0, output: bytes = b"") -> CapturedSubprocess:
+    """Build the ``run_subprocess_capture`` result the fakes return."""
+    return CapturedSubprocess(returncode=returncode, stdout=output, timed_out=False)
 
-    ``communicate`` returns the configured merged-stream bytes;
-    ``returncode`` carries the configured exit code. Only the
-    bits ``_schedule_storage_regenerate`` reads.
-    """
 
-    def __init__(self, returncode: int = 0, output: bytes = b"") -> None:
-        self.returncode = returncode
-        self._output = output
-
-    async def communicate(self) -> tuple[bytes, bytes]:
-        return (self._output, b"")
+def _armed_delay(controller: DevicesController, configuration: str = "kitchen.yaml") -> float:
+    """Seconds until *configuration*'s armed retry fires."""
+    handle = controller.state.regen.retry_timers[configuration]
+    return handle.when() - asyncio.get_running_loop().time()
 
 
 def _seed_attempts(
@@ -124,12 +120,12 @@ async def test_regenerate_spawns_esphome_compile_only_generate(
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
     captured_cmd: list[list[str]] = []
 
-    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> CapturedSubprocess:
         captured_cmd.append(list(args))
-        return _FakeProc(returncode=0)
+        return _capture_result(returncode=0)
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
     persist_calls: list[str] = []
@@ -175,12 +171,12 @@ async def test_out_of_band_network_edit_spawns_only_generate(
     )
     captured_cmd: list[list[str]] = []
 
-    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> CapturedSubprocess:
         captured_cmd.append(list(args))
-        return _FakeProc(returncode=0)
+        return _capture_result(returncode=0)
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
     monkeypatch.setattr(DevicesController, "_finalize_regen_success", AsyncMock())
@@ -276,12 +272,12 @@ async def test_regenerate_skips_when_stamp_terminal(
     _seed_attempts(controller, "kitchen.yaml", storage_regen._MAX_REGEN_ATTEMPTS, age=300.0)
     spawn_calls: list[tuple[str, ...]] = []
 
-    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> CapturedSubprocess:
         spawn_calls.append(args)
-        return _FakeProc(returncode=0)
+        return _capture_result(returncode=0)
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
 
@@ -291,11 +287,9 @@ async def test_regenerate_skips_when_stamp_terminal(
     assert spawn_calls == []
     # Only a TTL re-check timer is armed: no scan event fires for an
     # untouched file, so expiry is the re-arm signal.
-    handle = controller.state.regen.retry_timers["kitchen.yaml"]
-    remaining = handle.when() - asyncio.get_running_loop().time()
-    ttl = storage_regen._REGEN_FAILURE_TTL_SECONDS
-    assert ttl - 301.0 < remaining <= ttl - 299.0
-    controller.state.regen.cancel_all_retry_timers()
+    assert _armed_delay(controller) == pytest.approx(
+        storage_regen._REGEN_FAILURE_TTL_SECONDS - 300.0, abs=1
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -319,11 +313,11 @@ async def test_regenerate_marks_failed_on_nonzero_exit(
     # Attempt 3 recorded 200s ago: past its 120s backoff, one attempt left.
     _seed_attempts(controller, "kitchen.yaml", 3, age=200.0)
 
-    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
-        return _FakeProc(returncode=1, output=b"YAML parse error at line 3")
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> CapturedSubprocess:
+        return _capture_result(returncode=1, output=b"YAML parse error at line 3")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
     persist_calls: list[str] = []
@@ -343,7 +337,6 @@ async def test_regenerate_marks_failed_on_nonzero_exit(
     assert md["regen_failed_attempts"] == storage_regen._MAX_REGEN_ATTEMPTS
     # Terminal → only the TTL re-check timer remains.
     assert set(controller.state.regen.retry_timers) == {"kitchen.yaml"}
-    controller.state.regen.cancel_all_retry_timers()
     # Pending cleared via the ``finally``.
     assert controller.state.regen.pending == set()
 
@@ -365,11 +358,11 @@ async def test_regenerate_marks_failed_on_spawn_oserror(
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
     _seed_attempts(controller, "kitchen.yaml", 3, age=200.0)
 
-    async def _broken_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+    async def _broken_spawn(*_args: str, **_kwargs: Any) -> CapturedSubprocess:
         raise OSError("esphome: command not found")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _broken_spawn,
     )
     monkeypatch.setattr(
@@ -385,7 +378,6 @@ async def test_regenerate_marks_failed_on_spawn_oserror(
     md = _read_store(controller, "kitchen.yaml")
     assert md["regen_failed_attempts"] == storage_regen._MAX_REGEN_ATTEMPTS
     assert set(controller.state.regen.retry_timers) == {"kitchen.yaml"}
-    controller.state.regen.cancel_all_retry_timers()
     assert controller.state.regen.pending == set()
 
 
@@ -409,11 +401,11 @@ async def test_regenerate_dedupes_same_tick_calls(
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
 
-    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
-        return _FakeProc(returncode=0)
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> CapturedSubprocess:
+        return _capture_result(returncode=0)
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
     monkeypatch.setattr(
@@ -454,13 +446,13 @@ async def test_regenerate_pending_blocks_in_flight_dupe(
     in_flight = asyncio.Event()
     release = asyncio.Event()
 
-    async def _hold(*_args: str, **_kwargs: Any) -> _FakeProc:
+    async def _hold(*_args: str, **_kwargs: Any) -> CapturedSubprocess:
         in_flight.set()
         await release.wait()
-        return _FakeProc(returncode=0)
+        return _capture_result(returncode=0)
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _hold,
     )
     monkeypatch.setattr(
@@ -507,11 +499,11 @@ async def test_regenerate_persists_mtime_and_wallclock_on_failure(
     yaml_path.write_text("not: valid: yaml\n", encoding="utf-8")
     expected_mtime = yaml_path.stat().st_mtime
 
-    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
-        return _FakeProc(returncode=1, output=b"YAML parse error")
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> CapturedSubprocess:
+        return _capture_result(returncode=1, output=b"YAML parse error")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
     monkeypatch.setattr(
@@ -532,7 +524,6 @@ async def test_regenerate_persists_mtime_and_wallclock_on_failure(
     assert md.get("regen_failed_mtime") == expected_mtime
     assert md.get("regen_failed_at") == 1700000000.0
     assert md.get("regen_failed_attempts") == 1
-    controller.state.regen.cancel_all_retry_timers()
 
 
 async def test_regenerate_persists_stamp_on_spawn_oserror(
@@ -551,11 +542,11 @@ async def test_regenerate_persists_stamp_on_spawn_oserror(
     yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
     expected_mtime = yaml_path.stat().st_mtime
 
-    async def _broken_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+    async def _broken_spawn(*_args: str, **_kwargs: Any) -> CapturedSubprocess:
         raise OSError("esphome: command not found")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _broken_spawn,
     )
     monkeypatch.setattr(
@@ -575,7 +566,6 @@ async def test_regenerate_persists_stamp_on_spawn_oserror(
     assert md.get("regen_failed_mtime") == expected_mtime
     assert md.get("regen_failed_at") == 1700000050.0
     assert md.get("regen_failed_attempts") == 1
-    controller.state.regen.cancel_all_retry_timers()
 
 
 async def test_regenerate_clears_failure_stamp_on_success(
@@ -602,11 +592,11 @@ async def test_regenerate_clears_failure_stamp_on_success(
         regen_failed_at=1700000000.0,
     )
 
-    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
-        return _FakeProc(returncode=0)
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> CapturedSubprocess:
+        return _capture_result(returncode=0)
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
     monkeypatch.setattr(
@@ -653,12 +643,12 @@ async def test_regenerate_retries_when_stamp_older_than_ttl(
 
     spawn_calls: list[tuple[str, ...]] = []
 
-    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> CapturedSubprocess:
         spawn_calls.append(args)
-        return _FakeProc(returncode=0)
+        return _capture_result(returncode=0)
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
     monkeypatch.setattr(
@@ -704,12 +694,12 @@ async def test_regenerate_runs_when_yaml_mtime_moves_past_stamp(
 
     spawn_calls: list[tuple[str, ...]] = []
 
-    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> CapturedSubprocess:
         spawn_calls.append(args)
-        return _FakeProc(returncode=0)
+        return _capture_result(returncode=0)
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
     monkeypatch.setattr(
@@ -739,12 +729,12 @@ async def test_regenerate_skips_when_yaml_unreadable(
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
     spawn_calls: list[tuple[str, ...]] = []
 
-    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> CapturedSubprocess:
         spawn_calls.append(args)
-        return _FakeProc(returncode=1, output=b"missing")
+        return _capture_result(returncode=1, output=b"missing")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
 
@@ -787,12 +777,12 @@ async def test_regenerate_clamps_negative_stamp_age(
 
     spawn_calls: list[tuple[str, ...]] = []
 
-    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> CapturedSubprocess:
         spawn_calls.append(args)
-        return _FakeProc(returncode=0)
+        return _capture_result(returncode=0)
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
 
@@ -827,12 +817,12 @@ async def test_regenerate_runs_when_only_one_stamp_half_present(
 
     spawn_calls: list[tuple[str, ...]] = []
 
-    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> CapturedSubprocess:
         spawn_calls.append(args)
-        return _FakeProc(returncode=0)
+        return _capture_result(returncode=0)
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
     monkeypatch.setattr(
@@ -872,12 +862,12 @@ async def test_regenerate_runs_when_stamp_has_corrupt_value(
 
     spawn_calls: list[tuple[str, ...]] = []
 
-    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> CapturedSubprocess:
         spawn_calls.append(args)
-        return _FakeProc(returncode=0)
+        return _capture_result(returncode=0)
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
     monkeypatch.setattr(
@@ -946,11 +936,11 @@ async def test_regenerate_persists_hash_and_clears_stamp_in_one_transaction(
         encoding="utf-8",
     )
 
-    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
-        return _FakeProc(returncode=0)
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> CapturedSubprocess:
+        return _capture_result(returncode=0)
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
 
@@ -994,11 +984,11 @@ async def test_regenerate_success_clears_stamp_when_build_info_missing(
     # No StorageJSON sidecar → ``read_build_info_hash`` returns
     # None.
 
-    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
-        return _FakeProc(returncode=0)
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> CapturedSubprocess:
+        return _capture_result(returncode=0)
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
 
@@ -1017,7 +1007,7 @@ async def test_regenerate_success_clears_stamp_when_build_info_missing(
     assert "regen_failed_mtime" not in md
     assert "regen_failed_at" not in md
     assert any(
-        "Could not read config_hash from build_info.json" in record.message
+        "Could not read config_hash from build_info.json" in record.getMessage()
         for record in caplog.records
     )
 
@@ -1081,22 +1071,6 @@ def test_fresh_stamp_clamps_future_dated_stamp() -> None:
     assert storage_regen._fresh_stamp(md, 5.0, 1000.0) == (1, 0.0)
 
 
-class _HangingProc:
-    """Subprocess stand-in whose ``communicate`` blocks until killed."""
-
-    def __init__(self) -> None:
-        self.returncode: int | None = None
-        self.killed = False
-        self._blocked = asyncio.Event()
-
-    async def communicate(self) -> tuple[bytes, bytes]:
-        await self._blocked.wait()
-        return (b"", b"")
-
-    def kill(self) -> None:
-        self.killed = True
-
-
 async def test_ttl_expiry_grants_fresh_budget(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1112,11 +1086,11 @@ async def test_ttl_expiry_grants_fresh_budget(
         age=storage_regen._REGEN_FAILURE_TTL_SECONDS + 100.0,
     )
 
-    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
-        return _FakeProc(returncode=1, output=b"YAML parse error")
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> CapturedSubprocess:
+        return _capture_result(returncode=1, output=b"YAML parse error")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
 
@@ -1124,8 +1098,7 @@ async def test_ttl_expiry_grants_fresh_budget(
     await _drain(controller)
 
     assert _read_store(controller, "kitchen.yaml")["regen_failed_attempts"] == 1
-    assert "kitchen.yaml" in controller.state.regen.retry_timers
-    controller.state.regen.cancel_all_retry_timers()
+    assert set(controller.state.regen.retry_timers) == {"kitchen.yaml"}
 
 
 async def test_restart_inside_backoff_rearms_remainder(
@@ -1140,12 +1113,12 @@ async def test_restart_inside_backoff_rearms_remainder(
     _seed_attempts(controller, "kitchen.yaml", 1, age=10.0)
     spawn_calls: list[tuple[str, ...]] = []
 
-    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> CapturedSubprocess:
         spawn_calls.append(args)
-        return _FakeProc(returncode=0)
+        return _capture_result(returncode=0)
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
 
@@ -1153,10 +1126,7 @@ async def test_restart_inside_backoff_rearms_remainder(
     await _drain(controller)
 
     assert spawn_calls == []
-    handle = controller.state.regen.retry_timers["kitchen.yaml"]
-    remaining = handle.when() - asyncio.get_running_loop().time()
-    assert 15.0 < remaining <= 20.5
-    controller.state.regen.cancel_all_retry_timers()
+    assert _armed_delay(controller) == pytest.approx(20.0, abs=5)
 
 
 async def test_backoff_elapsed_runs_next_attempt(
@@ -1170,12 +1140,12 @@ async def test_backoff_elapsed_runs_next_attempt(
     _seed_attempts(controller, "kitchen.yaml", 1, age=40.0)
     spawn_calls: list[tuple[str, ...]] = []
 
-    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> CapturedSubprocess:
         spawn_calls.append(args)
-        return _FakeProc(returncode=1, output=b"YAML parse error")
+        return _capture_result(returncode=1, output=b"YAML parse error")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
 
@@ -1184,79 +1154,64 @@ async def test_backoff_elapsed_runs_next_attempt(
 
     assert len(spawn_calls) == 1
     assert _read_store(controller, "kitchen.yaml")["regen_failed_attempts"] == 2
-    controller.state.regen.cancel_all_retry_timers()
 
 
-async def test_cancelled_run_kills_subprocess_without_stamp(
+async def test_cancelled_run_records_nothing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """A run cancelled mid-subprocess kills the child and records nothing."""
+    """A run cancelled mid-subprocess records nothing.
+
+    The child kill itself is the capture helper's contract
+    (``test_run_subprocess_capture_cancel_kills_child``).
+    """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
-    proc = _HangingProc()
     started = asyncio.Event()
 
-    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _HangingProc:
+    async def _hanging_capture(*_args: str, **_kwargs: Any) -> CapturedSubprocess:
         started.set()
-        return proc
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
-        _fake_spawn,
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
+        _hanging_capture,
     )
 
     controller._schedule_storage_regenerate("kitchen.yaml")
     await asyncio.wait_for(started.wait(), 1)
-    await asyncio.sleep(0)  # let the run reach the communicate await
     (task,) = controller._spawned_tasks  # type: ignore[attr-defined]
     task.cancel()
     await asyncio.gather(task, return_exceptions=True)
     controller._spawned_tasks.clear()  # type: ignore[attr-defined]
 
-    assert proc.killed
     assert _read_store(controller, "kitchen.yaml") == {}
     assert controller.state.regen.pending == set()
 
 
-async def test_communicate_failure_kills_child_and_counts_the_attempt(
+async def test_capture_error_counts_the_attempt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """A pipe error mid-communicate kills the child and feeds the ladder."""
+    """A capture helper error feeds the ladder."""
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
 
-    class _BrokenPipeProc:
-        returncode: int | None = None
-
-        def __init__(self) -> None:
-            self.killed = False
-
-        async def communicate(self) -> tuple[bytes, bytes]:
-            raise OSError("broken pipe")
-
-        def kill(self) -> None:
-            self.killed = True
-
-    proc = _BrokenPipeProc()
-
-    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _BrokenPipeProc:
-        return proc
+    async def _broken_capture(*_args: str, **_kwargs: Any) -> CapturedSubprocess:
+        raise OSError("broken pipe")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
-        _fake_spawn,
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
+        _broken_capture,
     )
 
     controller._schedule_storage_regenerate("kitchen.yaml")
     await _drain(controller)
 
-    assert proc.killed
     assert _read_store(controller, "kitchen.yaml")["regen_failed_attempts"] == 1
-    controller.state.regen.cancel_all_retry_timers()
 
 
 async def test_vanished_mid_run_stamps_prespawn_mtime(
@@ -1270,13 +1225,13 @@ async def test_vanished_mid_run_stamps_prespawn_mtime(
     yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
     prespawn_mtime = yaml_path.stat().st_mtime
 
-    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> CapturedSubprocess:
         # Off-loop: blockbuster flags blocking unlink on the loop (Linux CI).
         await asyncio.to_thread(yaml_path.unlink)
-        return _FakeProc(returncode=1, output=b"gone")
+        return _capture_result(returncode=1, output=b"gone")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
 
@@ -1307,48 +1262,42 @@ async def test_regenerate_warns_when_yaml_unreadable(
     monkeypatch.setattr(DevicesController, "_finalize_regen_success", AsyncMock())
     spawn_calls: list[tuple[str, ...]] = []
 
-    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> CapturedSubprocess:
         spawn_calls.append(args)
-        return _FakeProc(returncode=0)
+        return _capture_result(returncode=0)
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
-    real_run_in_executor = storage_regen.run_in_executor
+    real_stat = Path.stat
     denials = 2
 
-    async def _denied(fn: Any, *args: Any) -> Any:
+    def _flaky_stat(self: Path, **kwargs: Any) -> Any:
         nonlocal denials
-        if denials:
+        if self.name == "kitchen.yaml" and denials:
             denials -= 1
             raise PermissionError("denied")
-        return await real_run_in_executor(fn, *args)
+        return real_stat(self, **kwargs)
 
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.run_in_executor", _denied
-    )
-
-    def _armed_delay() -> float:
-        handle = controller.state.regen.retry_timers["kitchen.yaml"]
-        return handle.when() - asyncio.get_running_loop().time()
+    monkeypatch.setattr(Path, "stat", _flaky_stat)
 
     with caplog.at_level(logging.WARNING):
         controller._schedule_storage_regenerate("kitchen.yaml")
         await _drain(controller)
 
     assert spawn_calls == []
-    assert any("config unreadable" in record.message for record in caplog.records)
+    assert any("config unreadable" in record.getMessage() for record in caplog.records)
     # A transient errno keeps the ladder alive: the base backoff re-arms.
     assert controller.state.regen.unreadable_strikes == {"kitchen.yaml": 1}
-    assert 29.0 < _armed_delay() <= 30.0
+    assert _armed_delay(controller) == pytest.approx(30.0, abs=1)
 
     # A second strike widens the re-arm.
     storage_regen._fire_retry(controller, "kitchen.yaml")
     await _drain(controller)
 
     assert controller.state.regen.unreadable_strikes == {"kitchen.yaml": 2}
-    assert 59.0 < _armed_delay() <= 60.0
+    assert _armed_delay(controller) == pytest.approx(60.0, abs=1)
 
     # The stat recovering clears the strikes and spawns.
     storage_regen._fire_retry(controller, "kitchen.yaml")
@@ -1369,11 +1318,11 @@ async def test_edit_between_failures_resets_attempts(
     yaml_path = tmp_path / "kitchen.yaml"
     yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
 
-    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
-        return _FakeProc(returncode=2, output=b"fatal: could not clone")
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> CapturedSubprocess:
+        return _capture_result(returncode=2, output=b"fatal: could not clone")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
 
@@ -1391,7 +1340,6 @@ async def test_edit_between_failures_resets_attempts(
     md = _read_store(controller, "kitchen.yaml")
     assert md["regen_failed_attempts"] == 1
     assert md["regen_failed_mtime"] == old_mtime + 10
-    controller.state.regen.cancel_all_retry_timers()
 
 
 async def test_regenerate_first_failure_stamps_and_arms_retry(
@@ -1403,11 +1351,11 @@ async def test_regenerate_first_failure_stamps_and_arms_retry(
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
 
-    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
-        return _FakeProc(returncode=2, output=b"fatal: could not clone")
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> CapturedSubprocess:
+        return _capture_result(returncode=2, output=b"fatal: could not clone")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
 
@@ -1415,8 +1363,7 @@ async def test_regenerate_first_failure_stamps_and_arms_retry(
     await _drain(controller)
 
     assert _read_store(controller, "kitchen.yaml")["regen_failed_attempts"] == 1
-    assert "kitchen.yaml" in controller.state.regen.retry_timers
-    controller.state.regen.cancel_all_retry_timers()
+    assert set(controller.state.regen.retry_timers) == {"kitchen.yaml"}
 
 
 async def test_regenerate_retry_fires_and_succeeds(
@@ -1431,13 +1378,16 @@ async def test_regenerate_retry_fires_and_succeeds(
         "esphome_device_builder.controllers.devices.storage_regen._RETRY_BACKOFF_BASE_SECONDS",
         0.0,
     )
-    outcomes = [_FakeProc(returncode=2, output=b"fatal: clone interrupted"), _FakeProc()]
+    outcomes = [
+        _capture_result(returncode=2, output=b"fatal: clone interrupted"),
+        _capture_result(),
+    ]
 
-    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> CapturedSubprocess:
         return outcomes.pop(0)
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
     monkeypatch.setattr(DevicesController, "_finalize_regen_success", AsyncMock())
@@ -1470,13 +1420,13 @@ async def test_regenerate_retry_budget_exhausts_to_stamp(
     )
     spawns = 0
 
-    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> CapturedSubprocess:
         nonlocal spawns
         spawns += 1
-        return _FakeProc(returncode=1, output=b"YAML parse error")
+        return _capture_result(returncode=1, output=b"YAML parse error")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _fake_spawn,
     )
 
@@ -1499,7 +1449,6 @@ async def test_regenerate_retry_budget_exhausts_to_stamp(
     assert giveup and "exit 1: YAML parse error" in giveup[0].getMessage()
     # A TTL re-check timer covers in-session expiry.
     assert set(controller.state.regen.retry_timers) == {"kitchen.yaml"}
-    controller.state.regen.cancel_all_retry_timers()
 
 
 async def test_stop_cancels_armed_retries_without_stamping(

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -260,6 +260,7 @@ async def test_regenerate_skips_when_stamp_terminal(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A fresh stamp with the budget spent → no spawn.
 
@@ -281,10 +282,14 @@ async def test_regenerate_skips_when_stamp_terminal(
         _fake_spawn,
     )
 
-    controller._schedule_storage_regenerate("kitchen.yaml")
-    await _drain(controller)
+    with caplog.at_level(logging.WARNING):
+        controller._schedule_storage_regenerate("kitchen.yaml")
+        await _drain(controller)
 
     assert spawn_calls == []
+    # A restarted session re-warns; the give-up warning fired in the
+    # session that spent the budget.
+    assert any("failed 4 times previously" in r.getMessage() for r in caplog.records)
     # Only a TTL re-check timer is armed: no scan event fires for an
     # untouched file, so expiry is the re-arm signal.
     assert _armed_delay(controller) == pytest.approx(
@@ -722,17 +727,16 @@ async def test_regenerate_runs_when_yaml_mtime_moves_past_stamp(
     assert len(spawn_calls) == 1
 
 
-async def test_regenerate_skips_when_yaml_unreadable(
+async def test_regenerate_skips_when_yaml_vanished(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """YAML vanished between scan and schedule → no spawn against it.
+    """YAML vanished between scan and schedule → no spawn, nothing armed.
 
-    A torn ``stat()`` (file removed mid-flight by an editor or
-    archive) returns ``OSError``; a spawn would just fail against
-    the missing file, so the run skips and the next scan event
-    for the path retriggers.
+    The pre-run ``stat()`` raises ``FileNotFoundError`` (file removed
+    mid-flight by an editor or archive); the run skips quietly and the
+    next scan event for the path retriggers.
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
     spawn_calls: list[tuple[str, ...]] = []
@@ -1202,22 +1206,26 @@ async def test_timed_out_run_counts_the_attempt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A run the capture helper timed out feeds the ladder."""
+    """A run the capture helper timed out warns with the output tail and feeds the ladder."""
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
 
     async def _timed_out_capture(*_args: str, **_kwargs: Any) -> CapturedSubprocess:
-        return CapturedSubprocess(returncode=None, stdout=b"", timed_out=True)
+        return CapturedSubprocess(returncode=None, stdout=b"cloning package...", timed_out=True)
 
     monkeypatch.setattr(
         "esphome_device_builder.controllers.devices.storage_regen.run_subprocess_capture",
         _timed_out_capture,
     )
 
-    controller._schedule_storage_regenerate("kitchen.yaml")
-    await _drain(controller)
+    with caplog.at_level(logging.WARNING):
+        controller._schedule_storage_regenerate("kitchen.yaml")
+        await _drain(controller)
 
+    timeouts = [r for r in caplog.records if "timed out after 300s" in r.getMessage()]
+    assert timeouts and "cloning package..." in timeouts[0].getMessage()
     assert _read_store(controller, "kitchen.yaml")["regen_failed_attempts"] == 1
     assert _armed_delay(controller) == pytest.approx(30.0, abs=1)
 

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -4,14 +4,13 @@ Most callers of the regenerate path mock it as a ``MagicMock``
 (see ``test_get_update_config.py`` and ``test_archive.py``) so the
 fire-and-forget spawn doesn't run. That leaves the body of
 ``_schedule_storage_regenerate`` itself uncovered: the
-duplicate-schedule guard, the failed-marker guard, the
-``create_subprocess_exec`` call, the non-zero-exit handling, the
-spawn-failure handling, and the post-success
+duplicate-schedule guard, the persisted-stamp consult (attempt
+budget, backoff min-age, TTL), the ``create_subprocess_exec``
+call, the failure stamping and retry arming, and the post-success
 ``_persist_expected_config_hash`` + ``_scanner.reload`` chain.
 
-These tests drive through the public ``update_config`` API but
-let ``_schedule_storage_regenerate`` execute for real, with a
-patched ``create_subprocess_exec`` returning a configurable
+These tests let ``_schedule_storage_regenerate`` execute for real,
+with a patched ``create_subprocess_exec`` returning a configurable
 ``FakeProc``. Background-task settling uses the same
 ``create_background_task`` plumbing the controller uses, so the
 tests exercise the actual coroutine the production code spawns.
@@ -21,6 +20,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+import time
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -72,9 +73,18 @@ class _FakeProc:
         return (b"", self._stderr)
 
 
-def _spend_retry_budget(controller: DevicesController, configuration: str) -> None:
-    """Consume the retry budget so the next failure stamps immediately."""
-    controller.state.regen.retry_strikes[configuration] = storage_regen._MAX_REGEN_RETRIES
+def _seed_attempts(
+    controller: DevicesController, configuration: str, attempts: int, *, age: float
+) -> None:
+    """Seed a failure stamp for the YAML's current mtime, *age* seconds old."""
+    mtime = (controller._db.settings.config_dir / configuration).stat().st_mtime
+    _seed_store(
+        controller,
+        configuration,
+        regen_failed_mtime=mtime,
+        regen_failed_at=time.time() - age,
+        regen_failed_attempts=attempts,
+    )
 
 
 async def _drain(controller: DevicesController) -> None:
@@ -83,9 +93,8 @@ async def _drain(controller: DevicesController) -> None:
     Drops ``return_exceptions=True`` so an unexpected crash inside the
     regenerate coroutine fails the test instead of silently masking
     as ``None`` in the gather result. Production swallows the error
-    branches in its own ``try/except`` (and asserts on
-    ``state.regen.failed``); anything reaching the gather here is a
-    bug we want surfaced.
+    branches in its own ``try/except``; anything reaching the gather
+    here is a bug we want surfaced.
     """
     pending: list[asyncio.Task] = controller._spawned_tasks  # type: ignore[attr-defined]
     if pending:
@@ -150,8 +159,6 @@ async def test_regenerate_spawns_esphome_compile_only_generate(
     assert reload_calls == [("reload", "kitchen.yaml")]
     # Pending guard cleared in the ``finally``.
     assert controller.state.regen.pending == set()
-    # Success → not in failed set.
-    assert controller.state.regen.failed == set()
 
 
 async def test_out_of_band_network_edit_spawns_only_generate(
@@ -252,22 +259,36 @@ def test_regenerate_skips_duplicate_schedule(
     assert controller._spawned_tasks == []  # type: ignore[attr-defined]
 
 
-def test_regenerate_skips_after_failed_marker(
-    tmp_path: Path, make_controller: MakeControllerFactory
+async def test_regenerate_skips_when_stamp_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
 ) -> None:
-    """Configuration in ``state.regen.failed`` → no respin.
+    """A fresh stamp with the budget spent → no spawn.
 
-    The marker is cleared by ``_on_scan_change`` when the YAML's
-    cache key changes (i.e. the user actually edited it). Until
-    then a respin would just burn another subprocess on the same
-    bad input.
+    The stamp releases when the YAML's mtime moves (the user
+    edited it) or its TTL expires; until then a respin would just
+    burn another subprocess on the same bad input.
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
-    controller.state.regen.failed.add("kitchen.yaml")
+    (tmp_path / "kitchen.yaml").write_text("not: valid: yaml\n", encoding="utf-8")
+    _seed_attempts(controller, "kitchen.yaml", storage_regen._MAX_REGEN_ATTEMPTS, age=300.0)
+    spawn_calls: list[tuple[str, ...]] = []
+
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+        spawn_calls.append(args)
+        return _FakeProc(returncode=0)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        _fake_spawn,
+    )
 
     controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
 
-    assert controller._spawned_tasks == []  # type: ignore[attr-defined]
+    assert spawn_calls == []
+    assert controller.state.regen.retry_timers == {}
 
 
 # ---------------------------------------------------------------------------
@@ -280,14 +301,16 @@ async def test_regenerate_marks_failed_on_nonzero_exit(
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """Non-zero exit with the retry budget spent → no reload, failure remembered.
+    """Non-zero exit on the last attempt → no reload, terminal stamp.
 
     Captures the typical "user saved a YAML with a syntax error"
-    case. The controller has to remember the failure so the
-    next save (with the same broken YAML) doesn't re-spawn.
+    case. The stamped budget has to survive so the next sight of
+    the same broken YAML doesn't re-spawn.
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
-    _spend_retry_budget(controller, "kitchen.yaml")
+    (tmp_path / "kitchen.yaml").write_text("not: valid: yaml\n", encoding="utf-8")
+    # Attempt 3 recorded 200s ago: past its 120s backoff, one attempt left.
+    _seed_attempts(controller, "kitchen.yaml", 3, age=200.0)
 
     async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
         return _FakeProc(returncode=1, stderr=b"YAML parse error at line 3")
@@ -303,13 +326,15 @@ async def test_regenerate_marks_failed_on_nonzero_exit(
 
     monkeypatch.setattr(DevicesController, "_persist_expected_config_hash", _fake_persist)
 
-    await controller.update_config(configuration="kitchen.yaml", content="not: valid: yaml\n")
+    controller._schedule_storage_regenerate("kitchen.yaml")
     await _drain(controller)
 
-    # Failure → reload skipped, persist skipped, failed marker set.
+    # Failure → reload skipped, persist skipped, budget spent on record.
     assert not any(c[0] == "reload" for c in controller._scanner.calls)
     assert persist_calls == []
-    assert controller.state.regen.failed == {"kitchen.yaml"}
+    md = _read_store(controller, "kitchen.yaml")
+    assert md["regen_failed_attempts"] == storage_regen._MAX_REGEN_ATTEMPTS
+    assert controller.state.regen.retry_timers == {}
     # Pending cleared via the ``finally``.
     assert controller.state.regen.pending == set()
 
@@ -319,7 +344,7 @@ async def test_regenerate_marks_failed_on_spawn_oserror(
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """Spawn raising with the retry budget spent → failure remembered.
+    """Spawn raising on the last attempt → terminal stamp.
 
     Triggers when ``esphome`` is missing from PATH (broken pip
     install, dashboard running outside its venv). The pending
@@ -328,7 +353,8 @@ async def test_regenerate_marks_failed_on_spawn_oserror(
     duplicate-schedule guard.
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
-    _spend_retry_budget(controller, "kitchen.yaml")
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    _seed_attempts(controller, "kitchen.yaml", 3, age=200.0)
 
     async def _broken_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
         raise OSError("esphome: command not found")
@@ -343,13 +369,13 @@ async def test_regenerate_marks_failed_on_spawn_oserror(
         AsyncMock(),
     )
 
-    await controller.update_config(
-        configuration="kitchen.yaml", content="esphome:\n  name: kitchen\n"
-    )
+    controller._schedule_storage_regenerate("kitchen.yaml")
     await _drain(controller)
 
     assert not any(c[0] == "reload" for c in controller._scanner.calls)
-    assert controller.state.regen.failed == {"kitchen.yaml"}
+    md = _read_store(controller, "kitchen.yaml")
+    assert md["regen_failed_attempts"] == storage_regen._MAX_REGEN_ATTEMPTS
+    assert controller.state.regen.retry_timers == {}
     assert controller.state.regen.pending == set()
 
 
@@ -466,7 +492,6 @@ async def test_regenerate_persists_mtime_and_wallclock_on_failure(
     get re-checked.
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
-    _spend_retry_budget(controller, "kitchen.yaml")
     yaml_path = tmp_path / "kitchen.yaml"
     yaml_path.write_text("not: valid: yaml\n", encoding="utf-8")
     expected_mtime = yaml_path.stat().st_mtime
@@ -495,6 +520,8 @@ async def test_regenerate_persists_mtime_and_wallclock_on_failure(
     md = _read_store(controller, "kitchen.yaml")
     assert md.get("regen_failed_mtime") == expected_mtime
     assert md.get("regen_failed_at") == 1700000000.0
+    assert md.get("regen_failed_attempts") == 1
+    controller.state.regen.cancel_all_retry_timers()
 
 
 async def test_regenerate_persists_stamp_on_spawn_oserror(
@@ -509,7 +536,6 @@ async def test_regenerate_persists_stamp_on_spawn_oserror(
     regressions where one branch persists and the other doesn't.
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
-    _spend_retry_budget(controller, "kitchen.yaml")
     yaml_path = tmp_path / "kitchen.yaml"
     yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
     expected_mtime = yaml_path.stat().st_mtime
@@ -537,6 +563,8 @@ async def test_regenerate_persists_stamp_on_spawn_oserror(
     md = _read_store(controller, "kitchen.yaml")
     assert md.get("regen_failed_mtime") == expected_mtime
     assert md.get("regen_failed_at") == 1700000050.0
+    assert md.get("regen_failed_attempts") == 1
+    controller.state.regen.cancel_all_retry_timers()
 
 
 async def test_regenerate_clears_failure_stamp_on_success(
@@ -584,56 +612,6 @@ async def test_regenerate_clears_failure_stamp_on_success(
     assert "regen_failed_at" not in md
 
 
-async def test_regenerate_skips_when_stamp_fresh_and_mtime_matches(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    make_controller: MakeControllerFactory,
-) -> None:
-    """Cross-restart skip: persisted stamp matches and is within TTL → no spawn.
-
-    Simulates the "broken config + backend restart" case. The
-    in-memory ``state.regen.failed`` set is empty (fresh process)
-    but the sidecar carries the prior backend's failure stamp;
-    the schedule call must populate ``state.regen.failed`` and
-    skip the spawn rather than burning another subprocess.
-    """
-    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
-    yaml_path = tmp_path / "kitchen.yaml"
-    yaml_path.write_text("not: valid: yaml\n", encoding="utf-8")
-    current_mtime = yaml_path.stat().st_mtime
-    _seed_store(
-        controller,
-        "kitchen.yaml",
-        regen_failed_mtime=current_mtime,
-        regen_failed_at=1700000000.0,
-    )
-    # 60s after the stamp — well within the 1h TTL.
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.time.time",
-        lambda: 1700000060.0,
-    )
-
-    spawn_calls: list[tuple[str, ...]] = []
-
-    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
-        spawn_calls.append(args)
-        return _FakeProc(returncode=0)
-
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
-        _fake_spawn,
-    )
-
-    controller._schedule_storage_regenerate("kitchen.yaml")
-    await _drain(controller)
-
-    assert spawn_calls == []
-    # The skip path also seeds the in-memory set so subsequent
-    # same-session schedules hit the cheaper guard instead of
-    # re-reading the sidecar.
-    assert controller.state.regen.failed == {"kitchen.yaml"}
-
-
 async def test_regenerate_retries_when_stamp_older_than_ttl(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -656,10 +634,10 @@ async def test_regenerate_retries_when_stamp_older_than_ttl(
         regen_failed_mtime=current_mtime,
         regen_failed_at=1700000000.0,
     )
-    # Advance the clock just past the 1h TTL.
+    # Advance the clock just past the TTL.
     monkeypatch.setattr(
         "esphome_device_builder.controllers.devices.storage_regen.time.time",
-        lambda: 1700000000.0 + 3700.0,
+        lambda: 1700000000.0 + storage_regen._REGEN_FAILURE_TTL_SECONDS + 100.0,
     )
 
     spawn_calls: list[tuple[str, ...]] = []
@@ -1049,12 +1027,240 @@ async def test_regenerate_success_clears_stamp_when_build_info_missing(
 # ---------------------------------------------------------------------------
 
 
-async def test_regenerate_failure_arms_retry_instead_of_stamp(
+@pytest.mark.parametrize(
+    ("attempts_value", "expected_attempts"),
+    [
+        pytest.param(
+            storage_regen._MAX_REGEN_ATTEMPTS, storage_regen._MAX_REGEN_ATTEMPTS, id="terminal"
+        ),
+        pytest.param(None, storage_regen._MAX_REGEN_ATTEMPTS, id="legacy-missing"),
+        pytest.param("garbage", storage_regen._MAX_REGEN_ATTEMPTS, id="corrupt"),
+        pytest.param(0, storage_regen._MAX_REGEN_ATTEMPTS, id="nonpositive"),
+        pytest.param(2, 2, id="mid-ladder"),
+    ],
+)
+def test_fresh_stamp_attempts_read(attempts_value: Any, expected_attempts: int) -> None:
+    """A missing, unparseable, or non-positive attempt count reads as terminal."""
+    md: dict[str, Any] = {"regen_failed_mtime": 5.0, "regen_failed_at": 1000.0}
+    if attempts_value is not None:
+        md["regen_failed_attempts"] = attempts_value
+    assert storage_regen._fresh_stamp(md, 5.0, 1060.0) == (expected_attempts, 60.0)
+
+
+@pytest.mark.parametrize(
+    ("md", "current_mtime", "now"),
+    [
+        pytest.param({}, 5.0, 1060.0, id="no-stamp"),
+        pytest.param(
+            {"regen_failed_mtime": 1.0, "regen_failed_at": 1000.0}, 5.0, 1060.0, id="mtime-moved"
+        ),
+        pytest.param(
+            {"regen_failed_mtime": 5.0, "regen_failed_at": 1000.0},
+            5.0,
+            1000.0 + storage_regen._REGEN_FAILURE_TTL_SECONDS + 1,
+            id="expired",
+        ),
+        pytest.param(
+            {"regen_failed_mtime": "garbage", "regen_failed_at": "garbage"},
+            5.0,
+            1060.0,
+            id="corrupt-halves",
+        ),
+    ],
+)
+def test_fresh_stamp_ignores_invalid_stamps(
+    md: dict[str, Any], current_mtime: float, now: float
+) -> None:
+    """A missing, stale, expired, or unparseable stamp reads as no stamp."""
+    assert storage_regen._fresh_stamp(md, current_mtime, now) is None
+
+
+def test_fresh_stamp_clamps_future_dated_stamp() -> None:
+    """Clock skew can't lock the regen out: a future stamp clamps to age 0."""
+    md = {"regen_failed_mtime": 5.0, "regen_failed_at": 2000.0, "regen_failed_attempts": 1}
+    assert storage_regen._fresh_stamp(md, 5.0, 1000.0) == (1, 0.0)
+
+
+class _HangingProc:
+    """Subprocess stand-in whose ``communicate`` blocks until killed."""
+
+    def __init__(self) -> None:
+        self.returncode: int | None = None
+        self.killed = False
+        self._blocked = asyncio.Event()
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        await self._blocked.wait()
+        return (b"", b"")
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+async def test_ttl_expiry_grants_fresh_budget(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """A first failure arms a backoff retry: no failed marker, no disk stamp."""
+    """A terminal stamp past its TTL runs again, and the next failure counts from 1."""
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    (tmp_path / "kitchen.yaml").write_text("not: valid: yaml\n", encoding="utf-8")
+    _seed_attempts(
+        controller,
+        "kitchen.yaml",
+        storage_regen._MAX_REGEN_ATTEMPTS,
+        age=storage_regen._REGEN_FAILURE_TTL_SECONDS + 100.0,
+    )
+
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+        return _FakeProc(returncode=1, stderr=b"YAML parse error")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        _fake_spawn,
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+
+    assert _read_store(controller, "kitchen.yaml")["regen_failed_attempts"] == 1
+    assert "kitchen.yaml" in controller.state.regen.retry_timers
+    controller.state.regen.cancel_all_retry_timers()
+
+
+async def test_restart_inside_backoff_rearms_remainder(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A fresh non-terminal stamp inside its backoff re-arms the remainder, no spawn."""
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    # Attempt 1 recorded 10s ago: 20s of its 30s backoff remain.
+    _seed_attempts(controller, "kitchen.yaml", 1, age=10.0)
+    spawn_calls: list[tuple[str, ...]] = []
+
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+        spawn_calls.append(args)
+        return _FakeProc(returncode=0)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        _fake_spawn,
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+
+    assert spawn_calls == []
+    handle = controller.state.regen.retry_timers["kitchen.yaml"]
+    remaining = handle.when() - asyncio.get_running_loop().time()
+    assert 15.0 < remaining <= 20.5
+    controller.state.regen.cancel_all_retry_timers()
+
+
+async def test_backoff_elapsed_runs_next_attempt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A fresh non-terminal stamp past its backoff spawns the next attempt."""
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    (tmp_path / "kitchen.yaml").write_text("not: valid: yaml\n", encoding="utf-8")
+    _seed_attempts(controller, "kitchen.yaml", 1, age=40.0)
+    spawn_calls: list[tuple[str, ...]] = []
+
+    async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
+        spawn_calls.append(args)
+        return _FakeProc(returncode=1, stderr=b"YAML parse error")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        _fake_spawn,
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+
+    assert len(spawn_calls) == 1
+    assert _read_store(controller, "kitchen.yaml")["regen_failed_attempts"] == 2
+    controller.state.regen.cancel_all_retry_timers()
+
+
+async def test_cancelled_run_kills_subprocess_without_stamp(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A run cancelled mid-subprocess kills the child and records nothing."""
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    proc = _HangingProc()
+    started = asyncio.Event()
+
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _HangingProc:
+        started.set()
+        return proc
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        _fake_spawn,
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await asyncio.wait_for(started.wait(), 1)
+    await asyncio.sleep(0)  # let the run reach the communicate await
+    (task,) = controller._spawned_tasks  # type: ignore[attr-defined]
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+    controller._spawned_tasks.clear()  # type: ignore[attr-defined]
+
+    assert proc.killed
+    assert _read_store(controller, "kitchen.yaml") == {}
+    assert controller.state.regen.pending == set()
+
+
+async def test_edit_between_failures_resets_attempts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """An mtime move between failures restarts the ladder at attempt 1."""
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
+        return _FakeProc(returncode=2, stderr=b"fatal: could not clone")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
+        _fake_spawn,
+    )
+
+    controller._schedule_storage_regenerate("kitchen.yaml")
+    await _drain(controller)
+    assert _read_store(controller, "kitchen.yaml")["regen_failed_attempts"] == 1
+
+    # The edit moves the mtime; the manually fired retry finds a stale
+    # stamp and the next failure counts from 1 with the new mtime.
+    old_mtime = yaml_path.stat().st_mtime
+    os.utime(yaml_path, (old_mtime + 10, old_mtime + 10))
+    storage_regen._fire_retry(controller, "kitchen.yaml")
+    await _drain(controller)
+
+    md = _read_store(controller, "kitchen.yaml")
+    assert md["regen_failed_attempts"] == 1
+    assert md["regen_failed_mtime"] == old_mtime + 10
+    controller.state.regen.cancel_all_retry_timers()
+
+
+async def test_regenerate_first_failure_stamps_and_arms_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A first failure records attempt 1 and arms a backoff retry."""
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
 
@@ -1069,10 +1275,8 @@ async def test_regenerate_failure_arms_retry_instead_of_stamp(
     controller._schedule_storage_regenerate("kitchen.yaml")
     await _drain(controller)
 
-    assert controller.state.regen.failed == set()
-    assert "regen_failed_at" not in _read_store(controller, "kitchen.yaml")
+    assert _read_store(controller, "kitchen.yaml")["regen_failed_attempts"] == 1
     assert "kitchen.yaml" in controller.state.regen.retry_timers
-    assert controller.state.regen.retry_strikes == {"kitchen.yaml": 1}
     controller.state.regen.cancel_all_retry_timers()
 
 
@@ -1107,9 +1311,7 @@ async def test_regenerate_retry_fires_and_succeeds(
     await _drain(controller)
 
     assert outcomes == []
-    assert controller.state.regen.failed == set()
     assert controller.state.regen.retry_timers == {}
-    assert controller.state.regen.retry_strikes == {}
     reload_calls = [c for c in controller._scanner.calls if c[0] == "reload"]
     assert reload_calls == [("reload", "kitchen.yaml")]
 
@@ -1139,55 +1341,33 @@ async def test_regenerate_retry_budget_exhausts_to_stamp(
     )
 
     controller._schedule_storage_regenerate("kitchen.yaml")
-    # The disk stamp is the terminal step of the exhausted-budget path.
+    # The terminal attempt count is the last step of the exhausted path.
     await wait_until(
-        lambda: "regen_failed_at" in _read_store(controller, "kitchen.yaml"),
+        lambda: (
+            _read_store(controller, "kitchen.yaml").get("regen_failed_attempts", 0)
+            >= storage_regen._MAX_REGEN_ATTEMPTS
+        ),
         1,
-        "failure stamp",
+        "terminal stamp",
     )
     await _drain(controller)
 
-    assert spawns == 1 + storage_regen._MAX_REGEN_RETRIES
-    assert controller.state.regen.failed == {"kitchen.yaml"}
+    assert spawns == storage_regen._MAX_REGEN_ATTEMPTS
     assert controller.state.regen.retry_timers == {}
-    assert "regen_failed_at" in _read_store(controller, "kitchen.yaml")
 
 
-async def test_shutdown_stamps_armed_retries(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    make_controller: MakeControllerFactory,
+async def test_stop_cancels_armed_retries_without_stamping(
+    tmp_path: Path, make_db: MakeDbFactory
 ) -> None:
-    """A shutdown inside the retry window persists the failure stamp."""
-    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
-    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    """``stop()`` cancels armed retries and writes nothing.
 
-    async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
-        return _FakeProc(returncode=2, stderr=b"fatal: could not clone")
-
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
-        _fake_spawn,
-    )
-
-    controller._schedule_storage_regenerate("kitchen.yaml")
-    await _drain(controller)
-    assert "kitchen.yaml" in controller.state.regen.retry_timers
-
-    await storage_regen.shutdown(controller)
-
-    assert controller.state.regen.retry_timers == {}
-    assert "regen_failed_at" in _read_store(controller, "kitchen.yaml")
-
-
-async def test_stop_stamps_armed_retries(tmp_path: Path, make_db: MakeDbFactory) -> None:
-    """``stop()`` reaches the shutdown stamp for an armed retry."""
+    The failure that armed the retry already stamped its attempt
+    count, so a restart resumes the ladder from the store.
+    """
     controller = DevicesController(make_db(tmp_path))
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
-    controller.state.regen.retry_strikes["kitchen.yaml"] = 1
-    controller.state.regen.retry_timers["kitchen.yaml"] = asyncio.get_running_loop().call_later(
-        30.0, lambda: None
-    )
+    handle = asyncio.get_running_loop().call_later(30.0, lambda: None)
+    controller.state.regen.retry_timers["kitchen.yaml"] = handle
 
     with (
         patch.multiple(controller._state_monitor, stop=AsyncMock()),
@@ -1197,8 +1377,9 @@ async def test_stop_stamps_armed_retries(tmp_path: Path, make_db: MakeDbFactory)
     ):
         await controller.stop()
 
+    assert handle.cancelled()
     assert controller.state.regen.retry_timers == {}
-    assert "regen_failed_at" in controller._metadata_store.get("kitchen.yaml")
+    assert controller._metadata_store.get("kitchen.yaml") == {}
 
 
 async def test_arm_retry_replaces_and_cancels_prior_handle() -> None:
@@ -1218,15 +1399,13 @@ async def test_arm_retry_replaces_and_cancels_prior_handle() -> None:
 
 
 async def test_cancel_all_retry_timers_cancels_pending_handles() -> None:
-    """``stop()``'s mass-cancel leaves no live retry timer or strike behind."""
+    """``stop()``'s mass-cancel leaves no live retry timer behind."""
     state = RegenState()
     loop = asyncio.get_running_loop()
     handles = [loop.call_later(30.0, lambda: None) for _ in range(2)]
     state.retry_timers = {"a.yaml": handles[0], "b.yaml": handles[1]}
-    state.retry_strikes = {"a.yaml": 2}
 
     state.cancel_all_retry_timers()
 
     assert all(handle.cancelled() for handle in handles)
     assert state.retry_timers == {}
-    assert state.retry_strikes == {}

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -760,23 +760,20 @@ async def test_regenerate_clamps_negative_stamp_age(
 ) -> None:
     """A future-dated ``regen_failed_at`` (clock skew, NTP step) is clamped to "fresh".
 
-    Without the ``max(0.0, ...)`` clamp, ``time.time() -
-    cached_at`` could be a large negative number — still less
-    than the TTL, so the guard would correctly skip the regen,
-    but only by accident of float comparison semantics. Pin the
-    clamp explicitly so a future refactor that drops it doesn't
-    silently change the contract.
+    ``_fresh_stamp``'s age clamp keeps the mid-ladder re-arm at the
+    rung's own backoff instead of inflating it by the skew.
     """
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
     yaml_path = tmp_path / "kitchen.yaml"
     yaml_path.write_text("not: valid: yaml\n", encoding="utf-8")
     current_mtime = yaml_path.stat().st_mtime
-    # Stamp claims the failure happened *in the future* (roughly year 2033).
+    # Stamp claims attempt 1 failed *in the future* (roughly year 2033).
     _seed_store(
         controller,
         "kitchen.yaml",
         regen_failed_mtime=current_mtime,
         regen_failed_at=2_000_000_000.0,
+        regen_failed_attempts=1,
     )
     monkeypatch.setattr(
         "esphome_device_builder.controllers.devices.storage_regen.time.time",
@@ -798,6 +795,8 @@ async def test_regenerate_clamps_negative_stamp_age(
     await _drain(controller)
 
     assert spawn_calls == []
+    # age clamped to 0 → the full 30s remainder, not 30s plus the skew.
+    assert _armed_delay(controller) == pytest.approx(30.0, abs=1)
 
 
 async def test_regenerate_runs_when_only_one_stamp_half_present(

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -60,17 +60,17 @@ def _read_store(controller: DevicesController, filename: str) -> dict[str, Any]:
 class _FakeProc:
     """Minimal ``asyncio.subprocess.Process`` stand-in.
 
-    ``communicate`` returns the configured stderr bytes;
+    ``communicate`` returns the configured merged-stream bytes;
     ``returncode`` carries the configured exit code. Only the
     bits ``_schedule_storage_regenerate`` reads.
     """
 
-    def __init__(self, returncode: int = 0, stderr: bytes = b"") -> None:
+    def __init__(self, returncode: int = 0, output: bytes = b"") -> None:
         self.returncode = returncode
-        self._stderr = stderr
+        self._output = output
 
     async def communicate(self) -> tuple[bytes, bytes]:
-        return (b"", self._stderr)
+        return (self._output, b"")
 
 
 def _seed_attempts(
@@ -320,7 +320,7 @@ async def test_regenerate_marks_failed_on_nonzero_exit(
     _seed_attempts(controller, "kitchen.yaml", 3, age=200.0)
 
     async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
-        return _FakeProc(returncode=1, stderr=b"YAML parse error at line 3")
+        return _FakeProc(returncode=1, output=b"YAML parse error at line 3")
 
     monkeypatch.setattr(
         "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
@@ -508,7 +508,7 @@ async def test_regenerate_persists_mtime_and_wallclock_on_failure(
     expected_mtime = yaml_path.stat().st_mtime
 
     async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
-        return _FakeProc(returncode=1, stderr=b"YAML parse error")
+        return _FakeProc(returncode=1, output=b"YAML parse error")
 
     monkeypatch.setattr(
         "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
@@ -741,7 +741,7 @@ async def test_regenerate_skips_when_yaml_unreadable(
 
     async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
         spawn_calls.append(args)
-        return _FakeProc(returncode=1, stderr=b"missing")
+        return _FakeProc(returncode=1, output=b"missing")
 
     monkeypatch.setattr(
         "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
@@ -1113,7 +1113,7 @@ async def test_ttl_expiry_grants_fresh_budget(
     )
 
     async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
-        return _FakeProc(returncode=1, stderr=b"YAML parse error")
+        return _FakeProc(returncode=1, output=b"YAML parse error")
 
     monkeypatch.setattr(
         "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
@@ -1172,7 +1172,7 @@ async def test_backoff_elapsed_runs_next_attempt(
 
     async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
         spawn_calls.append(args)
-        return _FakeProc(returncode=1, stderr=b"YAML parse error")
+        return _FakeProc(returncode=1, output=b"YAML parse error")
 
     monkeypatch.setattr(
         "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
@@ -1273,7 +1273,7 @@ async def test_vanished_mid_run_stamps_prespawn_mtime(
     async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
         # Off-loop: blockbuster flags blocking unlink on the loop (Linux CI).
         await asyncio.to_thread(yaml_path.unlink)
-        return _FakeProc(returncode=1, stderr=b"gone")
+        return _FakeProc(returncode=1, output=b"gone")
 
     monkeypatch.setattr(
         "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
@@ -1301,8 +1301,10 @@ async def test_regenerate_warns_when_yaml_unreadable(
     make_controller: MakeControllerFactory,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A non-vanish stat error re-arms the ladder loudly instead of stranding it."""
+    """A non-vanish stat error re-arms the ladder loudly, escalating per strike."""
     controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    monkeypatch.setattr(DevicesController, "_finalize_regen_success", AsyncMock())
     spawn_calls: list[tuple[str, ...]] = []
 
     async def _fake_spawn(*args: str, **_kwargs: Any) -> _FakeProc:
@@ -1313,13 +1315,23 @@ async def test_regenerate_warns_when_yaml_unreadable(
         "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
         _fake_spawn,
     )
+    real_run_in_executor = storage_regen.run_in_executor
+    denials = 2
 
-    async def _denied(_fn: Any) -> float:
-        raise PermissionError("denied")
+    async def _denied(fn: Any, *args: Any) -> Any:
+        nonlocal denials
+        if denials:
+            denials -= 1
+            raise PermissionError("denied")
+        return await real_run_in_executor(fn, *args)
 
     monkeypatch.setattr(
         "esphome_device_builder.controllers.devices.storage_regen.run_in_executor", _denied
     )
+
+    def _armed_delay() -> float:
+        handle = controller.state.regen.retry_timers["kitchen.yaml"]
+        return handle.when() - asyncio.get_running_loop().time()
 
     with caplog.at_level(logging.WARNING):
         controller._schedule_storage_regenerate("kitchen.yaml")
@@ -1328,8 +1340,22 @@ async def test_regenerate_warns_when_yaml_unreadable(
     assert spawn_calls == []
     assert any("config unreadable" in record.message for record in caplog.records)
     # A transient errno keeps the ladder alive: the base backoff re-arms.
-    assert set(controller.state.regen.retry_timers) == {"kitchen.yaml"}
-    controller.state.regen.cancel_all_retry_timers()
+    assert controller.state.regen.unreadable_strikes == {"kitchen.yaml": 1}
+    assert 29.0 < _armed_delay() <= 30.0
+
+    # A second strike widens the re-arm.
+    storage_regen._fire_retry(controller, "kitchen.yaml")
+    await _drain(controller)
+
+    assert controller.state.regen.unreadable_strikes == {"kitchen.yaml": 2}
+    assert 59.0 < _armed_delay() <= 60.0
+
+    # The stat recovering clears the strikes and spawns.
+    storage_regen._fire_retry(controller, "kitchen.yaml")
+    await _drain(controller)
+
+    assert controller.state.regen.unreadable_strikes == {}
+    assert len(spawn_calls) == 1
     assert controller.state.regen.pending == set()
 
 
@@ -1344,7 +1370,7 @@ async def test_edit_between_failures_resets_attempts(
     yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
 
     async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
-        return _FakeProc(returncode=2, stderr=b"fatal: could not clone")
+        return _FakeProc(returncode=2, output=b"fatal: could not clone")
 
     monkeypatch.setattr(
         "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
@@ -1378,7 +1404,7 @@ async def test_regenerate_first_failure_stamps_and_arms_retry(
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
 
     async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
-        return _FakeProc(returncode=2, stderr=b"fatal: could not clone")
+        return _FakeProc(returncode=2, output=b"fatal: could not clone")
 
     monkeypatch.setattr(
         "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",
@@ -1405,7 +1431,7 @@ async def test_regenerate_retry_fires_and_succeeds(
         "esphome_device_builder.controllers.devices.storage_regen._RETRY_BACKOFF_BASE_SECONDS",
         0.0,
     )
-    outcomes = [_FakeProc(returncode=2, stderr=b"fatal: clone interrupted"), _FakeProc()]
+    outcomes = [_FakeProc(returncode=2, output=b"fatal: clone interrupted"), _FakeProc()]
 
     async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
         return outcomes.pop(0)
@@ -1447,7 +1473,7 @@ async def test_regenerate_retry_budget_exhausts_to_stamp(
     async def _fake_spawn(*_args: str, **_kwargs: Any) -> _FakeProc:
         nonlocal spawns
         spawns += 1
-        return _FakeProc(returncode=1, stderr=b"YAML parse error")
+        return _FakeProc(returncode=1, output=b"YAML parse error")
 
     monkeypatch.setattr(
         "esphome_device_builder.controllers.devices.storage_regen.create_subprocess_exec",

--- a/tests/controllers/devices/test_subscribe_reachability.py
+++ b/tests/controllers/devices/test_subscribe_reachability.py
@@ -479,7 +479,6 @@ def test_scan_change_removed_clears_tracker(
     # don't have to hand-build an import_discovery. The tracker
     # clear is what we're pinning down.
     controller._state_monitor.importable.revisit_all_importables = MagicMock()
-    controller.state.regen.failed = set()
 
     controller._on_scan_change(ScanChange.REMOVED, device)
 

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -354,56 +354,6 @@ def test_set_device_metadata_clears_mac_on_empty(tmp_path: Path) -> None:
     assert "mac_address" not in get_device_metadata(tmp_path, "kitchen.yaml")
 
 
-def test_set_device_metadata_persists_regen_failure_stamp(tmp_path: Path) -> None:
-    """``regen_failed_mtime`` + ``regen_failed_at`` round-trip together.
-
-    Persisted so a backend restart skips replaying a regen on a
-    YAML that already failed at this exact mtime — without it,
-    every dashboard boot burns a subprocess on broken configs
-    (missing ``!secret``, unreachable git package) just to fail
-    again. The wall-clock half feeds the controller-side TTL so
-    transient external problems eventually get re-checked even
-    when the YAML is untouched.
-    """
-    set_device_metadata(
-        tmp_path,
-        "kitchen.yaml",
-        regen_failed_mtime=1700000000.5,
-        regen_failed_at=1700000005.0,
-    )
-
-    assert get_device_metadata(tmp_path, "kitchen.yaml") == {
-        "regen_failed_mtime": 1700000000.5,
-        "regen_failed_at": 1700000005.0,
-    }
-
-
-def test_set_device_metadata_clears_regen_failure_stamp_on_zero(tmp_path: Path) -> None:
-    """Both stamp halves cleared explicitly via ``0.0``.
-
-    The success path of ``_schedule_storage_regenerate`` clears
-    both fields so a future backend restart picks up the now-good
-    YAML. Passing ``0.0`` is the explicit clear path; ``None``
-    leaves the field alone.
-    """
-    set_device_metadata(
-        tmp_path,
-        "kitchen.yaml",
-        regen_failed_mtime=1700000000.5,
-        regen_failed_at=1700000005.0,
-    )
-    set_device_metadata(
-        tmp_path,
-        "kitchen.yaml",
-        regen_failed_mtime=0.0,
-        regen_failed_at=0.0,
-    )
-
-    md = get_device_metadata(tmp_path, "kitchen.yaml")
-    assert "regen_failed_mtime" not in md
-    assert "regen_failed_at" not in md
-
-
 def test_set_device_metadata_persists_build_size_triple(tmp_path: Path) -> None:
     """The (bytes, dir_mtime, info_mtime) triple round-trips together.
 


### PR DESCRIPTION
# What does this implement/fix?

The regen failure ladder kept three sources of truth: the session failed set, the in RAM strike counts and the disk stamp. That split produced the four seams in #2534, a spent budget was terminal in session even after the stamp's TTL, a restart inside the backoff window either lost the ladder or converted one transient failure into the full lockout, an out of band edit of a never compiled config scheduled nothing, and a run cancelled at shutdown orphaned its esphome child.

Every failure now stamps the metadata store with the attempt count (`regen_failed_mtime`/`_at`/`_attempts`), and the stamp is the single source: `_run` consults it (terminal skip at 4 attempts, a restart inside a backoff window re-arms the remainder instead of spawning early, the TTL grants a fresh budget in session too), an edit resets the ladder by construction since the mtime no longer matches, shutdown only cancels timers, and a cancelled run kills its subprocess without recording anything. The session failed set and strike dict are deleted; the one RAM counter that remains is `unreadable_strikes`, for stat failures the stamp cannot key (no mtime to record against), escalating and bounded by the TTL. The scan gate extends to UPDATED so out of band edits recover, and an UPDATED that cancels an armed retry reschedules so the edited YAML spawns fresh. Failures stamp against the mtime read before the spawn, so an edit landing mid run is never charged the old content's failure. A terminal config arms a re-check timer for the stamp's expiry, no scan event fires for an untouched file, and the give up warning carries a short failure summary. The spawn moves to the shared `run_subprocess_capture` helper: merged streams so the summary captures esphome's stdout validation dump, and a five minute timeout so a wedged run counts as a failure instead of holding the regen lock forever. A stamp without the attempts field reads as terminal and self expires; released versions only wrote stamps at budget exhaustion, so that fallback is exact for them and conservative only for the unreleased window after #2535. The TTL moves from one hour to four; transients are the in window ladder's job now, so the TTL only paces re-checks and the give up warning for genuinely broken configs.

**Related issue or feature (if applicable):**

- fixes #2534

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
