### PR TITLE
Adapt the catalog guards to the 2026.8 cn105 hub split and BLE hub rename

### DIFF
--- a/script/check_catalog.py
+++ b/script/check_catalog.py
@@ -308,8 +308,8 @@ _GATING_EXPECTATIONS: list[tuple[str, str, str | None]] = [
 # the checked-in catalog from both sides.
 _GATING_FLOORS: dict[str, int] = {
     "mqtt": 6000,
-    "web_server": 2000,
-    "zigbee": 1600,
+    "web_server": 2500,
+    "zigbee": 2000,
 }
 
 # Catalog-wide floor on automation entries carrying live-introspection

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -713,7 +713,7 @@ _MACHINE_DERIVED_RANGE_FIELDS: set[tuple[str, tuple[str, ...]]] = {
 # upstream validates each rate and a re-sync captures it; CN105's choice is
 # permanent (variable by heat-pump model).
 _CURATED_BUS_CONSTRAINTS: dict[str, dict[str, dict[str, Any]]] = {
-    "climate.mitsubishi_cn105": {"uart": {"baud_rate": [2400, 9600]}},
+    "mitsubishi_cn105": {"uart": {"baud_rate": [2400, 9600]}},
     "sensor.bl0940": {"uart": {"baud_rate": 4800}},
     "sensor.pzem004t": {"uart": {"baud_rate": 9600}},
     "sensor.senseair": {"uart": {"baud_rate": 9600}},
@@ -3523,6 +3523,12 @@ def _convert_field(  # noqa: PLR0912, PLR0915, C901
     # Recurse into nested schemas for type=nested.
     if entry_type == "nested" and isinstance(inner_schema, dict):
         inner = _convert_config_vars(inner_schema, schema_dir, _seen_refs=_seen_refs)
+        if not inner and not inner_schema.get("extends"):
+            # Every own child filtered away (a trigger-only group like
+            # mitsubishi_cn105's vane) — drop the empty dead-end group.
+            # An extends-carrying group stays: its emptiness is a cycle
+            # guard or an unresolved base, not a dead end.
+            return None
         entry["config_entries"] = inner or None
         entry["platform_type"] = _detect_platform_type(inner_schema)
         # When every child would render as advanced anyway, hide the

--- a/tests/test_sync_components_bus_constraints.py
+++ b/tests/test_sync_components_bus_constraints.py
@@ -101,7 +101,14 @@ def test_cv_all_wrapped_final_validate_is_unwrapped(tmp_path: Path) -> None:
 
 def test_curated_cn105_is_a_baud_choice_list() -> None:
     """CN105's rate is heat-pump-dependent, so it's curated as a 2400/9600 choice."""
-    assert _CURATED_BUS_CONSTRAINTS["climate.mitsubishi_cn105"]["uart"]["baud_rate"] == [2400, 9600]
+    assert _CURATED_BUS_CONSTRAINTS["mitsubishi_cn105"]["uart"]["baud_rate"] == [2400, 9600]
+
+
+def _cn105_body() -> dict[str, Any]:
+    """Load the CN105 uart owner: the 2026.8 hub when shipped, else the legacy climate platform."""
+    hub = _OUTPUT_BODIES_DIR / "mitsubishi_cn105.json"
+    path = hub if hub.exists() else _OUTPUT_BODIES_DIR / "climate.mitsubishi_cn105.json"
+    return orjson.loads(path.read_bytes())
 
 
 def test_curated_fixed_baud_rows_are_scalars() -> None:
@@ -143,7 +150,7 @@ def test_apply_curated_is_noop_for_unlisted_component() -> None:
 
 def test_shipped_catalog_carries_curated_baud() -> None:
     """The generated bodies merge the curated baud (CN105 list, sim800l onto its require_*)."""
-    cn105 = orjson.loads((_OUTPUT_BODIES_DIR / "climate.mitsubishi_cn105.json").read_bytes())
+    cn105 = _cn105_body()
     assert cn105["bus_constraints"]["uart"]["baud_rate"] == [2400, 9600]
     sim = orjson.loads((_OUTPUT_BODIES_DIR / "sim800l.json").read_bytes())
     assert sim["bus_constraints"]["uart"]["baud_rate"] == 9600
@@ -152,8 +159,7 @@ def test_shipped_catalog_carries_curated_baud() -> None:
 
 def test_shipped_catalog_captures_cn105_cv_all_constraints() -> None:
     """CN105's cv.All-wrapped FINAL_VALIDATE constraints land beside the curated baud."""
-    cn105 = orjson.loads((_OUTPUT_BODIES_DIR / "climate.mitsubishi_cn105.json").read_bytes())
-    uart = cn105["bus_constraints"]["uart"]
+    uart = _cn105_body()["bus_constraints"]["uart"]
     assert uart["parity"] == "EVEN"
     assert uart["require_rx"] is True
     assert uart["require_tx"] is True

--- a/tests/test_sync_components_nested_collapse.py
+++ b/tests/test_sync_components_nested_collapse.py
@@ -47,6 +47,20 @@ def test_empty_schema_wrapper_collapses(schema_dir: Path) -> None:
     assert not entry.get("config_entries")
 
 
+def test_trigger_only_nested_group_drops(schema_dir: Path) -> None:
+    """The mitsubishi_cn105 ``vane`` shape: every child filters away, so the group goes."""
+    raw = {
+        "key": "Optional",
+        "type": "schema",
+        "schema": {
+            "config_vars": {
+                "on_state": {"key": "Optional", "type": "trigger"},
+            },
+        },
+    }
+    assert _convert_field("vane", raw, schema_dir) is None
+
+
 def test_local_field_reuses_root_extends_ref(schema_dir: Path) -> None:
     """A local field re-extending the root's ref expands; it isn't a cycle."""
     node = {

--- a/tests/test_sync_components_sub_readings.py
+++ b/tests/test_sync_components_sub_readings.py
@@ -360,4 +360,6 @@ def test_catalog_singleton_base_ids_advanced_multi_stay_shown() -> None:
     spi = {e["key"]: e for e in _load_body("sensor.bmp280_spi")["config_entries"]}
     assert spi["spi_id"].get("advanced", False) is False
     ble = {e["key"]: e for e in _load_body("sensor.mopeka_pro_check")["config_entries"]}
-    assert ble["esp32_ble_id"].get("advanced", False) is False
+    # 2026.8 renamed the hub binding key esp32_ble_id -> ble_hub_id.
+    hub_id = "ble_hub_id" if "ble_hub_id" in ble else "esp32_ble_id"
+    assert ble[hub_id].get("advanced", False) is False


### PR DESCRIPTION
# What does this implement/fix?

The regenerated 2026.8.0b3 catalog (#2560) trips four shipped-catalog guards. This adapts the sync and the guards to the upstream changes so a re-run of the catalog sync goes green:

- mitsubishi_cn105 was split into a hub that owns the uart plus a climate platform. The curated 2400/9600 baud choice moves to the hub, where the FINAL_VALIDATE parity and require constraints already land; the shipped-catalog tests read whichever layout ships.
- The hub's vane group contains only an on_state trigger, and trigger keys are skipped from config entries, so it shipped as a childless nested group. The sync now drops a nested group whose own children all filter away; extends-carrying groups are kept, their emptiness is a cycle guard or an unresolved base, not a dead end.
- mopeka_pro_check's hub binding key was renamed esp32_ble_id to ble_hub_id; the sub-readings test accepts either spelling.
- The catalog grew past the gating-floor band; web_server goes 2000 to 2500 and zigbee 1600 to 2000, both inside the band for the old and the new catalog.

Verified both ways: the full suite passes against the shipped catalog on main, and a full catalog regeneration against the 2026.8.0b3 schema with esphome 2026.8.0b3 installed passes all four guard files; the regen delta beyond the bot's #2560 output is exactly the two cn105 entries.

**Related issue or feature (if applicable):**

- related: https://github.com/esphome/esphome/issues/18386

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
