### PR TITLE
Resolve the storage sidecar by filename in the ESP-IDF e2e

### DIFF
--- a/tests/e2e/slow/esp32/test_esp_idf_compile_download.py
+++ b/tests/e2e/slow/esp32/test_esp_idf_compile_download.py
@@ -45,7 +45,9 @@ def _local_download_set(data_dir: Path) -> set[str]:
     against the receiver's own storage + build dir, so the parity check
     shares one source of truth with the offloader side.
     """
-    [storage_path] = list((data_dir / "storage").glob("*.json"))
+    # esphome dev writes `<file>.validated.json` beside the sidecar, so a
+    # `*.json` glob can't single out the StorageJSON.
+    storage_path = data_dir / "storage" / f"{_CONFIGURATION_FILENAME}.json"
     storage = StorageJSON.load(storage_path)
     assert storage is not None
     return {entry["file"] for entry in collect_download_entries(storage, storage_path)}


### PR DESCRIPTION
# What does this implement/fix?

The E2E native ESP-IDF job intermittently fails with `ValueError: too many values to unpack` at the storage glob in `test_esp_idf_compile_download_round_trip`. esphome dev now writes a `<file>.validated.json` validated config cache beside the StorageJSON sidecar in the same `storage/` dir, so the `*.json` glob can match two files; the cache write is non fatal upstream, which is why only some runs hit it. The test knows its config filename, so build the sidecar path directly instead of globbing. Production is unaffected; nothing in the package enumerates the storage dir.

**Related issue or feature (if applicable):**

- fixes the flaky failure seen in https://github.com/esphome/device-builder/actions/runs/31397282182/job/93483181548

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [ ] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
