### PR TITLE
Teach the block rename rule the multi_conf list form

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -398,9 +398,10 @@ against legacy behaviour before assuming the simpler version suffices.
   hand-written code. Data-driven pairs get the migration leg *only*:
   esphome itself still accepts the legacy spelling, and the one-click
   nudge is the repair path in place of read support or write-time
-  respell (those remain bespoke-only). A `multi_conf` component's
-  block is a list the block rule can't address, so its pairs stay
-  canary-guarded. Anything else (wrapper-nested pairs like api's
+  respell (those remain bespoke-only). The block rule handles both the
+  mapping and the list form of a component block, so `multi_conf`
+  pairs ship data-driven too; platform-domain blocks (`- platform:`
+  lists) stay canary-guarded. Anything else (wrapper-nested pairs like api's
   item discriminator, registry-node renames needing the id alias) needs
   bespoke handling: hard-coded read support, a canonical respell on any
   write touching the legacy-spelled block (per the pass-through

--- a/esphome_device_builder/controllers/migrations.py
+++ b/esphome_device_builder/controllers/migrations.py
@@ -168,7 +168,9 @@ def _apply_component_block_field(lines: list[str], rule: MigrationRule) -> list[
     # inside a mapping body is a nested list, not a multi_conf item.
     list_form = False
     for idx in range(header + 1, min(end, len(lines))):
-        if in_scalar[idx]:
+        # A scalar open before the column-0 header ends at it, so a masked
+        # line can't precede the block's first content line.
+        if in_scalar[idx]:  # pragma: no cover
             continue
         stripped = lines[idx].strip()
         if not stripped or stripped.startswith("#"):

--- a/esphome_device_builder/controllers/migrations.py
+++ b/esphome_device_builder/controllers/migrations.py
@@ -157,15 +157,32 @@ def _apply_generated_renames(lines: list[str]) -> list[str]:
 
 
 def _apply_component_block_field(lines: list[str], rule: MigrationRule) -> list[str]:
-    """Rename a child key of the top-level ``<component>:`` block."""
+    """Rename a child key of the top-level ``<component>:`` block, mapping or list form."""
     header = find_block_header(lines, rule.component)
     if header is None:
         return lines
-    hit = _respell_body_field(lines, header, 0, rule.old, rule.new, _block_scalar_mask(lines))
-    if hit is None:
-        return lines
+    in_scalar = _block_scalar_mask(lines)
+    end = block_end_index(lines, header)
+    items = top_list_item_starts(lines, header, end)
+    if not items:
+        hit = _respell_body_field(lines, header, 0, rule.old, rule.new, in_scalar)
+        if hit is None:
+            return lines
+        out = list(lines)
+        out[hit[0]] = hit[1]
+        return out
     out = list(lines)
-    out[hit[0]] = hit[1]
+    for item_start in items:
+        keys = _item_child_keys(lines, item_start, end, in_scalar)
+        if any(key == rule.new for _idx, _col, key in keys):
+            continue
+        target = next(((idx, col) for idx, col, key in keys if key == rule.old), None)
+        if target is None:
+            continue
+        idx, col = target
+        content = lines[idx].rstrip("\n\r")
+        eol = lines[idx][len(content) :]
+        out[idx] = content[:col] + rule.new + content[col + len(rule.old) :] + eol
     return out
 
 

--- a/esphome_device_builder/controllers/migrations.py
+++ b/esphome_device_builder/controllers/migrations.py
@@ -183,18 +183,9 @@ def _apply_component_block_field(lines: list[str], rule: MigrationRule) -> list[
         out[hit[0]] = hit[1]
         return out
     out = list(lines)
-    items = top_list_item_starts(lines, header, end)
-    for item_start in items:
+    for item_start in top_list_item_starts(lines, header, end):
         keys = _item_child_keys(lines, item_start, end, in_scalar)
-        if any(key == rule.new for _idx, _col, key in keys):
-            continue
-        target = next(((idx, col) for idx, col, key in keys if key == rule.old), None)
-        if target is None:
-            continue
-        idx, col = target
-        content = lines[idx].rstrip("\n\r")
-        eol = lines[idx][len(content) :]
-        out[idx] = content[:col] + rule.new + content[col + len(rule.old) :] + eol
+        _respell_item_key(lines, out, keys, rule.old, rule.new)
     return out
 
 
@@ -214,16 +205,27 @@ def _apply_platform_item_field(lines: list[str], rule: MigrationRule) -> list[st
         )
         if platform != rule.platform:
             continue
-        if any(key == rule.new for _idx, _col, key in keys):
-            continue
-        target = next(((idx, col) for idx, col, key in keys if key == rule.old), None)
-        if target is None:
-            continue
-        idx, col = target
-        content = lines[idx].rstrip("\n\r")
-        eol = lines[idx][len(content) :]
-        out[idx] = content[:col] + rule.new + content[col + len(rule.old) :] + eol
+        _respell_item_key(lines, out, keys, rule.old, rule.new)
     return out
+
+
+def _respell_item_key(
+    lines: list[str],
+    out: list[str],
+    keys: list[tuple[int, int, str]],
+    old: str,
+    new: str,
+) -> None:
+    """Respell a list item's *old* depth-1 key into *out*; no-op on collision or absence."""
+    if any(key == new for _idx, _col, key in keys):
+        return
+    target = next(((idx, col) for idx, col, key in keys if key == old), None)
+    if target is None:
+        return
+    idx, col = target
+    content = lines[idx].rstrip("\n\r")
+    eol = lines[idx][len(content) :]
+    out[idx] = content[:col] + new + content[col + len(old) :] + eol
 
 
 #: Upstream's closed ``CLK_MODES_DEPRECATED`` table — anything else is an

--- a/esphome_device_builder/controllers/migrations.py
+++ b/esphome_device_builder/controllers/migrations.py
@@ -22,6 +22,7 @@ from ..helpers.yaml.scan import (
     block_end_index,
     child_block_end,
     find_block_header,
+    is_list_item_line,
     leading_ws,
     top_list_item_starts,
 )
@@ -163,8 +164,18 @@ def _apply_component_block_field(lines: list[str], rule: MigrationRule) -> list[
         return lines
     in_scalar = _block_scalar_mask(lines)
     end = block_end_index(lines, header)
-    items = top_list_item_starts(lines, header, end)
-    if not items:
+    # The block's first content line decides its form; a deeper dash
+    # inside a mapping body is a nested list, not a multi_conf item.
+    list_form = False
+    for idx in range(header + 1, min(end, len(lines))):
+        if in_scalar[idx]:
+            continue
+        stripped = lines[idx].strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        list_form = is_list_item_line(stripped)
+        break
+    if not list_form:
         hit = _respell_body_field(lines, header, 0, rule.old, rule.new, in_scalar)
         if hit is None:
             return lines
@@ -172,6 +183,7 @@ def _apply_component_block_field(lines: list[str], rule: MigrationRule) -> list[
         out[hit[0]] = hit[1]
         return out
     out = list(lines)
+    items = top_list_item_starts(lines, header, end)
     for item_start in items:
         keys = _item_child_keys(lines, item_start, end, in_scalar)
         if any(key == rule.new for _idx, _col, key in keys):

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -5013,13 +5013,10 @@ def introspect_component(component_id: str) -> dict[str, Any]:
     platform_manifests = [pm for _domain, pm in platform_manifests_by_domain]
 
     manifest_multi_conf = bool(getattr(manifest, "multi_conf", False))
-    # Platform-domain blocks (sensor:, ota:, …) are - platform: lists,
-    # the same shape multi_conf makes of a component block.
-    list_form = (
-        manifest_multi_conf
-        or bool(getattr(manifest, "is_platform_component", False))
-        or component_id in _LIST_SCHEMA_MULTI_CONF
-    )
+    # Platform-domain blocks (sensor:, ota:, …) are - platform: lists whose
+    # items the block rule can't address by component key; a multi_conf
+    # component's own list form is handled by the block rule.
+    list_form = bool(getattr(manifest, "is_platform_component", False))
     _classify_rename_pairs(component_id, _collect_rename_keys(manifest), list_form=list_form)
     for domain, platform_manifest in platform_manifests_by_domain:
         _classify_rename_pairs(component_id, _collect_rename_keys(platform_manifest), domain=domain)
@@ -8449,9 +8446,9 @@ def _classify_rename_pairs(
     A *direct* pair (the validator sits on the schema's own mapping, no
     wrapper descent) is a plain child-key rename the generic migration
     engine applies; anything else needs bespoke handling. *list_form*
-    marks a ``multi_conf`` component whose block is a list —
-    ``component_block_field`` can't address those, so its pairs fall to
-    the canary.
+    marks a platform-domain block, whose ``- platform:`` items
+    ``component_block_field`` can't address, so its pairs fall to the
+    canary.
     """
     for (old, new), direct in pairs.items():
         if (component_id, old, new) in _HANDLED_RENAME_KEYS:

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -5016,8 +5016,10 @@ def introspect_component(component_id: str) -> dict[str, Any]:
     # Platform-domain blocks (sensor:, ota:, …) are - platform: lists whose
     # items the block rule can't address by component key; a multi_conf
     # component's own list form is handled by the block rule.
-    list_form = bool(getattr(manifest, "is_platform_component", False))
-    _classify_rename_pairs(component_id, _collect_rename_keys(manifest), list_form=list_form)
+    platform_domain = bool(getattr(manifest, "is_platform_component", False))
+    _classify_rename_pairs(
+        component_id, _collect_rename_keys(manifest), platform_domain=platform_domain
+    )
     for domain, platform_manifest in platform_manifests_by_domain:
         _classify_rename_pairs(component_id, _collect_rename_keys(platform_manifest), domain=domain)
 
@@ -8438,14 +8440,14 @@ def _classify_rename_pairs(
     pairs: Mapping[tuple[str, str], bool],
     *,
     domain: str | None = None,
-    list_form: bool = False,
+    platform_domain: bool = False,
 ) -> None:
     """
     Route discovered pairs: expressible → migration-rules artifact, else canary.
 
     A *direct* pair (the validator sits on the schema's own mapping, no
     wrapper descent) is a plain child-key rename the generic migration
-    engine applies; anything else needs bespoke handling. *list_form*
+    engine applies; anything else needs bespoke handling. *platform_domain*
     marks a platform-domain block, whose ``- platform:`` items
     ``component_block_field`` can't address, so its pairs fall to the
     canary.
@@ -8453,7 +8455,7 @@ def _classify_rename_pairs(
     for (old, new), direct in pairs.items():
         if (component_id, old, new) in _HANDLED_RENAME_KEYS:
             continue
-        if direct and not list_form and old != new:
+        if direct and not platform_domain and old != new:
             if domain is None:
                 _MIGRATION_RULES.add(("component_block_field", component_id, "", "", old, new))
             else:

--- a/tests/test_config_migrations.py
+++ b/tests/test_config_migrations.py
@@ -623,6 +623,12 @@ def test_component_block_field_mapping_key_before_nested_automation(generated_ru
     assert "    - lambda: 'x'\n" in new_text
 
 
+def test_component_block_field_leading_comment_does_not_decide_form(generated_rules) -> None:
+    generated_rules(_BLOCK_RULE)
+    text = "mycomp:\n  # items\n\n  - old_key: a\n"
+    assert "  - new_key: a\n" in _respell(text)
+
+
 def test_component_block_field_mapping_scalar_dash_is_not_the_form(generated_rules) -> None:
     generated_rules(_BLOCK_RULE)
     text = "mycomp:\n  lambda: |-\n    - old_key: fake\n  old_key: 1\n"

--- a/tests/test_config_migrations.py
+++ b/tests/test_config_migrations.py
@@ -605,6 +605,15 @@ def test_component_block_field_list_ignores_deeper_decoys(generated_rules) -> No
     assert render_migrations("mycomp:\n  - child:\n      old_key: 1\n") is None
 
 
+def test_component_block_field_mapping_with_nested_list_stays_mapping(generated_rules) -> None:
+    """A dash inside a mapping body is a nested list, not the multi_conf form."""
+    generated_rules(_BLOCK_RULE)
+    text = "mycomp:\n  seq:\n    - old_key: nested\n  old_key: 1\n"
+    new_text = _respell(text)
+    assert "  new_key: 1\n" in new_text
+    assert "    - old_key: nested\n" in new_text
+
+
 def test_generated_and_bespoke_rules_share_one_diff(generated_rules) -> None:
     generated_rules(_VOC_RULE)
     text = _LEGACY_API_YAML + "\n" + _SGP4X_YAML

--- a/tests/test_config_migrations.py
+++ b/tests/test_config_migrations.py
@@ -614,6 +614,23 @@ def test_component_block_field_mapping_with_nested_list_stays_mapping(generated_
     assert "    - old_key: nested\n" in new_text
 
 
+def test_component_block_field_mapping_key_before_nested_automation(generated_rules) -> None:
+    """The ble_client shape: the real key beside an on_x automation list."""
+    generated_rules(_BLOCK_RULE)
+    text = "mycomp:\n  old_key: my_tracker\n  on_connect:\n    - lambda: 'x'\n"
+    new_text = _respell(text)
+    assert "  new_key: my_tracker\n" in new_text
+    assert "    - lambda: 'x'\n" in new_text
+
+
+def test_component_block_field_mapping_scalar_dash_is_not_the_form(generated_rules) -> None:
+    generated_rules(_BLOCK_RULE)
+    text = "mycomp:\n  lambda: |-\n    - old_key: fake\n  old_key: 1\n"
+    new_text = _respell(text)
+    assert "  new_key: 1\n" in new_text
+    assert "    - old_key: fake\n" in new_text
+
+
 def test_generated_and_bespoke_rules_share_one_diff(generated_rules) -> None:
     generated_rules(_VOC_RULE)
     text = _LEGACY_API_YAML + "\n" + _SGP4X_YAML

--- a/tests/test_config_migrations.py
+++ b/tests/test_config_migrations.py
@@ -582,6 +582,29 @@ def test_component_block_field_absent_component_is_a_noop(generated_rules) -> No
     assert render_migrations("other:\n  old_key: 1\n") is None
 
 
+def test_component_block_field_list_form_renames_every_item(generated_rules) -> None:
+    """The multi_conf shape (xiaomi_rtcgq02lm esp32_ble_id -> ble_hub_id)."""
+    generated_rules(_BLOCK_RULE)
+    text = "mycomp:\n  - old_key: a  # note\n    other: 1\n  - old_key: b\n"
+    new_text = _respell(text)
+    assert "  - new_key: a  # note\n" in new_text
+    assert "  - new_key: b\n" in new_text
+    assert "    other: 1\n" in new_text
+
+
+def test_component_block_field_list_item_collision_skips_that_item(generated_rules) -> None:
+    generated_rules(_BLOCK_RULE)
+    text = "mycomp:\n  - old_key: a\n    new_key: b\n  - old_key: c\n"
+    new_text = _respell(text)
+    assert "  - old_key: a\n" in new_text
+    assert "  - new_key: c\n" in new_text
+
+
+def test_component_block_field_list_ignores_deeper_decoys(generated_rules) -> None:
+    generated_rules(_BLOCK_RULE)
+    assert render_migrations("mycomp:\n  - child:\n      old_key: 1\n") is None
+
+
 def test_generated_and_bespoke_rules_share_one_diff(generated_rules) -> None:
     generated_rules(_VOC_RULE)
     text = _LEGACY_API_YAML + "\n" + _SGP4X_YAML

--- a/tests/test_sync_components_rename_keys.py
+++ b/tests/test_sync_components_rename_keys.py
@@ -189,11 +189,20 @@ def test_shared_closure_reachable_both_ways_classifies_nested(cv: ModuleType) ->
     assert _collect_rename_keys(_manifest(schema)) == {("service", "action"): False}
 
 
-def test_list_form_component_pair_routes_to_the_canary() -> None:
-    """A multi_conf component's block is a list the block rule can't address."""
-    _classify_rename_pairs("uart", {("old", "new"): True}, list_form=True)
+def test_platform_domain_pair_routes_to_the_canary() -> None:
+    """A platform-domain block's ``- platform:`` items the block rule can't address."""
+    _classify_rename_pairs("sensor", {("old", "new"): True}, platform_domain=True)
     assert set() == _MIGRATION_RULES
-    assert {("uart", "old", "new")} == _UNHANDLED_RENAME_KEYS
+    assert {("sensor", "old", "new")} == _UNHANDLED_RENAME_KEYS
+
+
+def test_multi_conf_component_pair_ships_data_driven() -> None:
+    """The block rule handles the list form, so multi_conf pairs emit as rules."""
+    _classify_rename_pairs("xiaomi_rtcgq02lm", {("esp32_ble_id", "ble_hub_id"): True})
+    assert {
+        ("component_block_field", "xiaomi_rtcgq02lm", "", "", "esp32_ble_id", "ble_hub_id")
+    } == _MIGRATION_RULES
+    assert set() == _UNHANDLED_RENAME_KEYS
 
 
 def test_non_direct_pair_routes_to_the_canary() -> None:


### PR DESCRIPTION
# What does this implement/fix?

With the bluetooth_proxy crash fixed, the 2026.8 catalog sync now stops at the rename canary: xiaomi_rtcgq02lm gained the esp32_ble_id to ble_hub_id rename from ble_device_base, and as a multi_conf component its pairs fell to the canary because the component_block_field rule only addressed the mapping form of a block.

This teaches _apply_component_block_field the list form, mirroring _apply_platform_item_field minus the platform match: each list item gets the child key renamed, an item already carrying the canonical key is skipped, deeper decoys and block scalars stay untouched. The sync then emits direct multi_conf pairs as data-driven rules instead of canary rows, so this rename class never needs hand handling again; platform-domain blocks stay canary-guarded.

Verified against the 2026.8.0b3 schema with esphome 2026.8.0b3 installed: the canary passes and the whole BLE hub rename family ships data-driven, 6 component_block_field rows and 38 platform_item_field rows. CLAUDE.md's rename paragraph is updated to match.

**Related issue or feature (if applicable):**

- related: https://github.com/esphome/esphome/issues/18386

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
