### PR TITLE
Fix cancel not stopping a running compile on Windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,8 +348,9 @@ against legacy behaviour before assuming the simpler version suffices.
   `FirmwareState.compile_lane` / `upload_lane` / `thread_upload_lane`
   (`controllers/firmware/_state.py`); each lane spawns
   `Lane.max_concurrency` workers off one FIFO queue, jobs occupying a
-  lane sit in `Lane.active` (job-id keyed), and running subprocesses live
-  in the job-keyed `FirmwareState.processes` registry so cancel
+  lane sit in `Lane.active` (job-id keyed), and running spawns live in
+  the job-keyed `FirmwareState.spawns` registry (`SpawnHandle` pairs
+  the subprocess with its Win32 job object) so cancel
   (`terminate_job_process`) signals exactly one job. `lane_for(job)`
   routes a network flash of an OpenThread device to the thread lane
   (Thread devices share one mesh/border router — concurrent OTAs starve

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -222,8 +222,11 @@ firmware/install {configuration} → QUEUED → RUNNING → output... → COMPLE
   so cancel signals exactly one job. Cancel kills the whole spawn tree:
   the process group on POSIX (`start_new_session=True` at the spawn), a
   kill-on-close Win32 job object on Windows (the parallel
-  `FirmwareState.job_objects` registry; `TerminateJobObject` first,
-  `taskkill /F /T` then a parent-only kill as fallbacks — #2552). A
+  `FirmwareState.job_objects` registry; a `taskkill /F /T` sweep runs
+  first while the tracked parent is alive to walk the PID tree from —
+  a child spawned before the job assignment is in no job — then
+  `TerminateJobObject`, then a parent-only kill when both fail —
+  #2552). A
   cancelled job's finalisation doesn't wait for stdout-pipe EOF: a
   kill survivor inherits the write handle (`close_fds=False`), so the
   runner's output pump abandons the pipe after a short drain window

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -219,7 +219,15 @@ firmware/install {configuration} → QUEUED → RUNNING → output... → COMPLE
   (peak concurrency is the cap plus one thread flash); each lane spawns
   `Lane.max_concurrency` workers off one FIFO queue, and running
   subprocesses live in the job-keyed `FirmwareState.processes` registry
-  so cancel signals exactly one job. **OpenThread flashes serialize**:
+  so cancel signals exactly one job. Cancel kills the whole spawn tree:
+  the process group on POSIX (`start_new_session=True` at the spawn), a
+  kill-on-close Win32 job object on Windows (the parallel
+  `FirmwareState.job_objects` registry; `TerminateJobObject` first,
+  `taskkill /F /T` then a parent-only kill as fallbacks — #2552). A
+  cancelled job's finalisation doesn't wait for stdout-pipe EOF: a
+  kill survivor inherits the write handle (`close_fds=False`), so the
+  runner's output pump abandons the pipe after a short drain window
+  once the tracked process is reaped. **OpenThread flashes serialize**:
   Thread devices share one mesh / border router, and concurrent OTAs
   over the mesh starve each other, so `lane_for` routes a network flash
   whose device loads `openthread` (per `DevicesController.is_thread_device`,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -217,16 +217,16 @@ firmware/install {configuration} → QUEUED → RUNNING → output... → COMPLE
   devices went back to sleep, and their updates failed. The upload cap
   bounds the combined memory of concurrent esphome subprocess trees
   (peak concurrency is the cap plus one thread flash); each lane spawns
-  `Lane.max_concurrency` workers off one FIFO queue, and running
-  subprocesses live in the job-keyed `FirmwareState.processes` registry
-  so cancel signals exactly one job. Cancel kills the whole spawn tree:
-  the process group on POSIX (`start_new_session=True` at the spawn), a
-  kill-on-close Win32 job object on Windows (the parallel
-  `FirmwareState.job_objects` registry; a `taskkill /F /T` sweep runs
-  first while the tracked parent is alive to walk the PID tree from —
-  a child spawned before the job assignment is in no job — then
-  `TerminateJobObject`, then a parent-only kill when both fail —
-  #2552). A
+  `Lane.max_concurrency` workers off one FIFO queue, and running spawns
+  live in the job-keyed `FirmwareState.spawns` registry (a
+  `SpawnRegistry` of `SpawnHandle`s pairing each subprocess with its
+  kill-on-close Win32 job object) so cancel signals exactly one job.
+  Cancel kills the whole spawn tree: the process group on POSIX
+  (`start_new_session=True` at the spawn); on Windows a
+  `taskkill /F /T` sweep runs first while the tracked parent is alive
+  to walk the PID tree from — a child spawned before the job
+  assignment is in no job — then `TerminateJobObject`, then a
+  parent-only kill when both fail — #2552. A
   cancelled job's finalisation doesn't wait for stdout-pipe EOF: a
   kill survivor inherits the write handle (`close_fds=False`), so the
   runner's output pump abandons the pipe after a short drain window

--- a/esphome_device_builder/controllers/firmware/_state.py
+++ b/esphome_device_builder/controllers/firmware/_state.py
@@ -6,6 +6,7 @@ import asyncio
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 
+from ...helpers.windows_job_object import WindowsJobObject
 from ...models import FirmwareJob, JobSource, JobStatus, JobType
 from .constants import MAX_CONCURRENT_UPLOADS
 
@@ -130,6 +131,10 @@ class FirmwareState:
     # ``firmware/cancel`` signals. Job-keyed rather than per-lane so an
     # off-lane spawn (the remote-install local flash) is cancellable too.
     processes: dict[str, asyncio.subprocess.Process] = field(default_factory=dict)
+
+    # Win32 job objects for running spawns, keyed by ``job_id`` (empty
+    # on POSIX).
+    job_objects: dict[str, WindowsJobObject] = field(default_factory=dict)
 
     # Active + recent jobs keyed by ``job_id``. ``persistence``
     # reads / writes on every state transition; ``clean``,

--- a/esphome_device_builder/controllers/firmware/_state.py
+++ b/esphome_device_builder/controllers/firmware/_state.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import sys
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -25,8 +24,7 @@ class SpawnHandle:
         """Wrap *proc*, assigning it to a kill-on-close job object on Windows."""
         # A child started before the job assignment lands is outside the
         # job; the terminate path's taskkill sweep covers that window.
-        win_job = WindowsJobObject.create_for_pid(proc.pid) if sys.platform == "win32" else None
-        return cls(proc, win_job)
+        return cls(proc, WindowsJobObject.create_for_pid(proc.pid))
 
     def close(self) -> None:
         """Release the Windows kill handle, if any."""
@@ -35,7 +33,11 @@ class SpawnHandle:
 
 
 class SpawnRegistry(dict[str, SpawnHandle]):
-    """Job-keyed running spawns — what ``firmware/cancel`` targets."""
+    """
+    Job-keyed running spawns — what ``firmware/cancel`` targets.
+
+    Mutate through ``register`` / ``release`` so kill handles close.
+    """
 
     @contextmanager
     def register(self, job_id: str, spawn: SpawnHandle) -> Iterator[None]:

--- a/esphome_device_builder/controllers/firmware/_state.py
+++ b/esphome_device_builder/controllers/firmware/_state.py
@@ -3,12 +3,58 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 
 from ...helpers.windows_job_object import WindowsJobObject
 from ...models import FirmwareJob, JobSource, JobStatus, JobType
 from .constants import MAX_CONCURRENT_UPLOADS
+
+
+@dataclass
+class SpawnHandle:
+    """One tracked spawn: the subprocess and its Windows kill handle."""
+
+    proc: asyncio.subprocess.Process
+    win_job: WindowsJobObject | None = None
+
+    @classmethod
+    def track(cls, proc: asyncio.subprocess.Process) -> SpawnHandle:
+        """Wrap *proc*, assigning it to a kill-on-close job object on Windows."""
+        # A child started before the job assignment lands is outside the
+        # job; the terminate path's taskkill sweep covers that window.
+        win_job = WindowsJobObject.create_for_pid(proc.pid) if sys.platform == "win32" else None
+        return cls(proc, win_job)
+
+    def close(self) -> None:
+        """Release the Windows kill handle, if any."""
+        if self.win_job is not None:
+            self.win_job.close()
+
+
+class SpawnRegistry(dict[str, SpawnHandle]):
+    """Job-keyed running spawns — what ``firmware/cancel`` targets."""
+
+    @contextmanager
+    def register(self, job_id: str, spawn: SpawnHandle) -> Iterator[None]:
+        """Hold *spawn* for *job_id*; restore any prior entry and close *spawn* on exit."""
+        prev = self.get(job_id)
+        self[job_id] = spawn
+        try:
+            yield
+        finally:
+            if prev is None:
+                self.pop(job_id, None)
+            else:
+                self[job_id] = prev
+            spawn.close()
+
+    def release(self, job_id: str) -> None:
+        """Drop *job_id*'s entry, closing its kill handle; no-op when absent."""
+        if (spawn := self.pop(job_id, None)) is not None:
+            spawn.close()
 
 
 @dataclass
@@ -127,14 +173,10 @@ class FirmwareState:
     # False routes every flash to the normal upload lane.
     is_thread_configuration: Callable[[str], bool] = field(default=lambda _configuration: False)
 
-    # Subprocesses spawned for running jobs, keyed by ``job_id`` — what
+    # Spawns for running jobs, keyed by ``job_id`` — what
     # ``firmware/cancel`` signals. Job-keyed rather than per-lane so an
     # off-lane spawn (the remote-install local flash) is cancellable too.
-    processes: dict[str, asyncio.subprocess.Process] = field(default_factory=dict)
-
-    # Win32 job objects for running spawns, keyed by ``job_id`` (empty
-    # on POSIX).
-    job_objects: dict[str, WindowsJobObject] = field(default_factory=dict)
+    spawns: SpawnRegistry = field(default_factory=SpawnRegistry)
 
     # Active + recent jobs keyed by ``job_id``. ``persistence``
     # reads / writes on every state transition; ``clean``,

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -452,8 +452,7 @@ async def _pump_output_until_exit(
     finally:
         # Sync only, so a propagating CancelledError is never swallowed
         # or stalled; the loop finishes cancelling the reader on its own.
-        if not reader.done():
-            reader.cancel()
+        reader.cancel()
 
 
 def _is_compile_start_line(line: str) -> bool:

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -9,6 +9,7 @@ under ``tests/controllers/firmware/test_helpers.py``.
 
 from __future__ import annotations
 
+import asyncio
 import ipaddress
 import logging
 import os
@@ -21,7 +22,8 @@ from typing import TYPE_CHECKING
 from esphome.upload_targets import PortType, get_port_type
 
 from ...helpers.api import CommandError
-from ...helpers.subprocess import run_subprocess_capture
+from ...helpers.async_ import drain_tasks
+from ...helpers.subprocess import consume_lines, run_subprocess_capture
 from ...models import (
     OTA_PORT,
     DeviceState,
@@ -50,10 +52,21 @@ from .constants import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from ...helpers.event_bus import EventBus
     from .controller import FirmwareController
 
 _LOGGER = logging.getLogger(__name__)
+
+# How often the output pump re-checks the tracked process for a reap
+# the pipe can't signal (asyncio's ``Process.wait`` is EOF-gated).
+_EXIT_POLL_SECONDS = 0.5
+
+# How long a cancelled job's output reader may keep draining after the
+# tracked process exits, before it's abandoned (surviving descendants
+# hold the inherited pipe handle open indefinitely).
+_CANCELLED_PIPE_DRAIN_SECONDS = 1.0
 
 
 def _is_no_module_named_esphome(text: str) -> bool:
@@ -409,6 +422,38 @@ def _ingest_notice_line(job: FirmwareJob, bus: EventBus, text: str) -> None:
     """Ingest a synthetic ``*** text ***`` line, separating it from an unterminated tail."""
     prefix = "\n" if job.output and not job.output[-1].endswith(("\n", "\r")) else ""
     _ingest_output_line(job, bus, f"{prefix}*** {text} ***\n")
+
+
+async def _pump_output_until_exit(
+    job_id: str,
+    proc: asyncio.subprocess.Process,
+    on_line: Callable[[str], None],
+    cancel_requested: set[str],
+) -> int:
+    """
+    Stream *proc*'s stdout to *on_line* and return its exit code.
+
+    A cancel-flagged *job_id* returns at the tracked process's reap
+    after a short drain window, even when a kill survivor holds the
+    pipe open past EOF.
+    """
+    assert proc.stdout is not None  # type narrowing
+    reader = asyncio.get_running_loop().create_task(consume_lines(proc.stdout, on_line))
+    try:
+        while True:
+            done, _pending = await asyncio.wait({reader}, timeout=_EXIT_POLL_SECONDS)
+            if done:
+                await reader
+                return await proc.wait()
+            if proc.returncode is not None and job_id in cancel_requested:
+                await asyncio.wait({reader}, timeout=_CANCELLED_PIPE_DRAIN_SECONDS)
+                await drain_tasks((reader,))
+                return proc.returncode
+    finally:
+        # Sync only, so a propagating CancelledError is never swallowed
+        # or stalled; the loop finishes cancelling the reader on its own.
+        if not reader.done():
+            reader.cancel()
 
 
 def _is_compile_start_line(line: str) -> bool:

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -438,7 +438,9 @@ async def _pump_output_until_exit(
     pipe open past EOF.
     """
     assert proc.stdout is not None  # type narrowing
-    reader = asyncio.get_running_loop().create_task(consume_lines(proc.stdout, on_line))
+    reader = asyncio.get_running_loop().create_task(
+        consume_lines(proc.stdout, on_line), name=f"job {job_id} output reader"
+    )
     warned_wedged = False
     try:
         while True:

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -68,6 +68,8 @@ _EXIT_POLL_SECONDS = 0.5
 # hold the inherited pipe handle open indefinitely).
 _CANCELLED_PIPE_DRAIN_SECONDS = 1.0
 
+_ABANDONED_PIPE_READ_SIZE = 65536
+
 
 def _is_no_module_named_esphome(text: str) -> bool:
     """Return True if *text* names ``esphome`` itself as missing.
@@ -453,9 +455,7 @@ async def _pump_output_until_exit(
             if job_id in cancel_requested:
                 await asyncio.wait({reader}, timeout=_CANCELLED_PIPE_DRAIN_SECONDS)
                 await drain_tasks((reader,), log_exceptions=True)
-                # The abandoned pipe EOFs when the survivor exits; reap
-                # the transport then instead of leaving it to GC.
-                create_logged_task(proc.wait(), name=f"job {job_id} spawn reaper")
+                create_logged_task(_reap_abandoned_spawn(proc), name=f"job {job_id} spawn reaper")
                 return proc.returncode
             if not warned_wedged:
                 warned_wedged = True
@@ -469,6 +469,19 @@ async def _pump_output_until_exit(
         # Sync only, so a propagating CancelledError is never swallowed
         # or stalled; the loop finishes cancelling the reader on its own.
         reader.cancel()
+
+
+async def _reap_abandoned_spawn(proc: asyncio.subprocess.Process) -> None:
+    """
+    Discard *proc*'s abandoned stdout until EOF, then reap the transport.
+
+    Without a consumer the stream buffer fills and pauses the pipe, so
+    EOF is never observed and the transport lives until GC.
+    """
+    assert proc.stdout is not None  # type narrowing
+    while await proc.stdout.read(_ABANDONED_PIPE_READ_SIZE):
+        pass
+    await proc.wait()
 
 
 def _is_compile_start_line(line: str) -> bool:

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 from esphome.upload_targets import PortType, get_port_type
 
 from ...helpers.api import CommandError
-from ...helpers.async_ import drain_tasks
+from ...helpers.async_ import create_logged_task, drain_tasks
 from ...helpers.subprocess import consume_lines, run_subprocess_capture
 from ...models import (
     OTA_PORT,
@@ -453,6 +453,9 @@ async def _pump_output_until_exit(
             if job_id in cancel_requested:
                 await asyncio.wait({reader}, timeout=_CANCELLED_PIPE_DRAIN_SECONDS)
                 await drain_tasks((reader,), log_exceptions=True)
+                # The abandoned pipe EOFs when the survivor exits; reap
+                # the transport then instead of leaving it to GC.
+                create_logged_task(proc.wait(), name=f"job {job_id} spawn reaper")
                 return proc.returncode
             if not warned_wedged:
                 warned_wedged = True

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -439,16 +439,27 @@ async def _pump_output_until_exit(
     """
     assert proc.stdout is not None  # type narrowing
     reader = asyncio.get_running_loop().create_task(consume_lines(proc.stdout, on_line))
+    warned_wedged = False
     try:
         while True:
             done, _pending = await asyncio.wait({reader}, timeout=_EXIT_POLL_SECONDS)
             if done:
                 await reader
                 return await proc.wait()
-            if proc.returncode is not None and job_id in cancel_requested:
+            if proc.returncode is None:
+                continue
+            if job_id in cancel_requested:
                 await asyncio.wait({reader}, timeout=_CANCELLED_PIPE_DRAIN_SECONDS)
-                await drain_tasks((reader,))
+                await drain_tasks((reader,), log_exceptions=True)
                 return proc.returncode
+            if not warned_wedged:
+                warned_wedged = True
+                _LOGGER.warning(
+                    "Job %s: process exited (%s) but a descendant still holds "
+                    "the output pipe — waiting for EOF",
+                    job_id,
+                    proc.returncode,
+                )
     finally:
         # Sync only, so a propagating CancelledError is never swallowed
         # or stalled; the loop finishes cancelling the reader on its own.

--- a/esphome_device_builder/controllers/firmware/lifecycle.py
+++ b/esphome_device_builder/controllers/firmware/lifecycle.py
@@ -174,10 +174,10 @@ async def terminate_job_process(controller: FirmwareController, job: FirmwareJob
 
     Walks the whole process group via
     :func:`terminate_subtree_with_grace` so SIGTERM reaches
-    esphome → platformio → gcc / esptool on POSIX, the job object
-    (``taskkill /F /T`` fallback) on Windows. The runner loop is what
-    actually finalises the job on exit — this helper only nudges the
-    process. Job-scoped so cancelling an upload never signals a
+    esphome → platformio → gcc / esptool on POSIX; Windows runs the
+    ``taskkill /F /T`` sweep then the job object. The runner loop is
+    what actually finalises the job on exit — this helper only nudges
+    the process. Job-scoped so cancelling an upload never signals a
     concurrent compile.
     """
     proc = controller.state.processes.get(job.job_id)

--- a/esphome_device_builder/controllers/firmware/lifecycle.py
+++ b/esphome_device_builder/controllers/firmware/lifecycle.py
@@ -96,6 +96,8 @@ def finalize_unexpected_error(
 def _release_lane_slot(controller: FirmwareController, job: FirmwareJob) -> None:
     """Clear *job*'s lane slot and subprocess registration, if any."""
     controller.state.processes.pop(job.job_id, None)
+    if (job_obj := controller.state.job_objects.pop(job.job_id, None)) is not None:
+        job_obj.close()
     for lane in controller.state.lanes():
         lane.active.pop(job.job_id, None)
 
@@ -172,15 +174,20 @@ async def terminate_job_process(controller: FirmwareController, job: FirmwareJob
 
     Walks the whole process group via
     :func:`terminate_subtree_with_grace` so SIGTERM reaches
-    esphome → platformio → gcc / esptool on POSIX, ``taskkill /F
-    /T`` on Windows. The runner loop is what actually finalises
-    the job on exit — this helper only nudges the process. Job-scoped
-    so cancelling an upload never signals a concurrent compile.
+    esphome → platformio → gcc / esptool on POSIX, the job object
+    (``taskkill /F /T`` fallback) on Windows. The runner loop is what
+    actually finalises the job on exit — this helper only nudges the
+    process. Job-scoped so cancelling an upload never signals a
+    concurrent compile.
     """
     proc = controller.state.processes.get(job.job_id)
     if proc is None:
         return
-    await terminate_subtree_with_grace(proc, job_label=f"job {job.job_id}")
+    await terminate_subtree_with_grace(
+        proc,
+        job_label=f"job {job.job_id}",
+        win_job=controller.state.job_objects.get(job.job_id),
+    )
 
 
 def _defer_install_if_target_offline(controller: FirmwareController, job: FirmwareJob) -> None:

--- a/esphome_device_builder/controllers/firmware/lifecycle.py
+++ b/esphome_device_builder/controllers/firmware/lifecycle.py
@@ -94,10 +94,8 @@ def finalize_unexpected_error(
 
 
 def _release_lane_slot(controller: FirmwareController, job: FirmwareJob) -> None:
-    """Clear *job*'s lane slot and subprocess registration, if any."""
-    controller.state.processes.pop(job.job_id, None)
-    if (job_obj := controller.state.job_objects.pop(job.job_id, None)) is not None:
-        job_obj.close()
+    """Clear *job*'s lane slot and spawn registration, if any."""
+    controller.state.spawns.release(job.job_id)
     for lane in controller.state.lanes():
         lane.active.pop(job.job_id, None)
 
@@ -180,13 +178,13 @@ async def terminate_job_process(controller: FirmwareController, job: FirmwareJob
     the process. Job-scoped so cancelling an upload never signals a
     concurrent compile.
     """
-    proc = controller.state.processes.get(job.job_id)
-    if proc is None:
+    spawn = controller.state.spawns.get(job.job_id)
+    if spawn is None:
         return
     await terminate_subtree_with_grace(
-        proc,
+        spawn.proc,
         job_label=f"job {job.job_id}",
-        win_job=controller.state.job_objects.get(job.job_id),
+        win_job=spawn.win_job,
     )
 
 

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -31,6 +31,7 @@ import asyncio
 import logging
 import os
 from collections.abc import Mapping
+from functools import partial
 from typing import TYPE_CHECKING, Any, Literal
 
 from esphome.const import __version__ as _offloader_esphome_version
@@ -43,7 +44,6 @@ from ...helpers.remote_artifacts_materialise import (
     MaterialiseError,
     materialise_remote_artifacts,
 )
-from ...helpers.subprocess import iter_lines_with_progress
 from ...models import (
     EventType,
     FirmwareJob,
@@ -66,7 +66,12 @@ from ..remote_build.peer_link_client import (
 from . import lifecycle
 from .bundle_phase import run_bundle_phase
 from .constants import ESPHOME_SUBPROCESS_ENV
-from .helpers import _fire_job_progress, _ingest_notice_line, _ingest_output_line
+from .helpers import (
+    _fire_job_progress,
+    _ingest_notice_line,
+    _ingest_output_line,
+    _pump_output_until_exit,
+)
 
 if TYPE_CHECKING:
     from ...helpers.event_bus import Event, EventBus
@@ -830,11 +835,12 @@ async def _run_upload_subprocess(
         if job.job_id in controller.state.cancel_requested:
             await controller._terminate_job_process(job)
 
-        assert proc.stdout is not None  # type narrowing
-        async for line in iter_lines_with_progress(proc.stdout):
-            _ingest_output_line(job, bus, line)
-
-        exit_code = await proc.wait()
+        exit_code = await _pump_output_until_exit(
+            job.job_id,
+            proc,
+            partial(_ingest_output_line, job, bus),
+            controller.state.cancel_requested,
+        )
 
     if lifecycle.cancel_if_requested(controller, job):
         return None

--- a/esphome_device_builder/controllers/firmware/runner.py
+++ b/esphome_device_builder/controllers/firmware/runner.py
@@ -11,7 +11,8 @@ from typing import TYPE_CHECKING, Any
 
 from ...controllers.remote_build.env_provisioner import EnvProvisionError
 from ...helpers.async_ import run_in_executor
-from ...helpers.subprocess import create_subprocess_exec, iter_lines_with_progress
+from ...helpers.subprocess import create_subprocess_exec
+from ...helpers.windows_job_object import WindowsJobObject
 from ...models import (
     FirmwareJob,
     JobFailureReason,
@@ -24,6 +25,7 @@ from .constants import _ERROR_PATTERNS
 from .helpers import (
     _ingest_output_line,
     _is_no_module_named_esphome,
+    _pump_output_until_exit,
 )
 from .remote_runner import run_remote_job
 
@@ -181,35 +183,25 @@ async def execute_job(  # noqa: PLR0915, PLR0912, C901
             if job.job_id in controller.state.cancel_requested:
                 await controller._terminate_job_process(job)
 
-            assert proc.stdout is not None  # type narrowing
-
-            # ``iter_lines_with_progress`` splits on `\n` _or_ `\r`
-            # so carriage-return-based in-place updates (esptool's
-            # `Writing at 0x... (5%)\r`, PlatformIO's progress
-            # bars) survive the pipe instead of getting buffered
-            # until the next newline. Each chunk keeps its
-            # trailing terminator so the frontend can decide
-            # whether to append a new line or overwrite the last
-            # one.
-            async for line in iter_lines_with_progress(proc.stdout):
-                # Shared with the source-routed remote runner
-                # (``remote_runner._on_output``). The helper
-                # buffers + trims + fires ``JOB_OUTPUT`` and
-                # advances ``JOB_PROGRESS`` on a parseable
-                # percentage — same per-line bookkeeping
-                # whether the build's bytes come from this
-                # CPU or a paired receiver. ``_check_error``
-                # stays inline because it mutates the
-                # nonlocal ``has_error_in_output`` /
-                # ``saw_no_esphome_module`` flags the
-                # post-exit handler reads; remote builds
-                # surface a structured ``failed`` status from
-                # the receiver instead, so the stderr scrape
-                # only matters here.
+            # Shared with the source-routed remote runner
+            # (``remote_runner._on_output``). ``_ingest_output_line``
+            # buffers + trims + fires ``JOB_OUTPUT`` and advances
+            # ``JOB_PROGRESS`` on a parseable percentage — same
+            # per-line bookkeeping whether the build's bytes come
+            # from this CPU or a paired receiver. ``_check_error``
+            # stays inline because it mutates the nonlocal
+            # ``has_error_in_output`` / ``saw_no_esphome_module``
+            # flags the post-exit handler reads; remote builds
+            # surface a structured ``failed`` status from the
+            # receiver instead, so the stderr scrape only matters
+            # here.
+            def _on_line(line: str) -> None:
                 _ingest_output_line(job, controller._db.bus, line)
                 _check_error(line)
 
-            exit_code = await proc.wait()
+            exit_code = await _pump_output_until_exit(
+                job.job_id, proc, _on_line, controller.state.cancel_requested
+            )
             job.exit_code = exit_code
 
         # If the user cancelled this job mid-run, the subprocess
@@ -368,9 +360,20 @@ async def tracked_subprocess(
     # traceback in the streamed job output instead.
     kwargs.setdefault("stdin", asyncio.subprocess.DEVNULL)
     proc = await create_subprocess_exec(*args, **kwargs)
+    # Windows tree-kill primitive; assigned on the same event-loop
+    # tick as the spawn, before the child can start children.
+    job_obj = WindowsJobObject.create_for_pid(proc.pid) if sys.platform == "win32" else None
     processes = controller.state.processes
+    job_objects = controller.state.job_objects
     prev = processes.get(job.job_id)
+    prev_job_obj = job_objects.get(job.job_id)
     processes[job.job_id] = proc
+    # Kept in lockstep with ``processes`` — a stale entry would pair a
+    # nested spawn's proc with the outer spawn's kill handle.
+    if job_obj is None:
+        job_objects.pop(job.job_id, None)
+    else:
+        job_objects[job.job_id] = job_obj
     try:
         yield proc
     except asyncio.CancelledError:
@@ -391,3 +394,9 @@ async def tracked_subprocess(
             processes.pop(job.job_id, None)
         else:
             processes[job.job_id] = prev
+        if prev_job_obj is None:
+            job_objects.pop(job.job_id, None)
+        else:
+            job_objects[job.job_id] = prev_job_obj
+        if job_obj is not None:
+            job_obj.close()

--- a/esphome_device_builder/controllers/firmware/runner.py
+++ b/esphome_device_builder/controllers/firmware/runner.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Any
 from ...controllers.remote_build.env_provisioner import EnvProvisionError
 from ...helpers.async_ import run_in_executor
 from ...helpers.subprocess import create_subprocess_exec
-from ...helpers.windows_job_object import WindowsJobObject
 from ...models import (
     FirmwareJob,
     JobFailureReason,
@@ -21,6 +20,7 @@ from ...models import (
     JobType,
 )
 from . import lifecycle, rename_flow
+from ._state import SpawnHandle
 from .constants import _ERROR_PATTERNS
 from .helpers import (
     _ingest_output_line,
@@ -327,7 +327,7 @@ async def tracked_subprocess(
     Required for every ``create_subprocess_exec`` call in the
     runner path — both the main install/upload spawn in
     ``_execute_job`` and pre-flight probes like
-    ``_verify_chip``. Registering in ``state.processes`` is what
+    ``_verify_chip``. Registering in ``state.spawns`` is what
     lets a concurrent ``firmware/cancel`` actually land SIGTERM
     on the running spawn; a direct ``create_subprocess_exec``
     call without this registration silently regresses the
@@ -360,44 +360,19 @@ async def tracked_subprocess(
     # traceback in the streamed job output instead.
     kwargs.setdefault("stdin", asyncio.subprocess.DEVNULL)
     proc = await create_subprocess_exec(*args, **kwargs)
-    # Windows tree-kill primitive. A child started before this
-    # assignment lands is outside the job; the terminate path's
-    # taskkill sweep covers that window.
-    job_obj = WindowsJobObject.create_for_pid(proc.pid) if sys.platform == "win32" else None
-    processes = controller.state.processes
-    job_objects = controller.state.job_objects
-    prev = processes.get(job.job_id)
-    prev_job_obj = job_objects.get(job.job_id)
-    processes[job.job_id] = proc
-    # Kept in lockstep with ``processes`` — a stale entry would pair a
-    # nested spawn's proc with the outer spawn's kill handle.
-    if job_obj is None:
-        job_objects.pop(job.job_id, None)
-    else:
-        job_objects[job.job_id] = job_obj
-    try:
-        yield proc
-    except asyncio.CancelledError:
-        # Runner-shutdown cancellation: the runner task itself
-        # was cancelled (vs. a user-driven ``firmware/cancel``,
-        # which calls ``_terminate_job_process`` from the
-        # cancel handler directly). Reuse the same group-aware
-        # termination helper here so SIGTERM walks the whole
-        # process group (esphome → platformio → gcc / esptool).
-        # ``proc.terminate()`` would only signal the python
-        # parent — on POSIX with ``start_new_session=True``
-        # that orphans the child tree and the build keeps
-        # running until the children finish on their own.
-        await controller._terminate_job_process(job)
-        raise
-    finally:
-        if prev is None:
-            processes.pop(job.job_id, None)
-        else:
-            processes[job.job_id] = prev
-        if prev_job_obj is None:
-            job_objects.pop(job.job_id, None)
-        else:
-            job_objects[job.job_id] = prev_job_obj
-        if job_obj is not None:
-            job_obj.close()
+    with controller.state.spawns.register(job.job_id, SpawnHandle.track(proc)):
+        try:
+            yield proc
+        except asyncio.CancelledError:
+            # Runner-shutdown cancellation: the runner task itself
+            # was cancelled (vs. a user-driven ``firmware/cancel``,
+            # which calls ``_terminate_job_process`` from the
+            # cancel handler directly). Reuse the same group-aware
+            # termination helper here so SIGTERM walks the whole
+            # process group (esphome → platformio → gcc / esptool).
+            # ``proc.terminate()`` would only signal the python
+            # parent — on POSIX with ``start_new_session=True``
+            # that orphans the child tree and the build keeps
+            # running until the children finish on their own.
+            await controller._terminate_job_process(job)
+            raise

--- a/esphome_device_builder/controllers/firmware/runner.py
+++ b/esphome_device_builder/controllers/firmware/runner.py
@@ -360,8 +360,9 @@ async def tracked_subprocess(
     # traceback in the streamed job output instead.
     kwargs.setdefault("stdin", asyncio.subprocess.DEVNULL)
     proc = await create_subprocess_exec(*args, **kwargs)
-    # Windows tree-kill primitive; assigned on the same event-loop
-    # tick as the spawn, before the child can start children.
+    # Windows tree-kill primitive. A child started before this
+    # assignment lands is outside the job; the terminate path's
+    # taskkill sweep covers that window.
     job_obj = WindowsJobObject.create_for_pid(proc.pid) if sys.platform == "win32" else None
     processes = controller.state.processes
     job_objects = controller.state.job_objects

--- a/esphome_device_builder/helpers/process.py
+++ b/esphome_device_builder/helpers/process.py
@@ -27,9 +27,9 @@ module:
 
 The orchestration helper ``terminate_subtree_with_grace`` ties those
 together: SIGTERM the group → wait the grace window → SIGKILL the
-group on POSIX; ``taskkill`` with a single-shot kill fallback on
-Windows. That's the shape ``FirmwareController._terminate_job_process``
-needs.
+group on POSIX; ``TerminateJobObject`` → ``taskkill`` → single-shot
+kill on Windows. That's the shape
+``FirmwareController._terminate_job_process`` needs.
 
 POSIX vs Windows asymmetry is deliberate: the POSIX path has a
 graceful SIGTERM stage because well-behaved tools (``esptool``,
@@ -46,8 +46,12 @@ import logging
 import os
 import signal
 import sys
+from typing import TYPE_CHECKING
 
 from .subprocess import create_subprocess_exec, kill_quietly
+
+if TYPE_CHECKING:
+    from .windows_job_object import WindowsJobObject
 
 __all__ = [
     "kill_quietly",
@@ -152,6 +156,7 @@ async def terminate_subtree_with_grace(
     *,
     grace_seconds: float = _TERMINATE_GRACE_SECONDS,
     job_label: str = "subprocess",
+    win_job: WindowsJobObject | None = None,
 ) -> None:
     """
     Bring down *proc* and its descendants, gracefully if possible.
@@ -162,12 +167,11 @@ async def terminate_subtree_with_grace(
     group exists to signal — without that, only the direct child
     receives the signal and the compiler grandchildren orphan.
 
-    Windows: ``taskkill /F /T`` to walk the kernel's parent-child
-    accounting and force-kill the subtree. There's no graceful
-    stage on Windows because the compile chain ignores polite
-    signals; if ``taskkill`` is missing or hangs, fall back to
-    ``proc.kill()`` so the direct child at least dies and the
-    runner loop can finalise the job.
+    Windows: ``TerminateJobObject`` on *win_job* when the spawn site
+    assigned one — the only primitive that atomically kills the whole
+    tree. Fall back to ``taskkill /F /T``, then ``proc.kill()`` so the
+    direct child at least dies. There's no graceful stage on Windows
+    because the compile chain ignores polite signals.
 
     No-op when *proc* has already exited. *job_label* is used in
     the warning log if the SIGTERM grace window expires (POSIX only).
@@ -175,6 +179,8 @@ async def terminate_subtree_with_grace(
     if proc.returncode is not None:
         return
     if sys.platform == "win32":
+        if win_job is not None and win_job.terminate():
+            return
         if not await _terminate_subtree_windows(proc.pid):
             kill_quietly(proc)
         return

--- a/esphome_device_builder/helpers/process.py
+++ b/esphome_device_builder/helpers/process.py
@@ -119,8 +119,8 @@ async def _terminate_subtree_windows(pid: int) -> bool:
 
     Returns False (and logs a warning) when ``taskkill`` is missing,
     times out, or exits non-zero (access denied, invalid pid, partial
-    failure). The caller should fall back to ``proc.kill()`` so the
-    parent at least dies even when the tree-walk fails.
+    failure); the chain then leans on the job object, with
+    ``proc.kill()`` as the last resort.
     """
     try:
         killer = await create_subprocess_exec(
@@ -143,7 +143,7 @@ async def _terminate_subtree_windows(pid: int) -> bool:
         return False
     if killer.returncode != 0:
         _LOGGER.warning(
-            "taskkill exited %s for pid %d — caller should fall back to proc.kill()",
+            "taskkill exited %s for pid %d — falling through to the job object",
             killer.returncode,
             pid,
         )

--- a/esphome_device_builder/helpers/process.py
+++ b/esphome_device_builder/helpers/process.py
@@ -27,8 +27,8 @@ module:
 
 The orchestration helper ``terminate_subtree_with_grace`` ties those
 together: SIGTERM the group → wait the grace window → SIGKILL the
-group on POSIX; ``TerminateJobObject`` → ``taskkill`` → single-shot
-kill on Windows. That's the shape
+group on POSIX; ``taskkill`` sweep → ``TerminateJobObject`` →
+single-shot kill on Windows. That's the shape
 ``FirmwareController._terminate_job_process`` needs.
 
 POSIX vs Windows asymmetry is deliberate: the POSIX path has a
@@ -167,11 +167,11 @@ async def terminate_subtree_with_grace(
     group exists to signal — without that, only the direct child
     receives the signal and the compiler grandchildren orphan.
 
-    Windows: ``TerminateJobObject`` on *win_job* when the spawn site
-    assigned one — the only primitive that atomically kills the whole
-    tree. Fall back to ``taskkill /F /T``, then ``proc.kill()`` so the
-    direct child at least dies. There's no graceful stage on Windows
-    because the compile chain ignores polite signals.
+    Windows: ``taskkill /F /T`` sweeps the PID tree first, then
+    ``TerminateJobObject`` on *win_job* atomically kills every job
+    member, then ``proc.kill()`` so the direct child at least dies.
+    There's no graceful stage on Windows because the compile chain
+    ignores polite signals.
 
     No-op when *proc* has already exited. *job_label* is used in
     the warning log if the SIGTERM grace window expires (POSIX only).
@@ -179,9 +179,13 @@ async def terminate_subtree_with_grace(
     if proc.returncode is not None:
         return
     if sys.platform == "win32":
-        if win_job is not None and win_job.terminate():
-            return
-        if not await _terminate_subtree_windows(proc.pid):
+        # Sweep before the job kill: a child spawned between
+        # CreateProcess and the job assignment is in no job, and the
+        # PID-tree walk can only reach it while the tracked parent is
+        # still alive to walk from.
+        swept = await _terminate_subtree_windows(proc.pid)
+        job_killed = win_job is not None and win_job.terminate()
+        if not swept and not job_killed:
             kill_quietly(proc)
         return
     if not _signal_process_group(proc.pid, signal.SIGTERM):

--- a/esphome_device_builder/helpers/subprocess.py
+++ b/esphome_device_builder/helpers/subprocess.py
@@ -213,6 +213,12 @@ async def iter_lines_with_progress(stream: asyncio.StreamReader) -> AsyncIterato
             yield chunk.decode("utf-8", errors="replace")
 
 
+async def consume_lines(stream: asyncio.StreamReader, on_line: Callable[[str], None]) -> None:
+    """Stream *stream* to *on_line* per chunk, split via :func:`iter_lines_with_progress`."""
+    async for chunk in iter_lines_with_progress(stream):
+        on_line(chunk)
+
+
 async def _consume_stdout(
     stdout: asyncio.StreamReader, on_line: Callable[[str], None] | None, buf: bytearray
 ) -> None:
@@ -226,8 +232,7 @@ async def _consume_stdout(
         while data := await stdout.read(_STREAM_READ_SIZE):
             buf += data
         return
-    async for chunk in iter_lines_with_progress(stdout):
-        on_line(chunk)
+    await consume_lines(stdout, on_line)
 
 
 async def _write_stdin(proc: asyncio.subprocess.Process, data: bytes) -> None:

--- a/esphome_device_builder/helpers/windows_job_object.py
+++ b/esphome_device_builder/helpers/windows_job_object.py
@@ -1,9 +1,6 @@
-"""Win32 job-object wrapper — the Windows process-tree kill primitive.
+"""Kill-on-close Win32 job objects — the Windows process-tree kill primitive.
 
-A kill-on-close job object is the Windows equivalent of the POSIX
-process group: ``TerminateJobObject`` takes down the whole spawned
-tree, and closing the handle reaps survivors. Importable on every
-platform; the pywin32 bindings exist only on Windows.
+Importable on every platform; the pywin32 bindings exist only on Windows.
 """
 
 from __future__ import annotations

--- a/esphome_device_builder/helpers/windows_job_object.py
+++ b/esphome_device_builder/helpers/windows_job_object.py
@@ -14,16 +14,14 @@ from typing import Any
 try:
     import pywintypes
     import win32api
+    import win32con
     import win32job
 except ImportError:  # non-Windows
-    pywintypes = win32api = win32job = None
+    pywintypes = win32api = win32con = win32job = None
 
 __all__ = ["WindowsJobObject"]
 
 _LOGGER = logging.getLogger(__name__)
-
-_PROCESS_SET_QUOTA = 0x0100
-_PROCESS_TERMINATE = 0x0001
 
 
 class WindowsJobObject:
@@ -35,6 +33,8 @@ class WindowsJobObject:
     @classmethod
     def create_for_pid(cls, pid: int) -> WindowsJobObject | None:
         """Create a kill-on-close job object and assign *pid*'s tree to it; None on failure."""
+        if win32job is None:
+            return None
         try:
             job = win32job.CreateJobObject(None, "")
             info = win32job.QueryInformationJobObject(
@@ -46,7 +46,9 @@ class WindowsJobObject:
             win32job.SetInformationJobObject(job, win32job.JobObjectExtendedLimitInformation, info)
             # No PID-reuse race here: the asyncio Process keeps its child
             # handle open until reaped, which pins the pid.
-            proc = win32api.OpenProcess(_PROCESS_SET_QUOTA | _PROCESS_TERMINATE, 0, pid)
+            proc = win32api.OpenProcess(
+                win32con.PROCESS_SET_QUOTA | win32con.PROCESS_TERMINATE, 0, pid
+            )
             try:
                 win32job.AssignProcessToJobObject(job, proc)
             finally:

--- a/esphome_device_builder/helpers/windows_job_object.py
+++ b/esphome_device_builder/helpers/windows_job_object.py
@@ -1,0 +1,148 @@
+"""Win32 job-object wrapper — the Windows process-tree kill primitive.
+
+A kill-on-close job object is the Windows equivalent of the POSIX
+process group: ``TerminateJobObject`` takes down the whole spawned
+tree, and closing the handle reaps survivors. Importable on every
+platform; kernel32 loads lazily.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+from functools import cache
+from typing import Any
+
+__all__ = ["WindowsJobObject"]
+
+_LOGGER = logging.getLogger(__name__)
+
+_JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
+_JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS = 9
+_PROCESS_SET_QUOTA = 0x0100
+_PROCESS_TERMINATE = 0x0001
+
+
+class _IoCounters(ctypes.Structure):
+    _fields_ = [
+        ("ReadOperationCount", ctypes.c_uint64),
+        ("WriteOperationCount", ctypes.c_uint64),
+        ("OtherOperationCount", ctypes.c_uint64),
+        ("ReadTransferCount", ctypes.c_uint64),
+        ("WriteTransferCount", ctypes.c_uint64),
+        ("OtherTransferCount", ctypes.c_uint64),
+    ]
+
+
+class _JobObjectBasicLimitInformation(ctypes.Structure):
+    _fields_ = [
+        ("PerProcessUserTimeLimit", ctypes.c_int64),
+        ("PerJobUserTimeLimit", ctypes.c_int64),
+        ("LimitFlags", ctypes.c_uint32),
+        ("MinimumWorkingSetSize", ctypes.c_size_t),
+        ("MaximumWorkingSetSize", ctypes.c_size_t),
+        ("ActiveProcessLimit", ctypes.c_uint32),
+        ("Affinity", ctypes.c_size_t),
+        ("PriorityClass", ctypes.c_uint32),
+        ("SchedulingClass", ctypes.c_uint32),
+    ]
+
+
+class _JobObjectExtendedLimitInformation(ctypes.Structure):
+    _fields_ = [
+        ("BasicLimitInformation", _JobObjectBasicLimitInformation),
+        ("IoInfo", _IoCounters),
+        ("ProcessMemoryLimit", ctypes.c_size_t),
+        ("JobMemoryLimit", ctypes.c_size_t),
+        ("PeakProcessMemoryUsed", ctypes.c_size_t),
+        ("PeakJobMemoryUsed", ctypes.c_size_t),
+    ]
+
+
+def _last_error() -> int:
+    """``ctypes.get_last_error()`` where it exists, else 0."""
+    get = getattr(ctypes, "get_last_error", None)
+    return get() if get is not None else 0
+
+
+@cache
+def _kernel32() -> Any:
+    k32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
+    # Explicit prototypes — the ctypes default return type is c_int,
+    # which truncates 64-bit HANDLE values.
+    k32.CreateJobObjectW.restype = ctypes.c_void_p
+    k32.CreateJobObjectW.argtypes = [ctypes.c_void_p, ctypes.c_wchar_p]
+    k32.SetInformationJobObject.restype = ctypes.c_int
+    k32.SetInformationJobObject.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_int,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+    ]
+    k32.OpenProcess.restype = ctypes.c_void_p
+    k32.OpenProcess.argtypes = [ctypes.c_uint32, ctypes.c_int, ctypes.c_uint32]
+    k32.AssignProcessToJobObject.restype = ctypes.c_int
+    k32.AssignProcessToJobObject.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    k32.TerminateJobObject.restype = ctypes.c_int
+    k32.TerminateJobObject.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+    k32.CloseHandle.restype = ctypes.c_int
+    k32.CloseHandle.argtypes = [ctypes.c_void_p]
+    return k32
+
+
+class WindowsJobObject:
+    """Owns a kill-on-close Win32 job-object handle wrapping one spawned process tree."""
+
+    def __init__(self, handle: int) -> None:
+        self._handle: int | None = handle
+
+    @classmethod
+    def create_for_pid(cls, pid: int) -> WindowsJobObject | None:
+        """Create a kill-on-close job object and assign *pid*'s tree to it; None on failure."""
+        k32 = _kernel32()
+        job = k32.CreateJobObjectW(None, None)
+        if not job:
+            _LOGGER.warning("CreateJobObjectW failed (error %d)", _last_error())
+            return None
+        info = _JobObjectExtendedLimitInformation()
+        info.BasicLimitInformation.LimitFlags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        if not k32.SetInformationJobObject(
+            job,
+            _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS,
+            ctypes.byref(info),
+            ctypes.sizeof(info),
+        ):
+            _LOGGER.warning("SetInformationJobObject failed (error %d)", _last_error())
+            k32.CloseHandle(job)
+            return None
+        # No PID-reuse race here: the asyncio Process keeps its child
+        # handle open until reaped, which pins the pid.
+        proc = k32.OpenProcess(_PROCESS_SET_QUOTA | _PROCESS_TERMINATE, 0, pid)
+        if not proc:
+            _LOGGER.warning("OpenProcess failed for pid %d (error %d)", pid, _last_error())
+            k32.CloseHandle(job)
+            return None
+        assigned = k32.AssignProcessToJobObject(job, proc)
+        error = _last_error()
+        k32.CloseHandle(proc)
+        if not assigned:
+            _LOGGER.warning("AssignProcessToJobObject failed for pid %d (error %d)", pid, error)
+            k32.CloseHandle(job)
+            return None
+        return cls(job)
+
+    def terminate(self) -> bool:
+        """Force-kill every process in the job; True iff the kernel accepted the kill."""
+        if self._handle is None:
+            return False
+        if not _kernel32().TerminateJobObject(self._handle, 1):
+            _LOGGER.warning("TerminateJobObject failed (error %d)", _last_error())
+            return False
+        return True
+
+    def close(self) -> None:
+        """Release the handle (kill-on-close reaps any survivors); idempotent."""
+        if self._handle is None:
+            return
+        _kernel32().CloseHandle(self._handle)
+        self._handle = None

--- a/esphome_device_builder/helpers/windows_job_object.py
+++ b/esphome_device_builder/helpers/windows_job_object.py
@@ -9,6 +9,8 @@ platform; the pywin32 bindings exist only on Windows.
 from __future__ import annotations
 
 import logging
+import sys
+from contextlib import suppress
 from typing import Any
 
 try:
@@ -34,7 +36,10 @@ class WindowsJobObject:
     def create_for_pid(cls, pid: int) -> WindowsJobObject | None:
         """Create a kill-on-close job object and assign *pid*'s tree to it; None on failure."""
         if win32job is None:
+            if sys.platform == "win32":
+                _LOGGER.warning("pywin32 is unavailable; cancel falls back to the taskkill sweep")
             return None
+        job = None
         try:
             job = win32job.CreateJobObject(None, "")
             info = win32job.QueryInformationJobObject(
@@ -55,6 +60,9 @@ class WindowsJobObject:
                 proc.Close()
         except pywintypes.error as err:
             _LOGGER.warning("Job-object setup failed for pid %d: %s", pid, err)
+            if job is not None:
+                with suppress(pywintypes.error):
+                    job.Close()
             return None
         return cls(job)
 

--- a/esphome_device_builder/helpers/windows_job_object.py
+++ b/esphome_device_builder/helpers/windows_job_object.py
@@ -3,131 +3,56 @@
 A kill-on-close job object is the Windows equivalent of the POSIX
 process group: ``TerminateJobObject`` takes down the whole spawned
 tree, and closing the handle reaps survivors. Importable on every
-platform; kernel32 loads lazily.
+platform; the pywin32 bindings exist only on Windows.
 """
 
 from __future__ import annotations
 
-import ctypes
 import logging
-from functools import cache
 from typing import Any
+
+try:
+    import pywintypes
+    import win32api
+    import win32job
+except ImportError:  # non-Windows
+    pywintypes = win32api = win32job = None
 
 __all__ = ["WindowsJobObject"]
 
 _LOGGER = logging.getLogger(__name__)
 
-_JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
-_JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS = 9
 _PROCESS_SET_QUOTA = 0x0100
 _PROCESS_TERMINATE = 0x0001
-
-
-class _IoCounters(ctypes.Structure):
-    _fields_ = [
-        ("ReadOperationCount", ctypes.c_uint64),
-        ("WriteOperationCount", ctypes.c_uint64),
-        ("OtherOperationCount", ctypes.c_uint64),
-        ("ReadTransferCount", ctypes.c_uint64),
-        ("WriteTransferCount", ctypes.c_uint64),
-        ("OtherTransferCount", ctypes.c_uint64),
-    ]
-
-
-class _JobObjectBasicLimitInformation(ctypes.Structure):
-    _fields_ = [
-        ("PerProcessUserTimeLimit", ctypes.c_int64),
-        ("PerJobUserTimeLimit", ctypes.c_int64),
-        ("LimitFlags", ctypes.c_uint32),
-        ("MinimumWorkingSetSize", ctypes.c_size_t),
-        ("MaximumWorkingSetSize", ctypes.c_size_t),
-        ("ActiveProcessLimit", ctypes.c_uint32),
-        ("Affinity", ctypes.c_size_t),
-        ("PriorityClass", ctypes.c_uint32),
-        ("SchedulingClass", ctypes.c_uint32),
-    ]
-
-
-class _JobObjectExtendedLimitInformation(ctypes.Structure):
-    _fields_ = [
-        ("BasicLimitInformation", _JobObjectBasicLimitInformation),
-        ("IoInfo", _IoCounters),
-        ("ProcessMemoryLimit", ctypes.c_size_t),
-        ("JobMemoryLimit", ctypes.c_size_t),
-        ("PeakProcessMemoryUsed", ctypes.c_size_t),
-        ("PeakJobMemoryUsed", ctypes.c_size_t),
-    ]
-
-
-def _last_error() -> int:
-    """``ctypes.get_last_error()`` where it exists, else 0."""
-    get = getattr(ctypes, "get_last_error", None)
-    return get() if get is not None else 0
-
-
-@cache
-def _kernel32() -> Any:
-    k32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
-    # Explicit prototypes — the ctypes default return type is c_int,
-    # which truncates 64-bit HANDLE values.
-    k32.CreateJobObjectW.restype = ctypes.c_void_p
-    k32.CreateJobObjectW.argtypes = [ctypes.c_void_p, ctypes.c_wchar_p]
-    k32.SetInformationJobObject.restype = ctypes.c_int
-    k32.SetInformationJobObject.argtypes = [
-        ctypes.c_void_p,
-        ctypes.c_int,
-        ctypes.c_void_p,
-        ctypes.c_uint32,
-    ]
-    k32.OpenProcess.restype = ctypes.c_void_p
-    k32.OpenProcess.argtypes = [ctypes.c_uint32, ctypes.c_int, ctypes.c_uint32]
-    k32.AssignProcessToJobObject.restype = ctypes.c_int
-    k32.AssignProcessToJobObject.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
-    k32.TerminateJobObject.restype = ctypes.c_int
-    k32.TerminateJobObject.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
-    k32.CloseHandle.restype = ctypes.c_int
-    k32.CloseHandle.argtypes = [ctypes.c_void_p]
-    return k32
 
 
 class WindowsJobObject:
     """Owns a kill-on-close Win32 job-object handle wrapping one spawned process tree."""
 
-    def __init__(self, handle: int) -> None:
-        self._handle: int | None = handle
+    def __init__(self, handle: Any) -> None:
+        self._handle: Any | None = handle
 
     @classmethod
     def create_for_pid(cls, pid: int) -> WindowsJobObject | None:
         """Create a kill-on-close job object and assign *pid*'s tree to it; None on failure."""
-        k32 = _kernel32()
-        job = k32.CreateJobObjectW(None, None)
-        if not job:
-            _LOGGER.warning("CreateJobObjectW failed (error %d)", _last_error())
-            return None
-        info = _JobObjectExtendedLimitInformation()
-        info.BasicLimitInformation.LimitFlags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
-        if not k32.SetInformationJobObject(
-            job,
-            _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS,
-            ctypes.byref(info),
-            ctypes.sizeof(info),
-        ):
-            _LOGGER.warning("SetInformationJobObject failed (error %d)", _last_error())
-            k32.CloseHandle(job)
-            return None
-        # No PID-reuse race here: the asyncio Process keeps its child
-        # handle open until reaped, which pins the pid.
-        proc = k32.OpenProcess(_PROCESS_SET_QUOTA | _PROCESS_TERMINATE, 0, pid)
-        if not proc:
-            _LOGGER.warning("OpenProcess failed for pid %d (error %d)", pid, _last_error())
-            k32.CloseHandle(job)
-            return None
-        assigned = k32.AssignProcessToJobObject(job, proc)
-        error = _last_error()
-        k32.CloseHandle(proc)
-        if not assigned:
-            _LOGGER.warning("AssignProcessToJobObject failed for pid %d (error %d)", pid, error)
-            k32.CloseHandle(job)
+        try:
+            job = win32job.CreateJobObject(None, "")
+            info = win32job.QueryInformationJobObject(
+                job, win32job.JobObjectExtendedLimitInformation
+            )
+            info["BasicLimitInformation"]["LimitFlags"] |= (
+                win32job.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+            )
+            win32job.SetInformationJobObject(job, win32job.JobObjectExtendedLimitInformation, info)
+            # No PID-reuse race here: the asyncio Process keeps its child
+            # handle open until reaped, which pins the pid.
+            proc = win32api.OpenProcess(_PROCESS_SET_QUOTA | _PROCESS_TERMINATE, 0, pid)
+            try:
+                win32job.AssignProcessToJobObject(job, proc)
+            finally:
+                proc.Close()
+        except pywintypes.error as err:
+            _LOGGER.warning("Job-object setup failed for pid %d: %s", pid, err)
             return None
         return cls(job)
 
@@ -135,8 +60,10 @@ class WindowsJobObject:
         """Force-kill every process in the job; True iff the kernel accepted the kill."""
         if self._handle is None:
             return False
-        if not _kernel32().TerminateJobObject(self._handle, 1):
-            _LOGGER.warning("TerminateJobObject failed (error %d)", _last_error())
+        try:
+            win32job.TerminateJobObject(self._handle, 1)
+        except pywintypes.error as err:
+            _LOGGER.warning("TerminateJobObject failed: %s", err)
             return False
         return True
 
@@ -144,5 +71,5 @@ class WindowsJobObject:
         """Release the handle (kill-on-close reaps any survivors); idempotent."""
         if self._handle is None:
             return
-        _kernel32().CloseHandle(self._handle)
-        self._handle = None
+        handle, self._handle = self._handle, None
+        handle.Close()

--- a/esphome_device_builder/helpers/windows_job_object.py
+++ b/esphome_device_builder/helpers/windows_job_object.py
@@ -74,4 +74,7 @@ class WindowsJobObject:
         if self._handle is None:
             return
         handle, self._handle = self._handle, None
-        handle.Close()
+        try:
+            handle.Close()
+        except pywintypes.error as err:
+            _LOGGER.warning("Closing job object failed (tree may leak): %s", err)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,9 @@ dependencies = [
   "mashumaro>=3.13",
   "orjson>=3.9.0",
   # Win32 job objects — the cancel path's process-tree kill primitive
-  # (``helpers/windows_job_object.py``); maintained bindings instead
-  # of hand-rolled ctypes structs.
-  "pywin32>=308; sys_platform == 'win32'",
+  # (``helpers/windows_job_object.py``). 311 is the first release with
+  # cp314 wheels, the Python the Windows CI leg runs.
+  "pywin32>=311; sys_platform == 'win32'",
   "pyyaml>=6.0",
   # ESPHome already ships ruamel.yaml as a transitive dependency,
   # but the automations editor's parse / upsert path imports it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,10 @@ dependencies = [
   "icmplib>=3.0.4",
   "mashumaro>=3.13",
   "orjson>=3.9.0",
+  # Win32 job objects — the cancel path's process-tree kill primitive
+  # (``helpers/windows_job_object.py``); maintained bindings instead
+  # of hand-rolled ctypes structs.
+  "pywin32>=308; sys_platform == 'win32'",
   "pyyaml>=6.0",
   # ESPHome already ships ruamel.yaml as a transitive dependency,
   # but the automations editor's parse / upsert path imports it

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -23,7 +23,13 @@ silently absorbing into a stub.
 from __future__ import annotations
 
 import asyncio
+import ctypes
+import os
+import signal
+import sys
+import time
 from collections.abc import Callable, Iterator
+from contextlib import suppress
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
@@ -39,6 +45,7 @@ from esphome_device_builder.controllers.firmware.download import DownloadTokens
 from esphome_device_builder.helpers.build_scheduler import BuildSchedulerInputs
 from esphome_device_builder.helpers.event_bus import Event, EventBus
 from esphome_device_builder.helpers.version_compat import VersionMatchPolicy
+from esphome_device_builder.helpers.windows_job_object import _kernel32
 from esphome_device_builder.models import (
     TERMINAL_JOB_STATUSES,
     DeviceState,
@@ -449,6 +456,51 @@ def seed_yamls(tmp_path: Path, *names: str) -> None:
     for name in names:
         stem = name.removesuffix(".yaml")
         (tmp_path / name).write_text(f"esphome:\n  name: {stem}\n", encoding="utf-8")
+
+
+def pid_alive(pid: int) -> bool:
+    """Whether *pid* is a live process, on either platform."""
+    if sys.platform == "win32":
+        # ``os.kill(pid, 0)`` on Windows is a TerminateProcess, not a
+        # probe — query the exit code through a limited-rights handle.
+        k32 = _kernel32()
+        k32.GetExitCodeProcess.restype = ctypes.c_int
+        k32.GetExitCodeProcess.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        handle = k32.OpenProcess(0x1000, 0, pid)  # PROCESS_QUERY_LIMITED_INFORMATION
+        if not handle:
+            return False
+        try:
+            code = ctypes.c_ulong()
+            if not k32.GetExitCodeProcess(handle, ctypes.byref(code)):
+                return False
+            return code.value == 259  # STILL_ACTIVE
+        finally:
+            k32.CloseHandle(handle)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but we can't signal it (macOS EPERM).
+        return True
+    return True
+
+
+async def wait_dead(pid: int, timeout: float = 5.0) -> bool:
+    """Poll until *pid* exits or *timeout* elapses; True iff it died."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not pid_alive(pid):
+            return True
+        await asyncio.sleep(0.05)
+    return not pid_alive(pid)
+
+
+def kill_pid(pid: int) -> None:
+    """Best-effort unconditional kill for test cleanup, on either platform."""
+    sig = signal.SIGTERM if sys.platform == "win32" else signal.SIGKILL
+    with suppress(OSError):
+        os.kill(pid, sig)
 
 
 def attach_device(controller: FirmwareController, configuration: str, state: DeviceState) -> None:

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -26,13 +26,13 @@ import asyncio
 import os
 import signal
 import sys
-import time
 from collections.abc import Callable, Iterator
 from contextlib import suppress
 
 if sys.platform == "win32":
     import pywintypes
     import win32api
+    import win32con
     import win32process
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -61,7 +61,7 @@ from esphome_device_builder.models import (
     StoredPairing,
 )
 
-from ...conftest import running_task
+from ...conftest import running_task, wait_until
 
 
 class EnqueueStep(StrEnum):
@@ -467,11 +467,11 @@ def pid_alive(pid: int) -> bool:
         # ``os.kill(pid, 0)`` on Windows is a TerminateProcess, not a
         # probe — query the exit code through a limited-rights handle.
         try:
-            handle = win32api.OpenProcess(0x1000, 0, pid)  # PROCESS_QUERY_LIMITED_INFORMATION
+            handle = win32api.OpenProcess(win32con.PROCESS_QUERY_LIMITED_INFORMATION, 0, pid)
         except pywintypes.error:
             return False
         try:
-            return win32process.GetExitCodeProcess(handle) == 259  # STILL_ACTIVE
+            return win32process.GetExitCodeProcess(handle) == win32con.STILL_ACTIVE
         finally:
             handle.Close()
     try:
@@ -484,14 +484,9 @@ def pid_alive(pid: int) -> bool:
     return True
 
 
-async def wait_dead(pid: int, timeout: float = 5.0) -> bool:
-    """Poll until *pid* exits or *timeout* elapses; True iff it died."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if not pid_alive(pid):
-            return True
-        await asyncio.sleep(0.05)
-    return not pid_alive(pid)
+async def wait_dead(pid: int, timeout: float = 5.0) -> None:
+    """Poll until *pid* exits; pytest-fail naming it on timeout."""
+    await wait_until(lambda: not pid_alive(pid), timeout, f"pid {pid} to exit", interval=0.05)
 
 
 def kill_pid(pid: int) -> None:

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -23,13 +23,17 @@ silently absorbing into a stub.
 from __future__ import annotations
 
 import asyncio
-import ctypes
 import os
 import signal
 import sys
 import time
 from collections.abc import Callable, Iterator
 from contextlib import suppress
+
+if sys.platform == "win32":
+    import pywintypes
+    import win32api
+    import win32process
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
@@ -45,7 +49,6 @@ from esphome_device_builder.controllers.firmware.download import DownloadTokens
 from esphome_device_builder.helpers.build_scheduler import BuildSchedulerInputs
 from esphome_device_builder.helpers.event_bus import Event, EventBus
 from esphome_device_builder.helpers.version_compat import VersionMatchPolicy
-from esphome_device_builder.helpers.windows_job_object import _kernel32
 from esphome_device_builder.models import (
     TERMINAL_JOB_STATUSES,
     DeviceState,
@@ -463,19 +466,14 @@ def pid_alive(pid: int) -> bool:
     if sys.platform == "win32":
         # ``os.kill(pid, 0)`` on Windows is a TerminateProcess, not a
         # probe — query the exit code through a limited-rights handle.
-        k32 = _kernel32()
-        k32.GetExitCodeProcess.restype = ctypes.c_int
-        k32.GetExitCodeProcess.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
-        handle = k32.OpenProcess(0x1000, 0, pid)  # PROCESS_QUERY_LIMITED_INFORMATION
-        if not handle:
+        try:
+            handle = win32api.OpenProcess(0x1000, 0, pid)  # PROCESS_QUERY_LIMITED_INFORMATION
+        except pywintypes.error:
             return False
         try:
-            code = ctypes.c_ulong()
-            if not k32.GetExitCodeProcess(handle, ctypes.byref(code)):
-                return False
-            return code.value == 259  # STILL_ACTIVE
+            return win32process.GetExitCodeProcess(handle) == 259  # STILL_ACTIVE
         finally:
-            k32.CloseHandle(handle)
+            handle.Close()
     try:
         os.kill(pid, 0)
     except ProcessLookupError:

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -28,12 +28,6 @@ import signal
 import sys
 from collections.abc import Callable, Iterator
 from contextlib import suppress
-
-if sys.platform == "win32":
-    import pywintypes
-    import win32api
-    import win32con
-    import win32process
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
@@ -62,6 +56,12 @@ from esphome_device_builder.models import (
 )
 
 from ...conftest import running_task, wait_until
+
+if sys.platform == "win32":
+    import pywintypes
+    import win32api
+    import win32con
+    import win32process
 
 
 class EnqueueStep(StrEnum):

--- a/tests/controllers/firmware/test_branches_coverage.py
+++ b/tests/controllers/firmware/test_branches_coverage.py
@@ -257,7 +257,7 @@ async def test_terminate_job_process_no_op_when_no_process(
 
     The cancel handler always calls ``_terminate_job_process``
     after flipping the status — but the QUEUED-cancel path runs
-    before the runner has spawned anything, so ``state.processes``
+    before the runner has spawned anything, so ``state.spawns``
     has no entry for the job. Pin the early return
     so a regression that fell through to ``terminate_subtree_*``
     against ``None`` would surface as a hard error here.

--- a/tests/controllers/firmware/test_cancel.py
+++ b/tests/controllers/firmware/test_cancel.py
@@ -149,7 +149,7 @@ async def test_cancel_queued_does_not_touch_terminate_job_process(
     """The QUEUED branch never reaches the subprocess terminator.
 
     Belt-and-braces: ``_terminate_job_process`` looks up the job in
-    ``state.processes`` and signals it. For a queued job
+    ``state.spawns`` and signals it. For a queued job
     there is no subprocess (no registry entry),
     so calling it here is at best a no-op; at worst a future
     refactor of the terminator that doesn't gracefully handle the

--- a/tests/controllers/firmware/test_cancel_pipe_drain.py
+++ b/tests/controllers/firmware/test_cancel_pipe_drain.py
@@ -14,9 +14,14 @@ import sys
 from contextlib import suppress
 from unittest.mock import MagicMock
 
+import pytest
+
+from esphome_device_builder.controllers.firmware import helpers as helpers_module
 from esphome_device_builder.controllers.firmware.helpers import _pump_output_until_exit
 from esphome_device_builder.helpers.subprocess import create_subprocess_exec
 from tests.controllers.firmware.conftest import kill_pid
+
+from ...conftest import wait_until
 
 _GRANDCHILD_HOLDING_PIPE_SCRIPT = (
     "import subprocess, sys; "
@@ -78,8 +83,68 @@ async def test_uncancelled_job_reads_to_eof() -> None:
     assert [line.strip() for line in lines if line.strip()] == ["one", "two", "three"]
 
 
-async def test_outer_cancellation_propagates_through_drain() -> None:
+async def test_uncancelled_job_with_held_pipe_warns_and_waits_for_eof(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Reaped process + held pipe + no cancel → one warning, EOF still decides."""
+    monkeypatch.setattr(helpers_module, "_EXIT_POLL_SECONDS", 0.05)
+    lines: list[str] = []
+    proc = await create_subprocess_exec(
+        sys.executable,
+        "-c",
+        _GRANDCHILD_HOLDING_PIPE_SCRIPT,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    task = asyncio.get_running_loop().create_task(
+        _pump_output_until_exit("normal-2", proc, lines.append, set())
+    )
+    logger_name = "esphome_device_builder.controllers.firmware.helpers"
+    try:
+        with caplog.at_level("WARNING", logger=logger_name):
+            await wait_until(
+                lambda: "holds the output pipe" in caplog.text,
+                10.0,
+                "wedged-pipe warning",
+                interval=0.05,
+            )
+        assert not task.done()
+    finally:
+        for line in lines:
+            if line.startswith("GRANDCHILD_PID="):
+                kill_pid(int(line.split("=", 1)[1]))
+        exit_code = await asyncio.wait_for(task, timeout=10.0)
+    assert exit_code == 0
+    assert sum("holds the output pipe" in rec.getMessage() for rec in caplog.records) == 1
+
+
+async def test_poll_continues_until_process_reaped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pump keeps polling while the process runs; the reap unblocks the cancel exit."""
+    monkeypatch.setattr(helpers_module, "_EXIT_POLL_SECONDS", 0)
+    monkeypatch.setattr(helpers_module, "_CANCELLED_PIPE_DRAIN_SECONDS", 0)
+    never_eof = asyncio.StreamReader()
+    proc = MagicMock(stdout=never_eof, returncode=None)
+    task = asyncio.get_running_loop().create_task(
+        _pump_output_until_exit("cancel-3", proc, lambda _line: None, {"cancel-3"})
+    )
+    await asyncio.sleep(0.02)
+    assert not task.done()
+
+    proc.returncode = 3
+    assert await asyncio.wait_for(task, timeout=5.0) == 3
+
+
+async def test_outer_cancellation_propagates_through_drain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Cancelling the pumping task mid-drain isn't swallowed by the reader teardown."""
+    # Zero the poll so the pump falls through to the drain wait on its
+    # first iteration; stretch the drain so the cancel lands inside it.
+    monkeypatch.setattr(helpers_module, "_EXIT_POLL_SECONDS", 0)
+    monkeypatch.setattr(helpers_module, "_CANCELLED_PIPE_DRAIN_SECONDS", 30.0)
     never_eof = asyncio.StreamReader()
     proc = MagicMock(stdout=never_eof, returncode=0)
     task = asyncio.get_running_loop().create_task(

--- a/tests/controllers/firmware/test_cancel_pipe_drain.py
+++ b/tests/controllers/firmware/test_cancel_pipe_drain.py
@@ -1,11 +1,4 @@
-"""``_pump_output_until_exit``: a cancelled job's exit isn't gated on pipe EOF.
-
-The compile chain runs with ``close_fds=False`` end to end, so any
-descendant that survives a cancel kill holds the inherited stdout write
-handle and the pipe never EOFs. These tests run on every OS in the
-matrix — the surviving-grandchild shape reproduces on POSIX too by
-skipping the kill entirely.
-"""
+"""``_pump_output_until_exit`` exit and drain semantics when a descendant holds the pipe."""
 
 from __future__ import annotations
 

--- a/tests/controllers/firmware/test_cancel_pipe_drain.py
+++ b/tests/controllers/firmware/test_cancel_pipe_drain.py
@@ -1,0 +1,93 @@
+"""``_pump_output_until_exit``: a cancelled job's exit isn't gated on pipe EOF.
+
+The compile chain runs with ``close_fds=False`` end to end, so any
+descendant that survives a cancel kill holds the inherited stdout write
+handle and the pipe never EOFs. These tests run on every OS in the
+matrix — the surviving-grandchild shape reproduces on POSIX too by
+skipping the kill entirely.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from contextlib import suppress
+from unittest.mock import MagicMock
+
+from esphome_device_builder.controllers.firmware.helpers import _pump_output_until_exit
+from esphome_device_builder.helpers.subprocess import create_subprocess_exec
+from tests.controllers.firmware.conftest import kill_pid
+
+_GRANDCHILD_HOLDING_PIPE_SCRIPT = (
+    "import subprocess, sys; "
+    "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'], "
+    "close_fds=False); "
+    "print(f'GRANDCHILD_PID={child.pid}', flush=True); "
+    "print('LINE_BEFORE_EXIT', flush=True)"
+)
+
+
+async def test_cancelled_job_finalizes_despite_pipe_held_open() -> None:
+    """Cancel + dead parent + grandchild holding stdout → pump returns after the drain window."""
+    lines: list[str] = []
+    proc = await create_subprocess_exec(
+        sys.executable,
+        "-c",
+        _GRANDCHILD_HOLDING_PIPE_SCRIPT,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    try:
+        exit_code = await asyncio.wait_for(
+            _pump_output_until_exit("cancel-1", proc, lines.append, {"cancel-1"}),
+            timeout=15.0,
+        )
+    finally:
+        for line in lines:
+            if line.startswith("GRANDCHILD_PID="):
+                kill_pid(int(line.split("=", 1)[1]))
+        # The grandchild's death EOFs the pipe; drain it and give the
+        # disconnect callbacks a few ticks so the transport closes
+        # inside this loop rather than warning at GC time.
+        assert proc.stdout is not None
+        with suppress(TimeoutError):
+            await asyncio.wait_for(proc.stdout.read(), timeout=5.0)
+        await proc.wait()
+        for _ in range(3):
+            await asyncio.sleep(0)
+    assert exit_code == 0
+    # Output written before the parent exited still made it through.
+    assert any("LINE_BEFORE_EXIT" in line for line in lines)
+
+
+async def test_uncancelled_job_reads_to_eof() -> None:
+    """No cancel → the pump drains the full output to EOF, exactly like the inline loop."""
+    lines: list[str] = []
+    proc = await create_subprocess_exec(
+        sys.executable,
+        "-c",
+        "print('one'); print('two'); print('three')",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    exit_code = await asyncio.wait_for(
+        _pump_output_until_exit("normal-1", proc, lines.append, set()),
+        timeout=15.0,
+    )
+    assert exit_code == 0
+    assert [line.strip() for line in lines if line.strip()] == ["one", "two", "three"]
+
+
+async def test_outer_cancellation_propagates_through_drain() -> None:
+    """Cancelling the pumping task mid-drain isn't swallowed by the reader teardown."""
+    never_eof = asyncio.StreamReader()
+    proc = MagicMock(stdout=never_eof, returncode=0)
+    task = asyncio.get_running_loop().create_task(
+        _pump_output_until_exit("cancel-2", proc, lambda _line: None, {"cancel-2"})
+    )
+    # Let the pump reach the drain wait (proc exits instantly; the
+    # reader never EOFs), then cancel the pumping task itself.
+    await asyncio.sleep(0.05)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+    assert task.cancelled()

--- a/tests/controllers/firmware/test_cancel_pipe_drain.py
+++ b/tests/controllers/firmware/test_cancel_pipe_drain.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from contextlib import suppress
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -44,13 +43,12 @@ async def test_cancelled_job_finalizes_despite_pipe_held_open() -> None:
         for line in lines:
             if line.startswith("GRANDCHILD_PID="):
                 kill_pid(int(line.split("=", 1)[1]))
-        # The grandchild's death EOFs the pipe; drain it and give the
-        # disconnect callbacks a few ticks so the transport closes
-        # inside this loop rather than warning at GC time.
-        assert proc.stdout is not None
-        with suppress(TimeoutError):
-            await asyncio.wait_for(proc.stdout.read(), timeout=5.0)
-        await proc.wait()
+        # The grandchild's death EOFs the pipe; the pump's reaper task
+        # drains it and closes the transport — await it so the close
+        # lands inside this loop rather than warning at GC time.
+        reapers = [t for t in asyncio.all_tasks() if "spawn reaper" in t.get_name()]
+        assert reapers, "the cancel path should have scheduled a spawn reaper"
+        await asyncio.wait_for(asyncio.gather(*reapers), timeout=5.0)
         for _ in range(3):
             await asyncio.sleep(0)
     assert exit_code == 0
@@ -128,6 +126,13 @@ async def test_poll_continues_until_process_reaped(
 
     proc.returncode = 3
     assert await asyncio.wait_for(task, timeout=5.0) == 3
+
+    # Let the scheduled reaper task drain leftovers, see EOF, and
+    # finish before teardown.
+    never_eof.feed_data(b"leftover output the reaper must discard\n")
+    never_eof.feed_eof()
+    reapers = [t for t in asyncio.all_tasks() if "spawn reaper" in t.get_name()]
+    await asyncio.wait_for(asyncio.gather(*reapers), timeout=5.0)
 
 
 async def test_outer_cancellation_propagates_through_drain(

--- a/tests/controllers/firmware/test_cancel_pipe_drain.py
+++ b/tests/controllers/firmware/test_cancel_pipe_drain.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import sys
 from contextlib import suppress
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -119,7 +119,7 @@ async def test_poll_continues_until_process_reaped(
     monkeypatch.setattr(helpers_module, "_EXIT_POLL_SECONDS", 0)
     monkeypatch.setattr(helpers_module, "_CANCELLED_PIPE_DRAIN_SECONDS", 0)
     never_eof = asyncio.StreamReader()
-    proc = MagicMock(stdout=never_eof, returncode=None)
+    proc = MagicMock(stdout=never_eof, returncode=None, wait=AsyncMock(return_value=3))
     task = asyncio.get_running_loop().create_task(
         _pump_output_until_exit("cancel-3", proc, lambda _line: None, {"cancel-3"})
     )

--- a/tests/controllers/firmware/test_execute_job_e2e.py
+++ b/tests/controllers/firmware/test_execute_job_e2e.py
@@ -315,7 +315,7 @@ async def test_compile_mid_run_cancel_marks_cancelled(
     - JOB_STARTED fires *before* the subprocess spawn (the runner
       flips the status before it ``await``s ``create_subprocess_exec``).
       Synchronising on it would race the spawn and we'd terminate
-      a process that hasn't been registered in ``state.processes``
+      a process that hasn't been registered in ``state.spawns``
       yet. So we wait for the first JOB_OUTPUT instead — that's
       the earliest signal the subprocess is alive AND the
       registry entry has been written.
@@ -348,7 +348,7 @@ async def test_compile_mid_run_cancel_marks_cancelled(
         captured.append({"type": event_type, "data": data})
         # First JOB_OUTPUT line means the subprocess is up,
         # streaming through ``iter_lines_with_progress``, and
-        # ``state.processes[job_id]`` has been registered.
+        # ``state.spawns[job_id]`` has been registered.
         if event_type == EventType.JOB_OUTPUT:
             proc_alive.set()
         elif event_type == EventType.JOB_CANCELLED:
@@ -364,8 +364,8 @@ async def test_compile_mid_run_cancel_marks_cancelled(
         # up the cancel flag when it loops back to read the next
         # line and sees EOF.
         controller.state.cancel_requested.add(job.job_id)
-        assert job.job_id in controller.state.processes
-        controller.state.processes[job.job_id].terminate()
+        assert job.job_id in controller.state.spawns
+        controller.state.spawns[job.job_id].proc.terminate()
 
         # Wait for the cancel event from the runner's natural
         # post-``proc.wait()`` path, NOT from the context exit's
@@ -400,7 +400,7 @@ async def test_execute_job_runner_shutdown_terminates_and_marks_cancelled(
     surrounding runner loop unwinds.
 
     Sequencing: wait for the first JOB_OUTPUT (proves the subprocess
-    is up *and* registered in ``state.processes``) before
+    is up *and* registered in ``state.spawns``) before
     cancelling, otherwise we'd race the subprocess spawn and either
     leak the process or hit the cancel before the try-block had
     entered.
@@ -439,8 +439,8 @@ async def test_execute_job_runner_shutdown_terminates_and_marks_cancelled(
 
     async with running_task(controller._run_queue()) as runner_task:
         await asyncio.wait_for(proc_alive.wait(), timeout=10.0)
-        assert job.job_id in controller.state.processes
-        proc = controller.state.processes[job.job_id]
+        assert job.job_id in controller.state.spawns
+        proc = controller.state.spawns[job.job_id].proc
 
         # Cancel the runner task itself — this is the shutdown shape,
         # not the user-cancel one. Nothing is added to

--- a/tests/controllers/firmware/test_execute_job_e2e.py
+++ b/tests/controllers/firmware/test_execute_job_e2e.py
@@ -51,6 +51,10 @@ from esphome_device_builder.controllers.firmware.constants import (
 from esphome_device_builder.controllers.remote_build.env_provisioner import EnvProvisionError
 from esphome_device_builder.models import EventType, JobFailureReason, JobStatus
 from tests.controllers.firmware.conftest import (
+    kill_pid,
+    wait_dead,
+)
+from tests.controllers.firmware.conftest import (
     run_until_terminal as _run_until_terminal,
 )
 from tests.controllers.firmware.conftest import (
@@ -545,6 +549,63 @@ async def test_execute_job_runner_shutdown_kills_subprocess_group(
         with suppress(ProcessLookupError):
             os.kill(cpid, 9)
         pytest.fail(f"child {cpid} survived runner-shutdown cancel — group SIGTERM didn't reach it")
+
+
+async def test_user_cancel_kills_process_tree_and_finalizes_promptly(
+    firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
+) -> None:
+    """``firmware/cancel`` kills the spawn's pipe-holding child too and finalizes in seconds.
+
+    Runs on every OS in the matrix — the Windows leg is the #2552
+    regression coverage.
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    _wire_real_queue(controller)
+    _fake_esphome(
+        controller,
+        "import subprocess, sys, time\n"
+        "child = subprocess.Popen("
+        "[sys.executable, '-c', 'import time; time.sleep(120)'], close_fds=False)\n"
+        "print(f'CHILD_PID={child.pid}', flush=True)\n"
+        "time.sleep(120)\n",
+    )
+    _seed_yaml(tmp_path)
+
+    job = await controller.compile(configuration="kitchen.yaml")
+
+    child_seen = asyncio.Event()
+    cancelled_fired = asyncio.Event()
+    child_pid: list[int] = []
+    real_fire = controller._db.bus.fire
+
+    def _watch(event_type: EventType, data: dict) -> None:
+        if event_type == EventType.JOB_OUTPUT and "CHILD_PID=" in data.get("line", ""):
+            child_pid.append(int(data["line"].split("=", 1)[1].strip()))
+            child_seen.set()
+        if event_type == EventType.JOB_CANCELLED:
+            cancelled_fired.set()
+        real_fire(event_type, data)
+
+    controller._db.bus.fire = _watch
+
+    try:
+        async with running_task(controller._run_queue()):
+            await asyncio.wait_for(child_seen.wait(), timeout=30.0)
+            assert child_pid, "test bug: never read CHILD_PID line"
+
+            await controller.cancel(job_id=job.job_id)
+
+            # Generous CI slack, yet far below the script's 120s runtime.
+            await asyncio.wait_for(cancelled_fired.wait(), timeout=30.0)
+            assert job.status == JobStatus.CANCELLED
+
+            # The whole tree died, not just the tracked parent.
+            assert await wait_dead(child_pid[0], timeout=10.0), (
+                f"child {child_pid[0]} survived firmware/cancel"
+            )
+    finally:
+        for pid in child_pid:
+            kill_pid(pid)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/controllers/firmware/test_execute_job_e2e.py
+++ b/tests/controllers/firmware/test_execute_job_e2e.py
@@ -554,11 +554,7 @@ async def test_execute_job_runner_shutdown_kills_subprocess_group(
 async def test_user_cancel_kills_process_tree_and_finalizes_promptly(
     firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
 ) -> None:
-    """``firmware/cancel`` kills the spawn's pipe-holding child too and finalizes in seconds.
-
-    Runs on every OS in the matrix — the Windows leg is the #2552
-    regression coverage.
-    """
+    """``firmware/cancel`` kills the spawn's pipe-holding child too and finalizes in seconds."""
     controller = firmware_controller_factory(with_queue=True)
     _wire_real_queue(controller)
     _fake_esphome(

--- a/tests/controllers/firmware/test_execute_job_e2e.py
+++ b/tests/controllers/firmware/test_execute_job_e2e.py
@@ -600,9 +600,7 @@ async def test_user_cancel_kills_process_tree_and_finalizes_promptly(
             assert job.status == JobStatus.CANCELLED
 
             # The whole tree died, not just the tracked parent.
-            assert await wait_dead(child_pid[0], timeout=10.0), (
-                f"child {child_pid[0]} survived firmware/cancel"
-            )
+            await wait_dead(child_pid[0], timeout=10.0)
     finally:
         for pid in child_pid:
             kill_pid(pid)

--- a/tests/controllers/firmware/test_parallel_uploads.py
+++ b/tests/controllers/firmware/test_parallel_uploads.py
@@ -146,7 +146,7 @@ async def test_cancel_one_of_three_concurrent_uploads_spares_siblings(
         await _wait_started(started, *names)
         # JOB_STARTED fires before the spawn; wait for every registration.
         async with asyncio.timeout(10):
-            while not all(job.job_id in controller.state.processes for job in jobs):
+            while not all(job.job_id in controller.state.spawns for job in jobs):
                 await asyncio.sleep(0.01)
 
         await controller.cancel(job_id=jobs[1].job_id)
@@ -157,8 +157,8 @@ async def test_cancel_one_of_three_concurrent_uploads_spares_siblings(
         # Siblings never saw a signal — still parked and RUNNING.
         assert jobs[0].status is JobStatus.RUNNING
         assert jobs[2].status is JobStatus.RUNNING
-        assert controller.state.processes[jobs[0].job_id].returncode is None
-        assert controller.state.processes[jobs[2].job_id].returncode is None
+        assert controller.state.spawns[jobs[0].job_id].proc.returncode is None
+        assert controller.state.spawns[jobs[2].job_id].proc.returncode is None
 
 
 # Each upload sleeps a per-device staggered duration (indexed by the

--- a/tests/controllers/firmware/test_queue_status.py
+++ b/tests/controllers/firmware/test_queue_status.py
@@ -27,7 +27,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController, remote_runner
-from esphome_device_builder.controllers.firmware._state import FirmwareState
+from esphome_device_builder.controllers.firmware._state import FirmwareState, SpawnHandle
 from esphome_device_builder.helpers.event_bus import EventBus
 from esphome_device_builder.models import (
     EventType,
@@ -169,7 +169,7 @@ def test_finalize_terminal_releases_slot_before_listener_fires(
     controller = _make_controller_with_real_bus()
     job = _job()
     controller.state.compile_lane.active[job.job_id] = job
-    controller.state.processes[job.job_id] = MagicMock()
+    controller.state.spawns[job.job_id] = SpawnHandle(MagicMock())
     captured = _capture_snapshot_in_listener(controller, event_type)
 
     controller._finalize_terminal(job, status)
@@ -177,7 +177,7 @@ def test_finalize_terminal_releases_slot_before_listener_fires(
     assert captured == [(True, False, 0)]
     # And the slot stays released after the fire returns.
     assert not controller.state.compile_lane.active
-    assert job.job_id not in controller.state.processes
+    assert job.job_id not in controller.state.spawns
 
 
 def test_finalize_terminal_skips_release_when_job_not_active() -> None:
@@ -243,7 +243,7 @@ def test_remote_runner_terminal_helpers_release_slot_before_fire(
     controller = _make_controller_with_real_bus()
     job = _job()
     controller.state.compile_lane.active[job.job_id] = job
-    controller.state.processes[job.job_id] = MagicMock()
+    controller.state.spawns[job.job_id] = SpawnHandle(MagicMock())
     captured = _capture_snapshot_in_listener(controller, event_type)
 
     if fn_name == "_finalize_success":
@@ -253,7 +253,7 @@ def test_remote_runner_terminal_helpers_release_slot_before_fire(
 
     assert captured == [(True, False, 0)]
     assert not controller.state.compile_lane.active
-    assert job.job_id not in controller.state.processes
+    assert job.job_id not in controller.state.spawns
     assert job.status is status
     if status is JobStatus.FAILED:
         # ``_fail_locally`` stamps ``job.error`` before

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -1558,7 +1558,7 @@ def _wire_upload_subprocess(
     runner doesn't reach into the (absent in unit tests)
     devices controller's address cache. The runner's
     ``_tracked_subprocess`` is the real method — it
-    registers the spawn in ``state.processes`` so the
+    registers the spawn in ``state.spawns`` so the
     cancel-during-upload tests can SIGTERM the chain.
     """
     quoted_stdout = repr(stdout)
@@ -1800,7 +1800,7 @@ async def test_remote_install_cancel_during_local_upload_finalises_as_cancelled(
     User Stop during the ``esphome upload`` subprocess finalises as CANCELLED.
 
     The runner's ``_tracked_subprocess`` registers the
-    upload spawn in ``controller.state.processes``, and
+    upload spawn in ``controller.state.spawns``, and
     ``FirmwareController.cancel``'s
     ``_terminate_job_process`` lands SIGTERM on the
     spawned tree. The subprocess exits non-zero (terminated
@@ -1834,9 +1834,9 @@ async def test_remote_install_cancel_during_local_upload_finalises_as_cancelled(
     ]
 
     async def _terminate(target: FirmwareJob) -> None:
-        proc = controller.state.processes.get(target.job_id)
-        assert proc is not None  # type narrowing
-        proc.terminate()
+        spawn = controller.state.spawns.get(target.job_id)
+        assert spawn is not None  # type narrowing
+        spawn.proc.terminate()
 
     controller._terminate_job_process = _terminate  # type: ignore[method-assign]
     job = _make_remote_install_job()
@@ -1846,7 +1846,7 @@ async def test_remote_install_cancel_during_local_upload_finalises_as_cancelled(
     _fire_state(controller, job_id=job.job_id, status="completed")
 
     # Wait until the subprocess is up.
-    while job.job_id not in controller.state.processes:
+    while job.job_id not in controller.state.spawns:
         await asyncio.sleep(0.01)
 
     _request_remote_cancel(controller, job)

--- a/tests/controllers/firmware/test_stop.py
+++ b/tests/controllers/firmware/test_stop.py
@@ -25,6 +25,7 @@ import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.controllers.firmware import lifecycle as _firmware_lifecycle_mod
+from esphome_device_builder.controllers.firmware._state import SpawnHandle
 from esphome_device_builder.helpers import process as _process_mod
 from esphome_device_builder.helpers.process import _signal_process_group
 from esphome_device_builder.helpers.subprocess import create_subprocess_exec
@@ -179,7 +180,7 @@ async def test_terminate_kills_grandchild_via_process_group(
         start_new_session=True,
     )
     job = MagicMock(job_id="test-job")
-    controller.state.processes[job.job_id] = proc  # type: ignore[assignment]
+    controller.state.spawns[job.job_id] = SpawnHandle(proc)
 
     try:
         # Read the two pid lines from stdout so we know what to verify.

--- a/tests/controllers/firmware/test_stop.py
+++ b/tests/controllers/firmware/test_stop.py
@@ -13,7 +13,6 @@ and asserting both pids are gone shortly after.
 from __future__ import annotations
 
 import asyncio
-import os
 import signal
 import subprocess
 import sys
@@ -29,7 +28,11 @@ from esphome_device_builder.controllers.firmware import lifecycle as _firmware_l
 from esphome_device_builder.helpers import process as _process_mod
 from esphome_device_builder.helpers.process import _signal_process_group
 from esphome_device_builder.helpers.subprocess import create_subprocess_exec
-from tests.controllers.firmware.conftest import BareFirmwareControllerFactory
+from tests.controllers.firmware.conftest import (
+    BareFirmwareControllerFactory,
+    pid_alive,
+    wait_dead,
+)
 
 # Process groups, ``os.fork``, and ``SIGKILL`` are POSIX-only. The
 # whole stop-button cancellation strategy here (``killpg`` against the
@@ -39,29 +42,6 @@ pytestmark = pytest.mark.skipif(
     sys.platform == "win32",
     reason="POSIX process-group / fork / SIGKILL semantics — not applicable on Windows.",
 )
-
-
-def _is_alive(pid: int) -> bool:
-    """Return True if *pid* is still running. Survives EPERM on macOS."""
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        # Process exists but we can't signal it — for our test that
-        # only happens if reused as a system pid (negligible odds).
-        return True
-    return True
-
-
-async def _wait_dead(pid: int, timeout: float = 3.0) -> bool:
-    """Poll until *pid* exits or *timeout* elapses."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if not _is_alive(pid):
-            return True
-        await asyncio.sleep(0.05)
-    return _is_alive(pid) is False
 
 
 # ---------------------------------------------------------------------------
@@ -218,8 +198,8 @@ async def test_terminate_kills_grandchild_via_process_group(
                 grandchild_pid = int(text.split("=", 1)[1])
         assert parent_pid is not None, "child never reported its pid"
         assert grandchild_pid is not None, "grandchild never reported its pid"
-        assert _is_alive(parent_pid)
-        assert _is_alive(grandchild_pid)
+        assert pid_alive(parent_pid)
+        assert pid_alive(grandchild_pid)
 
         # Hit Stop. Both pids must die — SIGTERM is ignored, so the
         # controller's grace window expires and SIGKILL escalates to
@@ -227,8 +207,8 @@ async def test_terminate_kills_grandchild_via_process_group(
         await controller._terminate_job_process(job)
         await proc.wait()
 
-        assert await _wait_dead(parent_pid), f"parent pid {parent_pid} still alive after stop"
-        grandchild_alive = not await _wait_dead(grandchild_pid)
+        assert await wait_dead(parent_pid), f"parent pid {parent_pid} still alive after stop"
+        grandchild_alive = not await wait_dead(grandchild_pid)
         assert not grandchild_alive, (
             f"grandchild pid {grandchild_pid} still alive after stop — "
             "process-group signal didn't reach it"

--- a/tests/controllers/firmware/test_stop.py
+++ b/tests/controllers/firmware/test_stop.py
@@ -207,12 +207,8 @@ async def test_terminate_kills_grandchild_via_process_group(
         await controller._terminate_job_process(job)
         await proc.wait()
 
-        assert await wait_dead(parent_pid), f"parent pid {parent_pid} still alive after stop"
-        grandchild_alive = not await wait_dead(grandchild_pid)
-        assert not grandchild_alive, (
-            f"grandchild pid {grandchild_pid} still alive after stop — "
-            "process-group signal didn't reach it"
-        )
+        await wait_dead(parent_pid)
+        await wait_dead(grandchild_pid)
     finally:
         # Belt-and-suspenders cleanup: if any assertion above failed
         # before the SIGKILL chain ran, the SIGTERM-trapped grandchild

--- a/tests/controllers/firmware/test_stop_windows.py
+++ b/tests/controllers/firmware/test_stop_windows.py
@@ -1,10 +1,10 @@
-"""Stop-button cancellation on Windows uses ``taskkill /F /T``.
+"""Stop-button cancellation on Windows: job object first, ``taskkill /F /T`` fallback.
 
 The POSIX path (``test_firmware_stop.py``) relies on process groups
 and ``killpg`` — primitives that don't exist on Windows. This module
 covers the Windows-specific branch in ``_terminate_job_process``:
-``taskkill`` walks the kernel's parent-PID tree and force-kills the
-whole subtree in one shot.
+``TerminateJobObject`` kills the whole tree atomically; ``taskkill``
+walks the kernel's parent-PID tree when no job object was assigned.
 """
 
 from __future__ import annotations
@@ -19,7 +19,12 @@ from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.helpers import process as process_module
 from esphome_device_builder.helpers.process import _terminate_subtree_windows
 from esphome_device_builder.helpers.subprocess import create_subprocess_exec
-from tests.controllers.firmware.conftest import BareFirmwareControllerFactory
+from esphome_device_builder.helpers.windows_job_object import WindowsJobObject
+from tests.controllers.firmware.conftest import (
+    BareFirmwareControllerFactory,
+    pid_alive,
+    wait_dead,
+)
 
 # Only the integration test below — which spawns a real subprocess
 # and exercises ``_terminate_job_process``'s Windows branch end
@@ -39,6 +44,45 @@ def controller(
 ) -> FirmwareController:
     """Stand up a FirmwareController shell — only the bits termination touches."""
     return bare_firmware_controller_factory()
+
+
+@windows_only
+async def test_terminate_kills_grandchild_via_job_object(
+    controller: FirmwareController,
+) -> None:
+    """The job object takes down a grandchild the parent-only kill would orphan."""
+    proc = await create_subprocess_exec(
+        sys.executable,
+        "-c",
+        "import subprocess, sys; "
+        "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']); "
+        "print(f'GRANDCHILD_PID={child.pid}', flush=True); "
+        "child.wait()",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    win_job = WindowsJobObject.create_for_pid(proc.pid)
+    assert win_job is not None
+    job = MagicMock(job_id="test-job")
+    controller.state.processes[job.job_id] = proc  # type: ignore[assignment]
+    controller.state.job_objects[job.job_id] = win_job
+
+    try:
+        assert proc.stdout is not None
+        line = await asyncio.wait_for(proc.stdout.readline(), timeout=10.0)
+        grandchild_pid = int(line.decode().split("=", 1)[1])
+        assert pid_alive(grandchild_pid)
+
+        await controller._terminate_job_process(job)
+
+        await asyncio.wait_for(proc.wait(), timeout=5.0)
+        assert await wait_dead(grandchild_pid), "grandchild survived the kill"
+    finally:
+        win_job.terminate()
+        win_job.close()
+        if proc.returncode is None:
+            proc.kill()
+            await proc.wait()
 
 
 @windows_only

--- a/tests/controllers/firmware/test_stop_windows.py
+++ b/tests/controllers/firmware/test_stop_windows.py
@@ -49,15 +49,28 @@ def controller(
 @windows_only
 async def test_terminate_kills_grandchild_via_job_object(
     controller: FirmwareController,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The job object takes down a grandchild the parent-only kill would orphan."""
+    """The job object alone takes down a grandchild when the taskkill sweep fails.
+
+    The spawned parent blocks on stdin until the job assignment has
+    landed, so the grandchild is deterministically a job member; the
+    sweep is forced to fail so only ``TerminateJobObject`` can kill.
+    """
+
+    async def _sweep_fails(_pid: int) -> bool:
+        return False
+
+    monkeypatch.setattr(process_module, "_terminate_subtree_windows", _sweep_fails)
     proc = await create_subprocess_exec(
         sys.executable,
         "-c",
         "import subprocess, sys; "
+        "sys.stdin.readline(); "
         "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']); "
         "print(f'GRANDCHILD_PID={child.pid}', flush=True); "
         "child.wait()",
+        stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
     )
@@ -68,6 +81,9 @@ async def test_terminate_kills_grandchild_via_job_object(
     controller.state.job_objects[job.job_id] = win_job
 
     try:
+        assert proc.stdin is not None
+        proc.stdin.write(b"\n")
+        await proc.stdin.drain()
         assert proc.stdout is not None
         line = await asyncio.wait_for(proc.stdout.readline(), timeout=10.0)
         grandchild_pid = int(line.decode().split("=", 1)[1])

--- a/tests/controllers/firmware/test_stop_windows.py
+++ b/tests/controllers/firmware/test_stop_windows.py
@@ -1,10 +1,11 @@
-"""Stop-button cancellation on Windows: job object first, ``taskkill /F /T`` fallback.
+"""Stop-button cancellation on Windows: ``taskkill /F /T`` sweep, then the job object.
 
 The POSIX path (``test_firmware_stop.py``) relies on process groups
 and ``killpg`` — primitives that don't exist on Windows. This module
-covers the Windows-specific branch in ``_terminate_job_process``:
-``TerminateJobObject`` kills the whole tree atomically; ``taskkill``
-walks the kernel's parent-PID tree when no job object was assigned.
+covers the Windows-specific branch in ``_terminate_job_process``: the
+sweep walks the kernel's parent-PID tree first (it alone reaches a
+child spawned before the job assignment landed), then
+``TerminateJobObject`` kills every job member atomically.
 """
 
 from __future__ import annotations

--- a/tests/controllers/firmware/test_stop_windows.py
+++ b/tests/controllers/firmware/test_stop_windows.py
@@ -27,9 +27,9 @@ from tests.controllers.firmware.conftest import (
     wait_dead,
 )
 
-# Only the integration test below — which spawns a real subprocess
-# and exercises ``_terminate_job_process``'s Windows branch end
-# to end — needs the Windows-only guard. The unit tests for
+# Only the integration tests below — which spawn real subprocesses
+# and exercise ``_terminate_job_process``'s Windows branch end
+# to end — need the Windows-only guard. The unit tests for
 # ``_terminate_subtree_windows`` patch out ``create_subprocess_exec``
 # entirely, so they're cross-platform-safe and contribute Windows-
 # branch coverage on every OS in the matrix.

--- a/tests/controllers/firmware/test_stop_windows.py
+++ b/tests/controllers/firmware/test_stop_windows.py
@@ -64,7 +64,7 @@ async def test_terminate_kills_grandchild_via_job_object(
     win_job = WindowsJobObject.create_for_pid(proc.pid)
     assert win_job is not None
     job = MagicMock(job_id="test-job")
-    controller.state.processes[job.job_id] = proc  # type: ignore[assignment]
+    controller.state.processes[job.job_id] = proc
     controller.state.job_objects[job.job_id] = win_job
 
     try:
@@ -76,7 +76,7 @@ async def test_terminate_kills_grandchild_via_job_object(
         await controller._terminate_job_process(job)
 
         await asyncio.wait_for(proc.wait(), timeout=5.0)
-        assert await wait_dead(grandchild_pid), "grandchild survived the kill"
+        await wait_dead(grandchild_pid)
     finally:
         win_job.terminate()
         win_job.close()

--- a/tests/controllers/firmware/test_stop_windows.py
+++ b/tests/controllers/firmware/test_stop_windows.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
+from esphome_device_builder.controllers.firmware._state import SpawnHandle
 from esphome_device_builder.helpers import process as process_module
 from esphome_device_builder.helpers.process import _terminate_subtree_windows
 from esphome_device_builder.helpers.subprocess import create_subprocess_exec
@@ -77,8 +78,7 @@ async def test_terminate_kills_grandchild_via_job_object(
     win_job = WindowsJobObject.create_for_pid(proc.pid)
     assert win_job is not None
     job = MagicMock(job_id="test-job")
-    controller.state.processes[job.job_id] = proc
-    controller.state.job_objects[job.job_id] = win_job
+    controller.state.spawns[job.job_id] = SpawnHandle(proc, win_job)
 
     try:
         assert proc.stdin is not None
@@ -114,7 +114,7 @@ async def test_terminate_kills_subprocess_via_taskkill(
         stderr=asyncio.subprocess.STDOUT,
     )
     job = MagicMock(job_id="test-job")
-    controller.state.processes[job.job_id] = proc  # type: ignore[assignment]
+    controller.state.spawns[job.job_id] = SpawnHandle(proc)
 
     try:
         await controller._terminate_job_process(job)

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -68,7 +68,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
+from esphome_device_builder.controllers.firmware import _state as state_module
 from esphome_device_builder.controllers.firmware import runner as runner_module
+from esphome_device_builder.controllers.firmware._state import SpawnHandle
 from esphome_device_builder.models import (
     FirmwareJob,
     JobStatus,
@@ -514,7 +516,7 @@ async def test_cancel_during_hanging_verify_chip_terminates_subprocess(
     the sleep duration. The only way that's possible is if the
     SIGTERM actually landed on the verify subprocess — which
     requires the spawn to have been registered in
-    ``state.processes``.
+    ``state.spawns``.
     """
     controller = firmware_controller_factory(with_queue=True)
     _wire_real_queue(controller)
@@ -554,7 +556,7 @@ async def test_cancel_during_hanging_verify_chip_terminates_subprocess(
     async def _cancel_when_verify_starts() -> None:
         await verify_spawned.wait()
         # Wait until the runner has registered the verify subprocess
-        # in ``state.processes``. The wrapper's ``verify_spawned``
+        # in ``state.spawns``. The wrapper's ``verify_spawned``
         # fires INSIDE the ``await create_subprocess_exec`` call —
         # ``_verify_chip`` hasn't received the proc back yet, so
         # firing the cancel right here would hit the very race we're
@@ -562,7 +564,7 @@ async def test_cancel_during_hanging_verify_chip_terminates_subprocess(
         # ``_terminate_job_process`` no-ops). The poll proves the
         # registration happens BEFORE the runner waits on the proc,
         # which is the contract that makes mid-verify cancel work.
-        while job.job_id not in controller.state.processes:
+        while job.job_id not in controller.state.spawns:
             await asyncio.sleep(0.01)
         await controller.cancel(job_id=job.job_id)
 
@@ -660,7 +662,7 @@ async def test_tracked_subprocess_registers_and_clears_process(
 
     Pin the contract:
 
-    1. Inside the ``async with`` block, ``state.processes[job_id]``
+    1. Inside the ``async with`` block, ``state.spawns[job_id]``
        IS the spawned proc (so SIGTERM via ``cancel`` lands on it).
     2. After the block exits cleanly, the entry returns to its
        prior value (absent here, but the helper restores
@@ -668,7 +670,7 @@ async def test_tracked_subprocess_registers_and_clears_process(
     """
     controller = firmware_controller_factory(with_settings=False, with_terminate=True)
     job = _make_job("j1")
-    assert job.job_id not in controller.state.processes
+    assert job.job_id not in controller.state.spawns
 
     async with controller._tracked_subprocess(
         job,
@@ -678,11 +680,11 @@ async def test_tracked_subprocess_registers_and_clears_process(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
     ) as proc:
-        assert controller.state.processes[job.job_id] is proc
+        assert controller.state.spawns[job.job_id].proc is proc
         await proc.wait()
 
     # Restored on exit.
-    assert job.job_id not in controller.state.processes
+    assert job.job_id not in controller.state.spawns
 
 
 async def test_tracked_subprocess_restores_prior_value_on_exit(
@@ -700,7 +702,7 @@ async def test_tracked_subprocess_restores_prior_value_on_exit(
     controller = firmware_controller_factory(with_settings=False, with_terminate=True)
     job = _make_job("j1")
     sentinel = object()
-    controller.state.processes[job.job_id] = sentinel  # type: ignore[assignment]
+    controller.state.spawns[job.job_id] = sentinel  # type: ignore[assignment]
 
     async with controller._tracked_subprocess(
         job,
@@ -710,10 +712,10 @@ async def test_tracked_subprocess_restores_prior_value_on_exit(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
     ) as proc:
-        assert controller.state.processes[job.job_id] is proc  # registered for the duration
+        assert controller.state.spawns[job.job_id].proc is proc  # registered for the duration
         await proc.wait()
 
-    assert controller.state.processes[job.job_id] is sentinel  # restored
+    assert controller.state.spawns[job.job_id] is sentinel  # restored
 
 
 async def test_tracked_subprocess_restores_prior_value_on_exception(
@@ -730,7 +732,7 @@ async def test_tracked_subprocess_restores_prior_value_on_exception(
     """
     controller = firmware_controller_factory(with_settings=False, with_terminate=True)
     job = _make_job("j1")
-    assert job.job_id not in controller.state.processes
+    assert job.job_id not in controller.state.spawns
 
     with pytest.raises(RuntimeError, match="boom"):
         async with controller._tracked_subprocess(
@@ -751,7 +753,7 @@ async def test_tracked_subprocess_restores_prior_value_on_exception(
             msg = "boom"
             raise RuntimeError(msg)
 
-    assert job.job_id not in controller.state.processes
+    assert job.job_id not in controller.state.spawns
 
 
 class _FakeJobObject:
@@ -765,18 +767,18 @@ class _FakeJobObject:
 
 
 def _force_job_object(monkeypatch: pytest.MonkeyPatch, job_obj: _FakeJobObject | None) -> None:
-    """Route the spawn's win32 gate to a stubbed ``create_for_pid`` on any platform."""
+    """Route ``SpawnHandle.track``'s win32 gate to a stubbed ``create_for_pid``."""
     monkeypatch.setattr(sys, "platform", "win32")
     stub = MagicMock()
     stub.create_for_pid.return_value = job_obj
-    monkeypatch.setattr(runner_module, "WindowsJobObject", stub)
+    monkeypatch.setattr(state_module, "WindowsJobObject", stub)
 
 
 async def test_tracked_subprocess_registers_and_closes_job_object(
     firmware_controller_factory: FirmwareControllerFactory,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The job-object registry mirrors ``processes``: held for the run, closed on exit."""
+    """The spawn's kill handle is held for the run and closed on exit."""
     controller = firmware_controller_factory(with_settings=False, with_terminate=True)
     job = _make_job("j1")
     fake = _FakeJobObject()
@@ -790,23 +792,24 @@ async def test_tracked_subprocess_registers_and_closes_job_object(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
     ) as proc:
-        assert controller.state.job_objects[job.job_id] is fake
+        assert controller.state.spawns[job.job_id].win_job is fake
         await proc.wait()
 
-    assert job.job_id not in controller.state.job_objects
+    assert job.job_id not in controller.state.spawns
     assert fake.close_calls == 1
 
 
-async def test_tracked_subprocess_restores_prior_job_object(
+async def test_tracked_subprocess_restores_prior_spawn_handle(
     firmware_controller_factory: FirmwareControllerFactory,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A nested spawn restores the outer registration and closes only its own object."""
+    """A nested spawn restores the outer handle and closes only its own kill handle."""
     controller = firmware_controller_factory(with_settings=False, with_terminate=True)
     job = _make_job("j1")
     outer = _FakeJobObject()
     inner = _FakeJobObject()
-    controller.state.job_objects[job.job_id] = outer  # type: ignore[assignment]
+    prior = SpawnHandle(MagicMock(), outer)  # type: ignore[arg-type]
+    controller.state.spawns[job.job_id] = prior
     _force_job_object(monkeypatch, inner)
 
     async with controller._tracked_subprocess(
@@ -817,52 +820,26 @@ async def test_tracked_subprocess_restores_prior_job_object(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
     ) as proc:
-        assert controller.state.job_objects[job.job_id] is inner
+        assert controller.state.spawns[job.job_id].win_job is inner
         await proc.wait()
 
-    assert controller.state.job_objects[job.job_id] is outer
+    assert controller.state.spawns[job.job_id] is prior
     assert inner.close_calls == 1
     assert outer.close_calls == 0
 
 
-async def test_tracked_subprocess_pops_stale_job_object_when_creation_fails(
-    firmware_controller_factory: FirmwareControllerFactory,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """No job object for this spawn drops a stale entry so cancel can't kill the wrong tree."""
-    controller = firmware_controller_factory(with_settings=False, with_terminate=True)
-    job = _make_job("j1")
-    outer = _FakeJobObject()
-    controller.state.job_objects[job.job_id] = outer  # type: ignore[assignment]
-    _force_job_object(monkeypatch, None)
-
-    async with controller._tracked_subprocess(
-        job,
-        sys.executable,
-        "-c",
-        "import sys\nsys.exit(0)\n",
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.STDOUT,
-    ) as proc:
-        assert job.job_id not in controller.state.job_objects
-        await proc.wait()
-
-    assert controller.state.job_objects[job.job_id] is outer
-    assert outer.close_calls == 0
-
-
-async def test_release_lane_slot_closes_job_object(
+async def test_release_lane_slot_closes_spawn_handle(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
-    """Finalising a job closes a job-object registration left behind by its run."""
+    """Finalising a job closes a spawn registration left behind by its run."""
     job = _make_job("j1")
     controller = firmware_controller_factory(job, with_settings=False, with_terminate=True)
     fake = _FakeJobObject()
-    controller.state.job_objects[job.job_id] = fake  # type: ignore[assignment]
+    controller.state.spawns[job.job_id] = SpawnHandle(MagicMock(), fake)  # type: ignore[arg-type]
 
     controller._finalize_terminal(job, JobStatus.FAILED)
 
-    assert job.job_id not in controller.state.job_objects
+    assert job.job_id not in controller.state.spawns
     assert fake.close_calls == 1
 
 
@@ -965,11 +942,11 @@ async def test_cancel_in_gap_between_verify_and_main_spawn_terminates(
     _seed_storage(tmp_path, target_platform="ESP32C3")
 
     real = runner_module.create_subprocess_exec
-    terminate_calls: list[asyncio.subprocess.Process | None] = []
+    terminate_calls: list[SpawnHandle | None] = []
     real_terminate = controller._terminate_job_process
 
     async def _spy_terminate(target: FirmwareJob) -> None:
-        terminate_calls.append(controller.state.processes.get(target.job_id))
+        terminate_calls.append(controller.state.spawns.get(target.job_id))
         await real_terminate(target)
 
     monkeypatch.setattr(controller, "_terminate_job_process", _spy_terminate)

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -63,7 +63,7 @@ import asyncio
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -752,6 +752,118 @@ async def test_tracked_subprocess_restores_prior_value_on_exception(
             raise RuntimeError(msg)
 
     assert job.job_id not in controller.state.processes
+
+
+class _FakeJobObject:
+    """``WindowsJobObject`` stand-in recording ``close()`` calls."""
+
+    def __init__(self) -> None:
+        self.close_calls = 0
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+def _force_job_object(monkeypatch: pytest.MonkeyPatch, job_obj: _FakeJobObject | None) -> None:
+    """Route the spawn's win32 gate to a stubbed ``create_for_pid`` on any platform."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    stub = MagicMock()
+    stub.create_for_pid.return_value = job_obj
+    monkeypatch.setattr(runner_module, "WindowsJobObject", stub)
+
+
+async def test_tracked_subprocess_registers_and_closes_job_object(
+    firmware_controller_factory: FirmwareControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The job-object registry mirrors ``processes``: held for the run, closed on exit."""
+    controller = firmware_controller_factory(with_settings=False, with_terminate=True)
+    job = _make_job("j1")
+    fake = _FakeJobObject()
+    _force_job_object(monkeypatch, fake)
+
+    async with controller._tracked_subprocess(
+        job,
+        sys.executable,
+        "-c",
+        "import sys\nsys.exit(0)\n",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    ) as proc:
+        assert controller.state.job_objects[job.job_id] is fake
+        await proc.wait()
+
+    assert job.job_id not in controller.state.job_objects
+    assert fake.close_calls == 1
+
+
+async def test_tracked_subprocess_restores_prior_job_object(
+    firmware_controller_factory: FirmwareControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A nested spawn restores the outer registration and closes only its own object."""
+    controller = firmware_controller_factory(with_settings=False, with_terminate=True)
+    job = _make_job("j1")
+    outer = _FakeJobObject()
+    inner = _FakeJobObject()
+    controller.state.job_objects[job.job_id] = outer  # type: ignore[assignment]
+    _force_job_object(monkeypatch, inner)
+
+    async with controller._tracked_subprocess(
+        job,
+        sys.executable,
+        "-c",
+        "import sys\nsys.exit(0)\n",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    ) as proc:
+        assert controller.state.job_objects[job.job_id] is inner
+        await proc.wait()
+
+    assert controller.state.job_objects[job.job_id] is outer
+    assert inner.close_calls == 1
+    assert outer.close_calls == 0
+
+
+async def test_tracked_subprocess_pops_stale_job_object_when_creation_fails(
+    firmware_controller_factory: FirmwareControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No job object for this spawn drops a stale entry so cancel can't kill the wrong tree."""
+    controller = firmware_controller_factory(with_settings=False, with_terminate=True)
+    job = _make_job("j1")
+    outer = _FakeJobObject()
+    controller.state.job_objects[job.job_id] = outer  # type: ignore[assignment]
+    _force_job_object(monkeypatch, None)
+
+    async with controller._tracked_subprocess(
+        job,
+        sys.executable,
+        "-c",
+        "import sys\nsys.exit(0)\n",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    ) as proc:
+        assert job.job_id not in controller.state.job_objects
+        await proc.wait()
+
+    assert controller.state.job_objects[job.job_id] is outer
+    assert outer.close_calls == 0
+
+
+async def test_release_lane_slot_closes_job_object(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """Finalising a job closes a job-object registration left behind by its run."""
+    job = _make_job("j1")
+    controller = firmware_controller_factory(job, with_settings=False, with_terminate=True)
+    fake = _FakeJobObject()
+    controller.state.job_objects[job.job_id] = fake  # type: ignore[assignment]
+
+    controller._finalize_terminal(job, JobStatus.FAILED)
+
+    assert job.job_id not in controller.state.job_objects
+    assert fake.close_calls == 1
 
 
 async def test_tracked_subprocess_gets_devnull_stdin(

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -725,6 +725,29 @@ async def test_tracked_subprocess_restores_prior_value_on_exception(
     assert job.job_id not in controller.state.spawns
 
 
+async def test_tracked_subprocess_terminates_spawn_on_cancellation(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """A cancellation unwinding the body terminates the spawn and still propagates."""
+    controller = firmware_controller_factory(with_settings=False, with_terminate=True)
+    job = _make_job("j1")
+
+    with pytest.raises(asyncio.CancelledError):
+        async with controller._tracked_subprocess(
+            job,
+            sys.executable,
+            "-c",
+            "import sys\nsys.exit(0)\n",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        ) as proc:
+            await proc.wait()
+            raise asyncio.CancelledError
+
+    controller._terminate_job_process.assert_awaited_once_with(job)
+    assert job.job_id not in controller.state.spawns
+
+
 class _FakeJobObject:
     """``WindowsJobObject`` stand-in recording ``close()`` calls."""
 

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -687,37 +687,6 @@ async def test_tracked_subprocess_registers_and_clears_process(
     assert job.job_id not in controller.state.spawns
 
 
-async def test_tracked_subprocess_restores_prior_value_on_exit(
-    firmware_controller_factory: FirmwareControllerFactory,
-) -> None:
-    """``_tracked_subprocess`` restores the prior registry entry.
-
-    The helper saves whatever was registered before it spawned
-    and restores it on exit, so a future caller that uses the
-    helper inside an outer one (or just after another spawn site
-    that's already populated the entry) doesn't accidentally
-    drop the active process reference. Absent is the
-    common case but the contract is "restore the prior value".
-    """
-    controller = firmware_controller_factory(with_settings=False, with_terminate=True)
-    job = _make_job("j1")
-    sentinel = object()
-    controller.state.spawns[job.job_id] = sentinel  # type: ignore[assignment]
-
-    async with controller._tracked_subprocess(
-        job,
-        sys.executable,
-        "-c",
-        "import sys\nsys.exit(0)\n",
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.STDOUT,
-    ) as proc:
-        assert controller.state.spawns[job.job_id].proc is proc  # registered for the duration
-        await proc.wait()
-
-    assert controller.state.spawns[job.job_id] is sentinel  # restored
-
-
 async def test_tracked_subprocess_restores_prior_value_on_exception(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -767,8 +736,7 @@ class _FakeJobObject:
 
 
 def _force_job_object(monkeypatch: pytest.MonkeyPatch, job_obj: _FakeJobObject | None) -> None:
-    """Route ``SpawnHandle.track``'s win32 gate to a stubbed ``create_for_pid``."""
-    monkeypatch.setattr(sys, "platform", "win32")
+    """Stub ``SpawnHandle.track``'s ``create_for_pid`` to return *job_obj*."""
     stub = MagicMock()
     stub.create_for_pid.return_value = job_obj
     monkeypatch.setattr(state_module, "WindowsJobObject", stub)

--- a/tests/test_helpers_process.py
+++ b/tests/test_helpers_process.py
@@ -242,3 +242,73 @@ async def test_terminate_subtree_with_grace_falls_back_to_proc_kill_on_taskkill_
     await terminate_subtree_with_grace(fake_proc)  # type: ignore[arg-type]
 
     assert fake_proc.kill_calls == 1
+
+
+@dataclass
+class _FakeWinJob:
+    """``WindowsJobObject`` stand-in: counted ``terminate()`` with a tunable verdict."""
+
+    terminate_result: bool = True
+    terminate_calls: int = 0
+
+    def terminate(self) -> bool:
+        self.terminate_calls += 1
+        return self.terminate_result
+
+
+@pytest.fixture
+def fake_taskkill(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    """Patch ``_terminate_subtree_windows`` (returns False) with a pid recorder."""
+    calls: list[int] = []
+
+    async def _impl(pid: int) -> bool:
+        calls.append(pid)
+        return False
+
+    monkeypatch.setattr(
+        "esphome_device_builder.helpers.process._terminate_subtree_windows",
+        _impl,
+    )
+    return calls
+
+
+@windows_only
+async def test_terminate_subtree_with_grace_job_object_short_circuits(
+    fake_proc: _FakeProc,
+    fake_taskkill: list[int],
+) -> None:
+    """Windows: a successful ``TerminateJobObject`` skips taskkill and ``proc.kill()``."""
+    win_job = _FakeWinJob()
+
+    await terminate_subtree_with_grace(fake_proc, win_job=win_job)  # type: ignore[arg-type]
+
+    assert win_job.terminate_calls == 1
+    assert fake_taskkill == []
+    assert fake_proc.kill_calls == 0
+
+
+@windows_only
+async def test_terminate_subtree_with_grace_job_object_failure_falls_through(
+    fake_proc: _FakeProc,
+    fake_taskkill: list[int],
+) -> None:
+    """Windows: job-object kill failing falls to taskkill, then ``proc.kill()``."""
+    win_job = _FakeWinJob(terminate_result=False)
+
+    await terminate_subtree_with_grace(fake_proc, win_job=win_job)  # type: ignore[arg-type]
+
+    assert win_job.terminate_calls == 1
+    assert fake_taskkill == [fake_proc.pid]
+    assert fake_proc.kill_calls == 1
+
+
+@windows_only
+async def test_terminate_subtree_with_grace_without_job_object_uses_taskkill(
+    fake_proc: _FakeProc,
+    fake_taskkill: list[int],
+) -> None:
+    """Windows: no job object preserves the taskkill-first chain."""
+    await terminate_subtree_with_grace(fake_proc)  # type: ignore[arg-type]
+
+    assert fake_taskkill == [fake_proc.pid]
+    assert fake_proc.kill_calls == 1

--- a/tests/test_helpers_process.py
+++ b/tests/test_helpers_process.py
@@ -21,11 +21,10 @@ from esphome_device_builder.helpers.process import (
     terminate_subtree_with_grace,
 )
 
-# Platform skipif markers — every signal-group test below is POSIX-only,
-# every taskkill test is Windows-only. Naming them once keeps the per-test
-# decorator a one-liner and the reason string in lockstep across the file.
+# The signal-group tests are POSIX-only; the fully-faked Windows chain
+# tests instead patch ``sys.platform`` (``win32_platform``) so the
+# sweep-before-job-object ordering is pinned on every matrix leg.
 posix_only = pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal-group path")
-windows_only = pytest.mark.skipif(sys.platform != "win32", reason="Windows taskkill path")
 
 
 @dataclass
@@ -217,10 +216,10 @@ async def test_terminate_subtree_with_grace_returns_when_sigterm_undelivered(
     assert waited is False
 
 
-@windows_only
 async def test_terminate_subtree_with_grace_falls_back_to_proc_kill_on_taskkill_failure(
     monkeypatch: pytest.MonkeyPatch,
     fake_proc: _FakeProc,
+    win32_platform: None,
 ) -> None:
     """Windows: taskkill returning False triggers the ``proc.kill()`` fallback.
 
@@ -280,10 +279,16 @@ def fake_taskkill(monkeypatch: pytest.MonkeyPatch) -> _FakeTaskkill:
     return fake
 
 
-@windows_only
+@pytest.fixture
+def win32_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Route ``terminate_subtree_with_grace`` down its win32 branch on any OS."""
+    monkeypatch.setattr(sys, "platform", "win32")
+
+
 async def test_terminate_subtree_with_grace_sweeps_before_job_object(
     fake_proc: _FakeProc,
     fake_taskkill: _FakeTaskkill,
+    win32_platform: None,
 ) -> None:
     """Windows: taskkill sweeps the live tree first, then the job object — no ``proc.kill()``."""
     win_job = _FakeWinJob()
@@ -295,10 +300,10 @@ async def test_terminate_subtree_with_grace_sweeps_before_job_object(
     assert fake_proc.kill_calls == 0
 
 
-@windows_only
 async def test_terminate_subtree_with_grace_job_object_covers_failed_sweep(
     fake_proc: _FakeProc,
     fake_taskkill: _FakeTaskkill,
+    win32_platform: None,
 ) -> None:
     """Windows: taskkill failing still ends with the job-object kill, no ``proc.kill()``."""
     fake_taskkill.return_value = False
@@ -310,10 +315,10 @@ async def test_terminate_subtree_with_grace_job_object_covers_failed_sweep(
     assert fake_proc.kill_calls == 0
 
 
-@windows_only
 async def test_terminate_subtree_with_grace_sweep_covers_failed_job_object(
     fake_proc: _FakeProc,
     fake_taskkill: _FakeTaskkill,
+    win32_platform: None,
 ) -> None:
     """Windows: a successful sweep suffices when the job-object kill fails."""
     win_job = _FakeWinJob(terminate_result=False)
@@ -323,10 +328,10 @@ async def test_terminate_subtree_with_grace_sweep_covers_failed_job_object(
     assert fake_proc.kill_calls == 0
 
 
-@windows_only
 async def test_terminate_subtree_with_grace_falls_back_to_proc_kill_when_both_fail(
     fake_proc: _FakeProc,
     fake_taskkill: _FakeTaskkill,
+    win32_platform: None,
 ) -> None:
     """Windows: sweep and job-object kill both failing degrades to ``proc.kill()``."""
     fake_taskkill.return_value = False
@@ -337,10 +342,10 @@ async def test_terminate_subtree_with_grace_falls_back_to_proc_kill_when_both_fa
     assert fake_proc.kill_calls == 1
 
 
-@windows_only
 async def test_terminate_subtree_with_grace_without_job_object_uses_taskkill(
     fake_proc: _FakeProc,
     fake_taskkill: _FakeTaskkill,
+    win32_platform: None,
 ) -> None:
     """Windows: no job object — a successful taskkill sweep alone suffices."""
     await terminate_subtree_with_grace(fake_proc)  # type: ignore[arg-type]

--- a/tests/test_helpers_process.py
+++ b/tests/test_helpers_process.py
@@ -256,59 +256,98 @@ class _FakeWinJob:
         return self.terminate_result
 
 
+@dataclass
+class _FakeTaskkill:
+    """Recorder + tunable verdict for the patched ``_terminate_subtree_windows``."""
+
+    calls: list[int] = field(default_factory=list)
+    return_value: bool = True
+
+
 @pytest.fixture
-def fake_taskkill(monkeypatch: pytest.MonkeyPatch) -> list[int]:
-    """Patch ``_terminate_subtree_windows`` (returns False) with a pid recorder."""
-    calls: list[int] = []
+def fake_taskkill(monkeypatch: pytest.MonkeyPatch) -> _FakeTaskkill:
+    """Patch ``_terminate_subtree_windows`` with a recorder; return the handle."""
+    fake = _FakeTaskkill()
 
     async def _impl(pid: int) -> bool:
-        calls.append(pid)
-        return False
+        fake.calls.append(pid)
+        return fake.return_value
 
     monkeypatch.setattr(
         "esphome_device_builder.helpers.process._terminate_subtree_windows",
         _impl,
     )
-    return calls
+    return fake
 
 
 @windows_only
-async def test_terminate_subtree_with_grace_job_object_short_circuits(
+async def test_terminate_subtree_with_grace_sweeps_before_job_object(
     fake_proc: _FakeProc,
-    fake_taskkill: list[int],
+    fake_taskkill: _FakeTaskkill,
 ) -> None:
-    """Windows: a successful ``TerminateJobObject`` skips taskkill and ``proc.kill()``."""
+    """Windows: taskkill sweeps the live tree first, then the job object fires — no ``proc.kill()``.
+
+    Ordering is load-bearing: a child spawned before the job assignment
+    is only reachable by the PID walk while the tracked parent is alive.
+    """
+    win_job = _FakeWinJob()
+
+    await terminate_subtree_with_grace(fake_proc, win_job=win_job)  # type: ignore[arg-type]
+
+    assert fake_taskkill.calls == [fake_proc.pid]
+    assert win_job.terminate_calls == 1
+    assert fake_proc.kill_calls == 0
+
+
+@windows_only
+async def test_terminate_subtree_with_grace_job_object_covers_failed_sweep(
+    fake_proc: _FakeProc,
+    fake_taskkill: _FakeTaskkill,
+) -> None:
+    """Windows: taskkill failing still ends with the job-object kill, no ``proc.kill()``."""
+    fake_taskkill.return_value = False
     win_job = _FakeWinJob()
 
     await terminate_subtree_with_grace(fake_proc, win_job=win_job)  # type: ignore[arg-type]
 
     assert win_job.terminate_calls == 1
-    assert fake_taskkill == []
     assert fake_proc.kill_calls == 0
 
 
 @windows_only
-async def test_terminate_subtree_with_grace_job_object_failure_falls_through(
+async def test_terminate_subtree_with_grace_sweep_covers_failed_job_object(
     fake_proc: _FakeProc,
-    fake_taskkill: list[int],
+    fake_taskkill: _FakeTaskkill,
 ) -> None:
-    """Windows: job-object kill failing falls to taskkill, then ``proc.kill()``."""
+    """Windows: a successful sweep suffices when the job-object kill fails."""
     win_job = _FakeWinJob(terminate_result=False)
 
     await terminate_subtree_with_grace(fake_proc, win_job=win_job)  # type: ignore[arg-type]
 
-    assert win_job.terminate_calls == 1
-    assert fake_taskkill == [fake_proc.pid]
+    assert fake_proc.kill_calls == 0
+
+
+@windows_only
+async def test_terminate_subtree_with_grace_falls_back_to_proc_kill_when_both_fail(
+    fake_proc: _FakeProc,
+    fake_taskkill: _FakeTaskkill,
+) -> None:
+    """Windows: sweep and job-object kill both failing degrades to ``proc.kill()``."""
+    fake_taskkill.return_value = False
+    win_job = _FakeWinJob(terminate_result=False)
+
+    await terminate_subtree_with_grace(fake_proc, win_job=win_job)  # type: ignore[arg-type]
+
     assert fake_proc.kill_calls == 1
 
 
 @windows_only
 async def test_terminate_subtree_with_grace_without_job_object_uses_taskkill(
     fake_proc: _FakeProc,
-    fake_taskkill: list[int],
+    fake_taskkill: _FakeTaskkill,
 ) -> None:
-    """Windows: no job object preserves the taskkill-first chain."""
+    """Windows: no job object — a successful taskkill sweep alone suffices."""
     await terminate_subtree_with_grace(fake_proc)  # type: ignore[arg-type]
 
-    assert fake_taskkill == [fake_proc.pid]
-    assert fake_proc.kill_calls == 1
+    assert fake_taskkill.calls == [fake_proc.pid]
+    assert fake_proc.kill_calls == 0

--- a/tests/test_helpers_process.py
+++ b/tests/test_helpers_process.py
@@ -285,11 +285,7 @@ async def test_terminate_subtree_with_grace_sweeps_before_job_object(
     fake_proc: _FakeProc,
     fake_taskkill: _FakeTaskkill,
 ) -> None:
-    """Windows: taskkill sweeps the live tree first, then the job object fires — no ``proc.kill()``.
-
-    Ordering is load-bearing: a child spawned before the job assignment
-    is only reachable by the PID walk while the tracked parent is alive.
-    """
+    """Windows: taskkill sweeps the live tree first, then the job object — no ``proc.kill()``."""
     win_job = _FakeWinJob()
 
     await terminate_subtree_with_grace(fake_proc, win_job=win_job)  # type: ignore[arg-type]

--- a/tests/test_helpers_windows_job_object.py
+++ b/tests/test_helpers_windows_job_object.py
@@ -92,6 +92,12 @@ def fake_win32(monkeypatch: pytest.MonkeyPatch) -> _FakeWin32:
     return fake
 
 
+def test_create_for_pid_none_without_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No pywin32 (POSIX) → no job object; the caller's taskkill fallback owns the kill."""
+    monkeypatch.setattr(wjo_module, "win32job", None)
+    assert WindowsJobObject.create_for_pid(4242) is None
+
+
 def test_create_for_pid_happy_path(fake_win32: _FakeWin32) -> None:
     """Create → kill-on-close limit → open pid → assign → close the process handle."""
     job = WindowsJobObject.create_for_pid(4242)
@@ -165,3 +171,20 @@ def test_close_is_idempotent(fake_win32: _FakeWin32) -> None:
     job.close()
     job.close()
     assert fake_win32.job.close_calls == 1
+
+
+def test_close_failure_is_logged_not_raised(
+    fake_win32: _FakeWin32, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A failing CloseHandle warns (possible leaked tree) and still marks the wrapper closed."""
+
+    class _RefusingHandle(_FakeHandle):
+        def Close(self) -> None:  # noqa: N802
+            super().Close()
+            raise _Win32Error(6, "CloseHandle", "invalid handle")
+
+    job = WindowsJobObject(_RefusingHandle("job"))
+    with caplog.at_level("WARNING"):
+        job.close()
+    assert any("Closing job object failed" in rec.getMessage() for rec in caplog.records)
+    assert job.terminate() is False

--- a/tests/test_helpers_windows_job_object.py
+++ b/tests/test_helpers_windows_job_object.py
@@ -98,6 +98,17 @@ def test_create_for_pid_none_without_bindings(monkeypatch: pytest.MonkeyPatch) -
     assert WindowsJobObject.create_for_pid(4242) is None
 
 
+def test_missing_bindings_on_windows_warn(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A broken pywin32 on a real Windows host degrades loudly, not silently."""
+    monkeypatch.setattr(wjo_module, "win32job", None)
+    monkeypatch.setattr(wjo_module.sys, "platform", "win32")
+    with caplog.at_level("WARNING"):
+        assert WindowsJobObject.create_for_pid(4242) is None
+    assert any("pywin32 is unavailable" in rec.getMessage() for rec in caplog.records)
+
+
 def test_create_for_pid_happy_path(fake_win32: _FakeWin32) -> None:
     """Create → kill-on-close limit → open pid → assign → close the process handle."""
     job = WindowsJobObject.create_for_pid(4242)
@@ -134,9 +145,10 @@ def test_create_for_pid_happy_path(fake_win32: _FakeWin32) -> None:
     ["CreateJobObject", "SetInformationJobObject", "OpenProcess", "AssignProcessToJobObject"],
 )
 def test_create_for_pid_none_on_failure(fake_win32: _FakeWin32, fail_at: str) -> None:
-    """A win32 error at any step logs and returns None instead of raising."""
+    """A win32 error at any step returns None and releases the job handle."""
     fake_win32.fail_at = fail_at
     assert WindowsJobObject.create_for_pid(4242) is None
+    assert fake_win32.job.close_calls == (0 if fail_at == "CreateJobObject" else 1)
 
 
 def test_create_for_pid_assign_failure_still_closes_process_handle(

--- a/tests/test_helpers_windows_job_object.py
+++ b/tests/test_helpers_windows_job_object.py
@@ -1,11 +1,4 @@
-"""Tests for ``helpers/windows_job_object.py`` — the Win32 tree-kill primitive.
-
-Cross-platform: the module's pywin32 bindings are monkeypatched with
-recording fakes, so the create → set-limits → assign sequence and every
-failure branch run on any OS in the matrix. Real-kernel coverage lives
-in the windows-only integration test in
-``tests/controllers/firmware/test_stop_windows.py``.
-"""
+"""``WindowsJobObject`` unit tests over recording pywin32 fakes, runnable on any OS."""
 
 from __future__ import annotations
 

--- a/tests/test_helpers_windows_job_object.py
+++ b/tests/test_helpers_windows_job_object.py
@@ -11,19 +11,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 
 from esphome_device_builder.helpers import windows_job_object as wjo_module
-from esphome_device_builder.helpers.windows_job_object import (
-    _PROCESS_SET_QUOTA,
-    _PROCESS_TERMINATE,
-    WindowsJobObject,
-)
-
-_KILL_ON_JOB_CLOSE = 0x2000
-_EXTENDED_INFO_CLASS = 9
+from esphome_device_builder.helpers.windows_job_object import WindowsJobObject
 
 
 class _Win32Error(Exception):
@@ -43,10 +36,14 @@ class _FakeHandle:
 
 @dataclass
 class _FakeWin32:
-    """Recording ``win32job`` + ``win32api`` stand-in with failure toggles."""
+    """Recording ``win32job`` + ``win32api`` + ``win32con`` stand-in with a failure toggle."""
+
+    JobObjectExtendedLimitInformation: ClassVar[int] = 9
+    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE: ClassVar[int] = 0x2000
+    PROCESS_SET_QUOTA: ClassVar[int] = 0x0100
+    PROCESS_TERMINATE: ClassVar[int] = 0x0001
 
     fail_at: str | None = None
-    terminate_error: bool = False
     calls: list[tuple[str, tuple[Any, ...]]] = field(default_factory=list)
     job: _FakeHandle = field(default_factory=lambda: _FakeHandle("job"))
     proc: _FakeHandle = field(default_factory=lambda: _FakeHandle("proc"))
@@ -78,9 +75,7 @@ class _FakeWin32:
         self._record("AssignProcessToJobObject", args)
 
     def TerminateJobObject(self, *args: Any) -> None:  # noqa: N802
-        self.calls.append(("TerminateJobObject", args))
-        if self.terminate_error:
-            raise _Win32Error(6, "TerminateJobObject", "invalid handle")
+        self._record("TerminateJobObject", args)
 
     def names(self) -> list[str]:
         return [name for name, _ in self.calls]
@@ -90,10 +85,9 @@ class _FakeWin32:
 def fake_win32(monkeypatch: pytest.MonkeyPatch) -> _FakeWin32:
     """Patch the module's pywin32 bindings with a recording fake."""
     fake = _FakeWin32()
-    fake.JobObjectExtendedLimitInformation = _EXTENDED_INFO_CLASS  # type: ignore[attr-defined]
-    fake.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = _KILL_ON_JOB_CLOSE  # type: ignore[attr-defined]
     monkeypatch.setattr(wjo_module, "win32job", fake)
     monkeypatch.setattr(wjo_module, "win32api", fake)
+    monkeypatch.setattr(wjo_module, "win32con", fake)
     monkeypatch.setattr(wjo_module, "pywintypes", SimpleNamespace(error=_Win32Error))
     return fake
 
@@ -111,9 +105,18 @@ def test_create_for_pid_happy_path(fake_win32: _FakeWin32) -> None:
         "AssignProcessToJobObject",
     ]
     set_args = fake_win32.calls[2][1]
-    assert set_args == (fake_win32.job, _EXTENDED_INFO_CLASS, fake_win32.info)
-    assert fake_win32.info["BasicLimitInformation"]["LimitFlags"] & _KILL_ON_JOB_CLOSE
-    assert fake_win32.calls[3][1] == (_PROCESS_SET_QUOTA | _PROCESS_TERMINATE, 0, 4242)
+    assert set_args == (
+        fake_win32.job,
+        _FakeWin32.JobObjectExtendedLimitInformation,
+        fake_win32.info,
+    )
+    limit_flags = fake_win32.info["BasicLimitInformation"]["LimitFlags"]
+    assert limit_flags & _FakeWin32.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+    assert fake_win32.calls[3][1] == (
+        _FakeWin32.PROCESS_SET_QUOTA | _FakeWin32.PROCESS_TERMINATE,
+        0,
+        4242,
+    )
     assert fake_win32.calls[4][1] == (fake_win32.job, fake_win32.proc)
     # Only the short-lived process handle is released; the job handle stays open.
     assert fake_win32.proc.close_calls == 1
@@ -144,7 +147,7 @@ def test_terminate_maps_kernel_result(fake_win32: _FakeWin32) -> None:
     job = WindowsJobObject(fake_win32.job)
     assert job.terminate() is True
     assert fake_win32.calls[-1] == ("TerminateJobObject", (fake_win32.job, 1))
-    fake_win32.terminate_error = True
+    fake_win32.fail_at = "TerminateJobObject"
     assert job.terminate() is False
 
 

--- a/tests/test_helpers_windows_job_object.py
+++ b/tests/test_helpers_windows_job_object.py
@@ -1,0 +1,153 @@
+"""Tests for ``helpers/windows_job_object.py`` — the Win32 tree-kill primitive.
+
+Cross-platform: the cached ``_kernel32`` accessor is monkeypatched with
+a recording fake, so the create → set-limits → assign call sequence and
+every failure branch run on any OS in the matrix. Real-kernel coverage
+lives in the windows-only integration test in
+``tests/controllers/firmware/test_stop_windows.py``.
+"""
+
+from __future__ import annotations
+
+import ctypes
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from esphome_device_builder.helpers import windows_job_object as wjo_module
+from esphome_device_builder.helpers.windows_job_object import (
+    _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS,
+    _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    _PROCESS_SET_QUOTA,
+    _PROCESS_TERMINATE,
+    WindowsJobObject,
+)
+
+_JOB_HANDLE = 0x1111
+_PROC_HANDLE = 0x2222
+
+
+@dataclass
+class _FakeKernel32:
+    """Recording kernel32 stand-in with tunable per-call return values."""
+
+    create_job_result: int | None = _JOB_HANDLE
+    set_information_result: int = 1
+    open_process_result: int | None = _PROC_HANDLE
+    assign_result: int = 1
+    terminate_result: int = 1
+    calls: list[tuple[str, tuple[Any, ...]]] = field(default_factory=list)
+    closed_handles: list[int] = field(default_factory=list)
+
+    def CreateJobObjectW(self, *args: Any) -> int | None:  # noqa: N802
+        self.calls.append(("CreateJobObjectW", args))
+        return self.create_job_result
+
+    def SetInformationJobObject(self, *args: Any) -> int:  # noqa: N802
+        self.calls.append(("SetInformationJobObject", args))
+        return self.set_information_result
+
+    def OpenProcess(self, *args: Any) -> int | None:  # noqa: N802
+        self.calls.append(("OpenProcess", args))
+        return self.open_process_result
+
+    def AssignProcessToJobObject(self, *args: Any) -> int:  # noqa: N802
+        self.calls.append(("AssignProcessToJobObject", args))
+        return self.assign_result
+
+    def TerminateJobObject(self, *args: Any) -> int:  # noqa: N802
+        self.calls.append(("TerminateJobObject", args))
+        return self.terminate_result
+
+    def CloseHandle(self, handle: int) -> int:  # noqa: N802
+        self.calls.append(("CloseHandle", (handle,)))
+        self.closed_handles.append(handle)
+        return 1
+
+    def names(self) -> list[str]:
+        return [name for name, _ in self.calls]
+
+
+@pytest.fixture
+def fake_kernel32(monkeypatch: pytest.MonkeyPatch) -> _FakeKernel32:
+    """Patch the cached ``_kernel32`` accessor with a recording fake."""
+    fake = _FakeKernel32()
+    monkeypatch.setattr(wjo_module, "_kernel32", lambda: fake)
+    return fake
+
+
+def test_create_for_pid_happy_path(fake_kernel32: _FakeKernel32) -> None:
+    """Create → kill-on-close limit → open pid → assign → close the process handle."""
+    job = WindowsJobObject.create_for_pid(4242)
+
+    assert job is not None
+    assert fake_kernel32.names() == [
+        "CreateJobObjectW",
+        "SetInformationJobObject",
+        "OpenProcess",
+        "AssignProcessToJobObject",
+        "CloseHandle",
+    ]
+    set_args = fake_kernel32.calls[1][1]
+    assert set_args[0] == _JOB_HANDLE
+    assert set_args[1] == _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS
+    info = ctypes.cast(set_args[2], ctypes.POINTER(wjo_module._JobObjectExtendedLimitInformation))
+    assert info.contents.BasicLimitInformation.LimitFlags == _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+    assert fake_kernel32.calls[2][1] == (_PROCESS_SET_QUOTA | _PROCESS_TERMINATE, 0, 4242)
+    assert fake_kernel32.calls[3][1] == (_JOB_HANDLE, _PROC_HANDLE)
+    # Only the short-lived process handle is released; the job handle stays open.
+    assert fake_kernel32.closed_handles == [_PROC_HANDLE]
+
+
+def test_create_for_pid_none_when_create_fails(fake_kernel32: _FakeKernel32) -> None:
+    """A NULL job handle short-circuits with nothing to close."""
+    fake_kernel32.create_job_result = None
+    assert WindowsJobObject.create_for_pid(4242) is None
+    assert fake_kernel32.closed_handles == []
+
+
+def test_create_for_pid_none_when_set_information_fails(fake_kernel32: _FakeKernel32) -> None:
+    """A failed limit set closes the job handle and returns None."""
+    fake_kernel32.set_information_result = 0
+    assert WindowsJobObject.create_for_pid(4242) is None
+    assert fake_kernel32.closed_handles == [_JOB_HANDLE]
+
+
+def test_create_for_pid_none_when_open_process_fails(fake_kernel32: _FakeKernel32) -> None:
+    """An unopenable pid closes the job handle and returns None."""
+    fake_kernel32.open_process_result = None
+    assert WindowsJobObject.create_for_pid(4242) is None
+    assert fake_kernel32.closed_handles == [_JOB_HANDLE]
+
+
+def test_create_for_pid_none_when_assign_fails(fake_kernel32: _FakeKernel32) -> None:
+    """A failed assignment closes both handles and returns None."""
+    fake_kernel32.assign_result = 0
+    assert WindowsJobObject.create_for_pid(4242) is None
+    assert fake_kernel32.closed_handles == [_PROC_HANDLE, _JOB_HANDLE]
+
+
+def test_terminate_maps_kernel_result(fake_kernel32: _FakeKernel32) -> None:
+    """``terminate`` reports the kernel verdict and targets the held handle."""
+    job = WindowsJobObject(_JOB_HANDLE)
+    assert job.terminate() is True
+    assert fake_kernel32.calls[-1] == ("TerminateJobObject", (_JOB_HANDLE, 1))
+    fake_kernel32.terminate_result = 0
+    assert job.terminate() is False
+
+
+def test_terminate_false_after_close(fake_kernel32: _FakeKernel32) -> None:
+    """A closed wrapper refuses to terminate (no handle to target)."""
+    job = WindowsJobObject(_JOB_HANDLE)
+    job.close()
+    assert job.terminate() is False
+    assert "TerminateJobObject" not in fake_kernel32.names()
+
+
+def test_close_is_idempotent(fake_kernel32: _FakeKernel32) -> None:
+    """Double-close releases the handle exactly once."""
+    job = WindowsJobObject(_JOB_HANDLE)
+    job.close()
+    job.close()
+    assert fake_kernel32.closed_handles == [_JOB_HANDLE]

--- a/tests/test_helpers_windows_job_object.py
+++ b/tests/test_helpers_windows_job_object.py
@@ -1,153 +1,164 @@
 """Tests for ``helpers/windows_job_object.py`` — the Win32 tree-kill primitive.
 
-Cross-platform: the cached ``_kernel32`` accessor is monkeypatched with
-a recording fake, so the create → set-limits → assign call sequence and
-every failure branch run on any OS in the matrix. Real-kernel coverage
-lives in the windows-only integration test in
+Cross-platform: the module's pywin32 bindings are monkeypatched with
+recording fakes, so the create → set-limits → assign sequence and every
+failure branch run on any OS in the matrix. Real-kernel coverage lives
+in the windows-only integration test in
 ``tests/controllers/firmware/test_stop_windows.py``.
 """
 
 from __future__ import annotations
 
-import ctypes
 from dataclasses import dataclass, field
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
 from esphome_device_builder.helpers import windows_job_object as wjo_module
 from esphome_device_builder.helpers.windows_job_object import (
-    _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS,
-    _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
     _PROCESS_SET_QUOTA,
     _PROCESS_TERMINATE,
     WindowsJobObject,
 )
 
-_JOB_HANDLE = 0x1111
-_PROC_HANDLE = 0x2222
+_KILL_ON_JOB_CLOSE = 0x2000
+_EXTENDED_INFO_CLASS = 9
+
+
+class _Win32Error(Exception):
+    """Stands in for ``pywintypes.error``."""
+
+
+class _FakeHandle:
+    """PyHANDLE stand-in: records closes, idempotent like the real thing."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.close_calls = 0
+
+    def Close(self) -> None:  # noqa: N802
+        self.close_calls += 1
 
 
 @dataclass
-class _FakeKernel32:
-    """Recording kernel32 stand-in with tunable per-call return values."""
+class _FakeWin32:
+    """Recording ``win32job`` + ``win32api`` stand-in with failure toggles."""
 
-    create_job_result: int | None = _JOB_HANDLE
-    set_information_result: int = 1
-    open_process_result: int | None = _PROC_HANDLE
-    assign_result: int = 1
-    terminate_result: int = 1
+    fail_at: str | None = None
+    terminate_error: bool = False
     calls: list[tuple[str, tuple[Any, ...]]] = field(default_factory=list)
-    closed_handles: list[int] = field(default_factory=list)
+    job: _FakeHandle = field(default_factory=lambda: _FakeHandle("job"))
+    proc: _FakeHandle = field(default_factory=lambda: _FakeHandle("proc"))
+    info: dict[str, Any] = field(
+        default_factory=lambda: {"BasicLimitInformation": {"LimitFlags": 0}}
+    )
 
-    def CreateJobObjectW(self, *args: Any) -> int | None:  # noqa: N802
-        self.calls.append(("CreateJobObjectW", args))
-        return self.create_job_result
+    def _record(self, name: str, args: tuple[Any, ...]) -> None:
+        self.calls.append((name, args))
+        if self.fail_at == name:
+            raise _Win32Error(5, name, "denied")
 
-    def SetInformationJobObject(self, *args: Any) -> int:  # noqa: N802
-        self.calls.append(("SetInformationJobObject", args))
-        return self.set_information_result
+    def CreateJobObject(self, *args: Any) -> _FakeHandle:  # noqa: N802
+        self._record("CreateJobObject", args)
+        return self.job
 
-    def OpenProcess(self, *args: Any) -> int | None:  # noqa: N802
-        self.calls.append(("OpenProcess", args))
-        return self.open_process_result
+    def QueryInformationJobObject(self, *args: Any) -> dict[str, Any]:  # noqa: N802
+        self._record("QueryInformationJobObject", args)
+        return self.info
 
-    def AssignProcessToJobObject(self, *args: Any) -> int:  # noqa: N802
-        self.calls.append(("AssignProcessToJobObject", args))
-        return self.assign_result
+    def SetInformationJobObject(self, *args: Any) -> None:  # noqa: N802
+        self._record("SetInformationJobObject", args)
 
-    def TerminateJobObject(self, *args: Any) -> int:  # noqa: N802
+    def OpenProcess(self, *args: Any) -> _FakeHandle:  # noqa: N802
+        self._record("OpenProcess", args)
+        return self.proc
+
+    def AssignProcessToJobObject(self, *args: Any) -> None:  # noqa: N802
+        self._record("AssignProcessToJobObject", args)
+
+    def TerminateJobObject(self, *args: Any) -> None:  # noqa: N802
         self.calls.append(("TerminateJobObject", args))
-        return self.terminate_result
-
-    def CloseHandle(self, handle: int) -> int:  # noqa: N802
-        self.calls.append(("CloseHandle", (handle,)))
-        self.closed_handles.append(handle)
-        return 1
+        if self.terminate_error:
+            raise _Win32Error(6, "TerminateJobObject", "invalid handle")
 
     def names(self) -> list[str]:
         return [name for name, _ in self.calls]
 
 
 @pytest.fixture
-def fake_kernel32(monkeypatch: pytest.MonkeyPatch) -> _FakeKernel32:
-    """Patch the cached ``_kernel32`` accessor with a recording fake."""
-    fake = _FakeKernel32()
-    monkeypatch.setattr(wjo_module, "_kernel32", lambda: fake)
+def fake_win32(monkeypatch: pytest.MonkeyPatch) -> _FakeWin32:
+    """Patch the module's pywin32 bindings with a recording fake."""
+    fake = _FakeWin32()
+    fake.JobObjectExtendedLimitInformation = _EXTENDED_INFO_CLASS  # type: ignore[attr-defined]
+    fake.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = _KILL_ON_JOB_CLOSE  # type: ignore[attr-defined]
+    monkeypatch.setattr(wjo_module, "win32job", fake)
+    monkeypatch.setattr(wjo_module, "win32api", fake)
+    monkeypatch.setattr(wjo_module, "pywintypes", SimpleNamespace(error=_Win32Error))
     return fake
 
 
-def test_create_for_pid_happy_path(fake_kernel32: _FakeKernel32) -> None:
+def test_create_for_pid_happy_path(fake_win32: _FakeWin32) -> None:
     """Create → kill-on-close limit → open pid → assign → close the process handle."""
     job = WindowsJobObject.create_for_pid(4242)
 
     assert job is not None
-    assert fake_kernel32.names() == [
-        "CreateJobObjectW",
+    assert fake_win32.names() == [
+        "CreateJobObject",
+        "QueryInformationJobObject",
         "SetInformationJobObject",
         "OpenProcess",
         "AssignProcessToJobObject",
-        "CloseHandle",
     ]
-    set_args = fake_kernel32.calls[1][1]
-    assert set_args[0] == _JOB_HANDLE
-    assert set_args[1] == _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS
-    info = ctypes.cast(set_args[2], ctypes.POINTER(wjo_module._JobObjectExtendedLimitInformation))
-    assert info.contents.BasicLimitInformation.LimitFlags == _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
-    assert fake_kernel32.calls[2][1] == (_PROCESS_SET_QUOTA | _PROCESS_TERMINATE, 0, 4242)
-    assert fake_kernel32.calls[3][1] == (_JOB_HANDLE, _PROC_HANDLE)
+    set_args = fake_win32.calls[2][1]
+    assert set_args == (fake_win32.job, _EXTENDED_INFO_CLASS, fake_win32.info)
+    assert fake_win32.info["BasicLimitInformation"]["LimitFlags"] & _KILL_ON_JOB_CLOSE
+    assert fake_win32.calls[3][1] == (_PROCESS_SET_QUOTA | _PROCESS_TERMINATE, 0, 4242)
+    assert fake_win32.calls[4][1] == (fake_win32.job, fake_win32.proc)
     # Only the short-lived process handle is released; the job handle stays open.
-    assert fake_kernel32.closed_handles == [_PROC_HANDLE]
+    assert fake_win32.proc.close_calls == 1
+    assert fake_win32.job.close_calls == 0
 
 
-def test_create_for_pid_none_when_create_fails(fake_kernel32: _FakeKernel32) -> None:
-    """A NULL job handle short-circuits with nothing to close."""
-    fake_kernel32.create_job_result = None
+@pytest.mark.parametrize(
+    "fail_at",
+    ["CreateJobObject", "SetInformationJobObject", "OpenProcess", "AssignProcessToJobObject"],
+)
+def test_create_for_pid_none_on_failure(fake_win32: _FakeWin32, fail_at: str) -> None:
+    """A win32 error at any step logs and returns None instead of raising."""
+    fake_win32.fail_at = fail_at
     assert WindowsJobObject.create_for_pid(4242) is None
-    assert fake_kernel32.closed_handles == []
 
 
-def test_create_for_pid_none_when_set_information_fails(fake_kernel32: _FakeKernel32) -> None:
-    """A failed limit set closes the job handle and returns None."""
-    fake_kernel32.set_information_result = 0
+def test_create_for_pid_assign_failure_still_closes_process_handle(
+    fake_win32: _FakeWin32,
+) -> None:
+    """The process handle is released even when assignment raises."""
+    fake_win32.fail_at = "AssignProcessToJobObject"
     assert WindowsJobObject.create_for_pid(4242) is None
-    assert fake_kernel32.closed_handles == [_JOB_HANDLE]
+    assert fake_win32.proc.close_calls == 1
 
 
-def test_create_for_pid_none_when_open_process_fails(fake_kernel32: _FakeKernel32) -> None:
-    """An unopenable pid closes the job handle and returns None."""
-    fake_kernel32.open_process_result = None
-    assert WindowsJobObject.create_for_pid(4242) is None
-    assert fake_kernel32.closed_handles == [_JOB_HANDLE]
-
-
-def test_create_for_pid_none_when_assign_fails(fake_kernel32: _FakeKernel32) -> None:
-    """A failed assignment closes both handles and returns None."""
-    fake_kernel32.assign_result = 0
-    assert WindowsJobObject.create_for_pid(4242) is None
-    assert fake_kernel32.closed_handles == [_PROC_HANDLE, _JOB_HANDLE]
-
-
-def test_terminate_maps_kernel_result(fake_kernel32: _FakeKernel32) -> None:
+def test_terminate_maps_kernel_result(fake_win32: _FakeWin32) -> None:
     """``terminate`` reports the kernel verdict and targets the held handle."""
-    job = WindowsJobObject(_JOB_HANDLE)
+    job = WindowsJobObject(fake_win32.job)
     assert job.terminate() is True
-    assert fake_kernel32.calls[-1] == ("TerminateJobObject", (_JOB_HANDLE, 1))
-    fake_kernel32.terminate_result = 0
+    assert fake_win32.calls[-1] == ("TerminateJobObject", (fake_win32.job, 1))
+    fake_win32.terminate_error = True
     assert job.terminate() is False
 
 
-def test_terminate_false_after_close(fake_kernel32: _FakeKernel32) -> None:
+def test_terminate_false_after_close(fake_win32: _FakeWin32) -> None:
     """A closed wrapper refuses to terminate (no handle to target)."""
-    job = WindowsJobObject(_JOB_HANDLE)
+    job = WindowsJobObject(fake_win32.job)
     job.close()
     assert job.terminate() is False
-    assert "TerminateJobObject" not in fake_kernel32.names()
+    assert "TerminateJobObject" not in fake_win32.names()
 
 
-def test_close_is_idempotent(fake_kernel32: _FakeKernel32) -> None:
+def test_close_is_idempotent(fake_win32: _FakeWin32) -> None:
     """Double-close releases the handle exactly once."""
-    job = WindowsJobObject(_JOB_HANDLE)
+    job = WindowsJobObject(fake_win32.job)
     job.close()
     job.close()
-    assert fake_kernel32.closed_handles == [_JOB_HANDLE]
+    assert fake_win32.job.close_calls == 1


### PR DESCRIPTION
# What does this implement/fix?

On Windows, cancelling a RUNNING compile did not stop it; the build ran to completion and only then flipped to CANCELLED. Two gaps combined to produce that. First, `start_new_session=True` is POSIX only, so a Windows spawn had no tree kill primitive beyond `taskkill /F /T`, and every taskkill failure mode fell back to killing only the direct child, which on a pip install is the `Scripts\esphome.exe` launcher; the python child and the whole platformio and gcc tree below it survived. Second, job finalisation was gated on stdout pipe EOF, and since the chain runs with `close_fds=False`, any surviving descendant holds the inherited write handle, so the job could not finalise until the last compiler exited.

The fix makes a kill-on-close Win32 job object the Windows kill primitive: `tracked_subprocess` assigns each spawn to one right after `create_subprocess_exec` returns. The terminate path runs `taskkill /F /T` first, while the tracked parent is still alive to walk the PID tree from, then `TerminateJobObject` atomically kills every job member; `proc.kill()` is the last resort when both fail. Sweep first ordering matters because the launcher stub can spawn python before the job assignment lands, and such a child is in no job; the sweep is the only kill that reaches it. The wrapper uses pywin32's `win32job` bindings (a new Windows only dependency) rather than hand rolled ctypes structs; esphome-desktop uses the same primitive through the official windows crate. The kill-on-close flag also reaps the tree if the dashboard dies with the handle open. Separately, the output loop is replaced by `_pump_output_until_exit`, which races the reader against the tracked process's reap (asyncio's `Process.wait` resolves only after every pipe disconnects, but `returncode` is stamped promptly); once the process is gone and the job is cancel flagged, the pipe gets a one second drain window and is abandoned, so the job finalises promptly even if a straggler survives holding the pipe.

New coverage: cross platform unit tests for the job object wrapper and the three stage kill chain, a windows-only integration test proving the job object kills a grandchild, pipe drain tests for the pump, and an e2e `firmware/cancel` test that spawns a real process tree and runs on the Windows CI leg with no skipif; it fails on the previous code both ways (tree survives, finalisation stalls).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2552

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
