### PR TITLE
Treat per-platform AUTO_LOAD arms as alternatives in the catalog sync

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -2622,6 +2622,48 @@ def _assemble_dependencies(
     return dependencies
 
 
+def _prune_alternative_platform_deps(dependencies: list[str], meta: dict[str, Any]) -> list[str]:
+    """
+    Drop closure platform deps naming several platforms.
+
+    A callable ``AUTO_LOAD`` resolved without a target platform unions its
+    per-platform arms, so their platform deps are alternatives, not
+    conjunctive requirements; schema-direct platform deps stay. The unpruned
+    list still feeds ``_platform_arm_alternatives`` so the arms count.
+    """
+    platforms = {normalize_platform(dep) for dep in dependencies if dep in _TARGET_PLATFORMS}
+    if len(platforms) <= 1:
+        return dependencies
+    direct = {dep for dep in meta.get("dependencies") or [] if dep in _TARGET_PLATFORMS}
+    return [dep for dep in dependencies if dep not in _TARGET_PLATFORMS or dep in direct]
+
+
+def _platform_arm_alternatives(
+    domain: str, stem_or_key: str, dependencies: list[str]
+) -> list[str] | None:
+    """
+    Supported chips for a component whose deps name several platforms.
+
+    Re-resolves the ``AUTO_LOAD`` closure once per target chip; a chip is
+    supported when its arm's platform deps name no other chip. ``None``
+    when the deps name at most one platform, or no chip qualifies.
+    """
+    named = {normalize_platform(dep) for dep in dependencies if dep in _TARGET_PLATFORMS}
+    if len(named) <= 1:
+        return None
+    admitted = [
+        chip
+        for chip in sorted(_target_platform_names() - {"libretiny"})
+        if {
+            normalize_platform(dep)
+            for dep in _auto_loaded_dependencies(domain, stem_or_key, chip)
+            if dep in _TARGET_PLATFORMS
+        }
+        <= {chip}
+    ]
+    return admitted or None
+
+
 def build_component_entry(
     top_key: str,
     section: dict,
@@ -2714,15 +2756,18 @@ def build_component_entry(
         "category": category,
         "docs_url": _strip_anchor(docs.url or ""),
         "image_url": image_map.get(component_id) or image_map.get(stem) or "",
-        "dependencies": dependencies,
+        "dependencies": _prune_alternative_platform_deps(dependencies, meta),
         "multi_conf": (
             introspection.get("multi_conf", False) or component_id in _LIST_SCHEMA_MULTI_CONF
         ),
         "bus_constraints": bus_constraints,
-        "supported_platforms": _derive_supported_platforms(
-            stem if domain else top_key,
-            dependencies,
-            introspection,
+        "supported_platforms": (
+            _platform_arm_alternatives(domain, stem if domain else top_key, dependencies)
+            or _derive_supported_platforms(
+                stem if domain else top_key,
+                dependencies,
+                introspection,
+            )
         ),
         # Resolved against referenced classes in ``build_catalog``; the
         # raw class→path map is stashed under ``_impl_class_paths`` until then.
@@ -4767,25 +4812,25 @@ _TARGET_PLATFORMS: frozenset[str] = frozenset(
 _NETWORK_TRANSPORTS: frozenset[str] = frozenset({"wifi", "ethernet", "openthread", "host"})
 
 
-def _resolve_auto_load(raw_auto_load: Any) -> list[str]:
+def _resolve_auto_load(raw_auto_load: Any, platform: str | None = None) -> list[str]:
     """
     Resolve a possibly-callable ``AUTO_LOAD`` to a list, else ``[]``.
 
-    A callable is invoked with no target platform set, so platform-gated extras
-    drop out and only the unconditional auto-loads come through; failures (raise
-    or non-list) fall back to ``[]``.
+    A callable is invoked with *platform* as the target platform (default
+    none, so platform-gated extras drop out and only the unconditional
+    auto-loads come through); failures (raise or non-list) fall back to ``[]``.
     """
     if callable(raw_auto_load):
         try:
             from esphome.const import KEY_CORE, KEY_TARGET_PLATFORM
             from esphome.core import CORE
 
-            # Force (not setdefault) the platform-agnostic state for the call,
-            # then restore so resolution can't leak CORE state between calls.
+            # Force (not setdefault) the requested state for the call, then
+            # restore so resolution can't leak CORE state between calls.
             core = CORE.data.setdefault(KEY_CORE, {})
             had_platform = KEY_TARGET_PLATFORM in core
             prev_platform = core.get(KEY_TARGET_PLATFORM)
-            core[KEY_TARGET_PLATFORM] = None
+            core[KEY_TARGET_PLATFORM] = platform
             try:
                 raw_auto_load = raw_auto_load()
             finally:
@@ -4799,15 +4844,17 @@ def _resolve_auto_load(raw_auto_load: Any) -> list[str]:
 
 
 @cache
-def _auto_loaded_dependencies(domain: str, stem_or_key: str) -> tuple[str, ...]:
+def _auto_loaded_dependencies(
+    domain: str, stem_or_key: str, platform: str | None = None
+) -> tuple[str, ...]:
     """
     ``DEPENDENCIES`` contributed by a component's ``AUTO_LOAD`` closure.
 
     ``AUTO_LOAD`` lives on the platform manifest for ``<domain>.<stem>``
-    entries and on the component manifest for bare ones. The auto-loaded
-    components themselves are always present so they never become
-    dependencies; only what *they* require does. Empty when ``esphome``
-    isn't importable.
+    entries and on the component manifest for bare ones; callables resolve
+    against *platform*. The auto-loaded components themselves are always
+    present so they never become dependencies; only what *they* require
+    does. Empty when ``esphome`` isn't importable.
     """
     loader = _get_esphome_loader()
     if loader is None:
@@ -4827,7 +4874,7 @@ def _auto_loaded_dependencies(domain: str, stem_or_key: str) -> tuple[str, ...]:
         return ()
     collected: list[str] = []
     seen: set[str] = set()
-    queue = [name for name in _resolve_auto_load(root.auto_load) if isinstance(name, str)]
+    queue = [name for name in _resolve_auto_load(root.auto_load, platform) if isinstance(name, str)]
     while queue:
         current = queue.pop()
         if current in seen:
@@ -4840,7 +4887,9 @@ def _auto_loaded_dependencies(domain: str, stem_or_key: str) -> tuple[str, ...]:
             dep for dep in getattr(manifest, "dependencies", None) or [] if isinstance(dep, str)
         )
         queue.extend(
-            name for name in _resolve_auto_load(manifest.auto_load) if isinstance(name, str)
+            name
+            for name in _resolve_auto_load(manifest.auto_load, platform)
+            if isinstance(name, str)
         )
     # A dep that is itself auto-loaded is always present — never a dependency.
     return tuple(dict.fromkeys(dep for dep in collected if dep and dep not in seen))

--- a/tests/test_sync_components_auto_load_dependencies.py
+++ b/tests/test_sync_components_auto_load_dependencies.py
@@ -25,7 +25,7 @@ class _FakeLoader:
         return self._platforms.get((domain, name))
 
 
-def _manifest(auto_load: list[str] | None = None, dependencies: list[str] | None = None) -> Any:
+def _manifest(auto_load: Any = None, dependencies: list[str] | None = None) -> Any:
     return SimpleNamespace(auto_load=auto_load or [], dependencies=dependencies or [])
 
 
@@ -109,3 +109,110 @@ def test_real_esphome_climate_ir_lg_gains_remote_transmitter() -> None:
     """The #1991 shape against the installed esphome."""
     pytest.importorskip("esphome")
     assert "remote_transmitter" in _auto_loaded_dependencies("climate", "climate_ir_lg")
+
+
+def _assemble(meta: dict[str, Any], key: str) -> list[str]:
+    full = sc._assemble_dependencies(meta, [], "", key, key)
+    return sc._prune_alternative_platform_deps(full, meta)
+
+
+@pytest.fixture
+def _no_implicit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sc, "_implicit_dependencies", frozenset)
+
+
+def test_multi_platform_closure_deps_are_alternatives(
+    monkeypatch: pytest.MonkeyPatch, _no_implicit: None
+) -> None:
+    """The 2026.8 bluetooth_proxy shape: union arms must not become AND deps."""
+    loader = _FakeLoader(
+        components={
+            "proxy": _manifest(auto_load=["conn"]),
+            "conn": _manifest(auto_load=["tracker_esp32", "tracker_rp2"]),
+            "tracker_esp32": _manifest(dependencies=["esp32"]),
+            "tracker_rp2": _manifest(dependencies=["rp2"]),
+        },
+        platforms={},
+    )
+    _install(monkeypatch, loader)
+    meta = {"dependencies": ["api"]}
+    full = sc._assemble_dependencies(meta, [], "", "proxy", "proxy")
+    assert set(full) == {"api", "esp32", "rp2"}
+    assert sc._prune_alternative_platform_deps(full, meta) == ["api"]
+    assert set(sc._derive_supported_platforms("proxy", full, {})) == {"esp32", "rp2"}
+
+
+def test_single_platform_closure_dep_still_narrows(
+    monkeypatch: pytest.MonkeyPatch, _no_implicit: None
+) -> None:
+    loader = _FakeLoader(
+        components={
+            "leaf": _manifest(auto_load=["tracker"]),
+            "tracker": _manifest(dependencies=["esp32"]),
+        },
+        platforms={},
+    )
+    _install(monkeypatch, loader)
+    assert _assemble({}, "leaf") == ["esp32"]
+
+
+def test_direct_platform_dep_survives_closure_conflict(
+    monkeypatch: pytest.MonkeyPatch, _no_implicit: None
+) -> None:
+    loader = _FakeLoader(
+        components={
+            "leaf": _manifest(auto_load=["backend"]),
+            "backend": _manifest(dependencies=["rp2"]),
+        },
+        platforms={},
+    )
+    _install(monkeypatch, loader)
+    assert _assemble({"dependencies": ["esp32"]}, "leaf") == ["esp32"]
+
+
+def test_rp2_alias_counts_as_one_platform(
+    monkeypatch: pytest.MonkeyPatch, _no_implicit: None
+) -> None:
+    loader = _FakeLoader(
+        components={
+            "leaf": _manifest(auto_load=["backend"]),
+            "backend": _manifest(dependencies=["rp2040"]),
+        },
+        platforms={},
+    )
+    _install(monkeypatch, loader)
+    assert _assemble({"dependencies": ["rp2"]}, "leaf") == ["rp2", "rp2040"]
+
+
+def test_platform_arm_alternatives_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Per-chip AUTO_LOAD arms admit exactly the chips with no foreign platform dep."""
+    esphome_core = pytest.importorskip("esphome.core")
+
+    def _arm(mapping: dict[str, list[str]], default: list[str]) -> Any:
+        def auto_load() -> list[str]:
+            return mapping.get(esphome_core.CORE.target_platform, default)
+
+        return auto_load
+
+    loader = _FakeLoader(
+        components={
+            "proxy": _manifest(
+                auto_load=_arm(
+                    {
+                        "esp32": ["tracker_esp32"],
+                        "bk72xx": ["base"],
+                        "rp2": ["tracker_rp2"],
+                    },
+                    ["tracker_esp32", "tracker_rp2"],
+                )
+            ),
+            "tracker_esp32": _manifest(dependencies=["esp32"]),
+            "tracker_rp2": _manifest(dependencies=["rp2"]),
+            "base": _manifest(),
+        },
+        platforms={},
+    )
+    _install(monkeypatch, loader)
+    deps = ["api", "esp32", "rp2"]
+    assert sc._platform_arm_alternatives("", "proxy", deps) == ["bk72xx", "esp32", "rp2"]
+    assert sc._platform_arm_alternatives("", "proxy", ["api", "esp32"]) is None


### PR DESCRIPTION
# What does this implement/fix?

2026.8 made bluetooth_proxy's AUTO_LOAD callable with per platform arms; resolved without a target platform it returns the union of every arm, so the closure walk collected esp32 and rp2 as if both were required, and the platform constraint propagation failed the sync as disjoint on every 2026.8 beta.

Closure platform deps naming more than one platform are alternatives, not requirements; they are now dropped from the shipped dependency list. The supported platforms are resolved by probing the AUTO_LOAD closure once per target chip, admitting each chip whose arm pulls in no foreign platform dep. bluetooth_proxy now emits dependencies `["api"]` and supported_platforms `["bk72xx", "esp32", "ln882x", "rp2"]`, matching the docs.

Verified with a full catalog build against the 2026.8.0b3 schema with esphome 2026.8.0b3 installed; the prune and probe engage only for bluetooth_proxy, every other entry is unchanged. This is only the sync fix; the min esphome pin bump and the release tracked upstream happen separately.

**Related issue or feature (if applicable):**

- related: https://github.com/esphome/esphome/issues/18386

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
