### PR TITLE
Give the download types sentinel a firmware path for esphome 2026.9

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -3782,7 +3782,9 @@ def _emit_platform_capabilities_index() -> None:
     # ``{title, description, file}`` with a sentinel storage. libretiny (reads
     # the build's firmware.json) and nrf52 (probes built files) are build-dir
     # dependent and stay out of the index — device-builder-helper handles them.
-    sentinel = SimpleNamespace(name="{name}")
+    # firmware_bin_path must be set: since esphome 2026.9 an unset path
+    # means "never built" and get_download_types returns no entries.
+    sentinel = SimpleNamespace(name="{name}", firmware_bin_path="firmware.bin")
     download_types: dict[str, list[dict[str, str]]] = {}
     for component in ("esp32", "esp8266", RP2_CANONICAL_PLATFORM):
         module = importlib.import_module(f"esphome.components.{component}")

--- a/tests/test_platform_capabilities.py
+++ b/tests/test_platform_capabilities.py
@@ -67,7 +67,9 @@ def test_index_within_installed_esphome() -> None:
     installed_no_wifi_boards = {
         board for board, info in BOARDS.items() if not info.get("wifi", False)
     }
-    sentinel = SimpleNamespace(name="{name}")
+    # firmware_bin_path must be set: since esphome 2026.9 an unset path
+    # means "never built" and get_download_types returns no entries.
+    sentinel = SimpleNamespace(name="{name}", firmware_bin_path="firmware.bin")
     pairs = [
         (set(caps.esp32_variants), set(VARIANTS)),
         (set(caps.esp32_no_wifi_variants), set(NO_WIFI_VARIANTS)),


### PR DESCRIPTION
# What does this implement/fix?

esphome/esphome#18367 changes every platform's `get_download_types` to return no entries when the sidecar records no `firmware_bin_path`, since an unset path now means nothing was built. The catalog sync script and the platform capabilities test call it with a plain `SimpleNamespace` sentinel that has no `firmware_bin_path` attribute at all, so that guard would raise `AttributeError` once the esphome change reaches the channels CI and the nightly catalog sync. Give the sentinel a firmware path; the extra attribute is ignored by released esphome, and the new esphome sees a set path and keeps returning the static entries.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
