### PR TITLE
Derive per-block scan state once in the generated-rename fold

### DIFF
--- a/esphome_device_builder/controllers/migrations.py
+++ b/esphome_device_builder/controllers/migrations.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
-from functools import cache
+from functools import cache, lru_cache
 
 from ..definitions import MigrationRule, load_migration_rules_index
 from ..helpers.yaml.scan import (
@@ -162,29 +162,67 @@ def _apply_action_node_rename(
 # bare-mapping ``ota:`` / ``time:`` form (implicit platform).
 def _apply_generated_renames(lines: list[str]) -> list[str]:
     """Apply the sync-discovered rename rules from the generated artifact."""
+    key_rules, block_groups, item_groups = _group_generated_rules(load_migration_rules_index())
     out = lines
-    rules = load_migration_rules_index()
     # Key respells first, so a same-release field rename inside the
     # renamed block still converges in this single fold pass.
-    for rule in rules:
-        if rule.kind == "component_key":
-            out = _respell_top_level_key(out, rule.old, rule.new)
-    for rule in rules:
-        # No fallthrough: a kind this build doesn't know is a no-op,
-        # never misapplied as some other kind's rename.
-        if rule.kind == "component_block_field":
-            out = _apply_component_block_field(out, rule)
-        elif rule.kind == "platform_item_field":
-            out = _apply_platform_item_field(out, rule)
+    for rule in key_rules:
+        out = _respell_top_level_key(out, rule.old, rule.new)
+    # The mask survives every respell below — key renames preserve line
+    # count, indentation, and everything after the key — so one pass
+    # serves all blocks; computed only once some target block exists.
+    in_scalar: list[bool] | None = None
+    for component, rules in block_groups:
+        header = find_block_header(out, component)
+        if header is None:
+            continue
+        if in_scalar is None:
+            in_scalar = _block_scalar_mask(out)
+        out = _apply_component_block_fields(out, header, rules, in_scalar)
+    for domain, rules in item_groups:
+        header = find_block_header(out, domain)
+        if header is None:
+            continue
+        if in_scalar is None:
+            in_scalar = _block_scalar_mask(out)
+        out = _apply_platform_item_fields(out, header, rules, in_scalar)
     return out
 
 
-def _apply_component_block_field(lines: list[str], rule: MigrationRule) -> list[str]:
-    """Rename a child key of the top-level ``<component>:`` block, mapping or list form."""
-    header = find_block_header(lines, rule.component)
-    if header is None:
-        return lines
-    in_scalar = _block_scalar_mask(lines)
+_RuleGroups = tuple[tuple[str, tuple[MigrationRule, ...]], ...]
+
+
+@lru_cache(maxsize=8)
+def _group_generated_rules(
+    rules: tuple[MigrationRule, ...],
+) -> tuple[tuple[MigrationRule, ...], _RuleGroups, _RuleGroups]:
+    """Split *rules* into key respells, block-field groups, and item-field groups."""
+    key_rules: list[MigrationRule] = []
+    block_groups: dict[str, list[MigrationRule]] = {}
+    item_groups: dict[str, list[MigrationRule]] = {}
+    for rule in rules:
+        # No fallthrough: a kind this build doesn't know is dropped here,
+        # never misapplied as some other kind's rename.
+        if rule.kind == "component_key":
+            key_rules.append(rule)
+        elif rule.kind == "component_block_field":
+            block_groups.setdefault(rule.component, []).append(rule)
+        elif rule.kind == "platform_item_field":
+            item_groups.setdefault(rule.domain, []).append(rule)
+    return (
+        tuple(key_rules),
+        tuple((name, tuple(group)) for name, group in block_groups.items()),
+        tuple((name, tuple(group)) for name, group in item_groups.items()),
+    )
+
+
+def _apply_component_block_fields(
+    lines: list[str],
+    header: int,
+    rules: tuple[MigrationRule, ...],
+    in_scalar: list[bool],
+) -> list[str]:
+    """Rename child keys of the top-level block at *header*, mapping or list form."""
     end = block_end_index(lines, header)
     # The block's first content line decides its form; a deeper dash
     # inside a mapping body is a nested list, not a multi_conf item.
@@ -199,27 +237,28 @@ def _apply_component_block_field(lines: list[str], rule: MigrationRule) -> list[
             continue
         list_form = is_list_item_line(stripped)
         break
-    if not list_form:
-        hit = _respell_body_field(lines, header, 0, rule.old, rule.new, in_scalar)
-        if hit is None:
-            return lines
-        out = list(lines)
-        out[hit[0]] = hit[1]
-        return out
     out = list(lines)
+    if not list_form:
+        for rule in rules:
+            hit = _respell_body_field(out, header, 0, rule.old, rule.new, in_scalar)
+            if hit is not None:
+                out[hit[0]] = hit[1]
+        return out
     for item_start in top_list_item_starts(lines, header, end):
         keys = _item_child_keys(lines, item_start, end, in_scalar)
-        _respell_item_key(lines, out, keys, rule.old, rule.new)
+        for rule in rules:
+            _respell_item_key(out, keys, rule.old, rule.new)
     return out
 
 
-def _apply_platform_item_field(lines: list[str], rule: MigrationRule) -> list[str]:
-    """Rename a child key of the ``- platform: <platform>`` items under ``<domain>:``."""
-    header = find_block_header(lines, rule.domain)
-    if header is None:
-        return lines
+def _apply_platform_item_fields(
+    lines: list[str],
+    header: int,
+    rules: tuple[MigrationRule, ...],
+    in_scalar: list[bool],
+) -> list[str]:
+    """Rename child keys of the ``- platform:`` items under the domain block at *header*."""
     end = block_end_index(lines, header)
-    in_scalar = _block_scalar_mask(lines)
     out = list(lines)
     for item_start in top_list_item_starts(lines, header, end):
         keys = _item_child_keys(lines, item_start, end, in_scalar)
@@ -227,29 +266,31 @@ def _apply_platform_item_field(lines: list[str], rule: MigrationRule) -> list[st
             (_entry_value(lines[idx], col) for idx, col, key in keys if key == "platform"),
             None,
         )
-        if platform != rule.platform:
+        if platform is None:
             continue
-        _respell_item_key(lines, out, keys, rule.old, rule.new)
+        for rule in rules:
+            if rule.platform == platform:
+                _respell_item_key(out, keys, rule.old, rule.new)
     return out
 
 
 def _respell_item_key(
-    lines: list[str],
     out: list[str],
     keys: list[tuple[int, int, str]],
     old: str,
     new: str,
 ) -> None:
-    """Respell a list item's *old* depth-1 key into *out*; no-op on collision or absence."""
+    """Respell a list item's *old* depth-1 key in *out*; no-op on collision or absence."""
     if any(key == new for _idx, _col, key in keys):
         return
-    target = next(((idx, col) for idx, col, key in keys if key == old), None)
-    if target is None:
+    slot = next((i for i, (_idx, _col, key) in enumerate(keys) if key == old), None)
+    if slot is None:
         return
-    idx, col = target
-    content = lines[idx].rstrip("\n\r")
-    eol = lines[idx][len(content) :]
+    idx, col, _key = keys[slot]
+    content = out[idx].rstrip("\n\r")
+    eol = out[idx][len(content) :]
     out[idx] = content[:col] + new + content[col + len(old) :] + eol
+    keys[slot] = (idx, col, new)
 
 
 #: Upstream's closed ``CLK_MODES_DEPRECATED`` table — anything else is an

--- a/esphome_device_builder/controllers/migrations.py
+++ b/esphome_device_builder/controllers/migrations.py
@@ -18,15 +18,15 @@ from __future__ import annotations
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
-from functools import cache, lru_cache
+from functools import cache
 
 from ..definitions import MigrationRule, load_migration_rules_index
 from ..helpers.yaml.scan import (
     block_end_index,
     child_block_end,
-    find_block_header,
     is_list_item_line,
     leading_ws,
+    top_level_key_index,
     top_list_item_starts,
 )
 from ..models.automations import YamlDiff
@@ -163,43 +163,43 @@ def _apply_action_node_rename(
 def _apply_generated_renames(lines: list[str]) -> list[str]:
     """Apply the sync-discovered rename rules from the generated artifact."""
     key_rules, block_groups, item_groups = _group_generated_rules(load_migration_rules_index())
-    out = lines
+    out = list(lines)
+    headers = top_level_key_index(out)
     # Key respells first, so a same-release field rename inside the
     # renamed block still converges in this single fold pass.
     for rule in key_rules:
-        out = _respell_top_level_key(out, rule.old, rule.new)
-    # The mask survives every respell below — key renames preserve line
-    # count, indentation, and everything after the key — so one pass
-    # serves all blocks; computed only once some target block exists.
+        _respell_top_level_key(out, headers, rule.old, rule.new)
+
     in_scalar: list[bool] | None = None
-    for component, rules in block_groups:
-        header = find_block_header(out, component)
-        if header is None:
-            continue
+
+    def mask() -> list[bool]:
+        # One pass serves every block: the respells below preserve line
+        # count, indentation, and everything after the key.
+        nonlocal in_scalar
         if in_scalar is None:
             in_scalar = _block_scalar_mask(out)
-        out = _apply_component_block_fields(out, header, rules, in_scalar)
-    for domain, rules in item_groups:
-        header = find_block_header(out, domain)
-        if header is None:
-            continue
-        if in_scalar is None:
-            in_scalar = _block_scalar_mask(out)
-        out = _apply_platform_item_fields(out, header, rules, in_scalar)
+        return in_scalar
+
+    for component, rules in block_groups.items():
+        if (header := headers.get(component)) is not None:
+            _apply_component_block_fields(out, header, rules, mask())
+    for domain, by_platform in item_groups.items():
+        if (header := headers.get(domain)) is not None:
+            _apply_platform_item_fields(out, header, by_platform, mask())
     return out
 
 
-_RuleGroups = tuple[tuple[str, tuple[MigrationRule, ...]], ...]
-
-
-@lru_cache(maxsize=8)
 def _group_generated_rules(
     rules: tuple[MigrationRule, ...],
-) -> tuple[tuple[MigrationRule, ...], _RuleGroups, _RuleGroups]:
-    """Split *rules* into key respells, block-field groups, and item-field groups."""
+) -> tuple[
+    list[MigrationRule],
+    dict[str, list[MigrationRule]],
+    dict[str, dict[str, list[MigrationRule]]],
+]:
+    """Split *rules* into key respells, per-component block groups, and per-platform item groups."""
     key_rules: list[MigrationRule] = []
     block_groups: dict[str, list[MigrationRule]] = {}
-    item_groups: dict[str, list[MigrationRule]] = {}
+    item_groups: dict[str, dict[str, list[MigrationRule]]] = {}
     for rule in rules:
         # No fallthrough: a kind this build doesn't know is dropped here,
         # never misapplied as some other kind's rename.
@@ -208,21 +208,17 @@ def _group_generated_rules(
         elif rule.kind == "component_block_field":
             block_groups.setdefault(rule.component, []).append(rule)
         elif rule.kind == "platform_item_field":
-            item_groups.setdefault(rule.domain, []).append(rule)
-    return (
-        tuple(key_rules),
-        tuple((name, tuple(group)) for name, group in block_groups.items()),
-        tuple((name, tuple(group)) for name, group in item_groups.items()),
-    )
+            item_groups.setdefault(rule.domain, {}).setdefault(rule.platform, []).append(rule)
+    return key_rules, block_groups, item_groups
 
 
 def _apply_component_block_fields(
     lines: list[str],
     header: int,
-    rules: tuple[MigrationRule, ...],
+    rules: list[MigrationRule],
     in_scalar: list[bool],
-) -> list[str]:
-    """Rename child keys of the top-level block at *header*, mapping or list form."""
+) -> None:
+    """Rename child keys of the top-level block at *header* in place, mapping or list form."""
     end = block_end_index(lines, header)
     # The block's first content line decides its form; a deeper dash
     # inside a mapping body is a nested list, not a multi_conf item.
@@ -237,29 +233,26 @@ def _apply_component_block_fields(
             continue
         list_form = is_list_item_line(stripped)
         break
-    out = list(lines)
     if not list_form:
         for rule in rules:
-            hit = _respell_body_field(out, header, 0, rule.old, rule.new, in_scalar)
+            hit = _respell_body_field(lines, header, 0, rule.old, rule.new, in_scalar)
             if hit is not None:
-                out[hit[0]] = hit[1]
-        return out
+                lines[hit[0]] = hit[1]
+        return
     for item_start in top_list_item_starts(lines, header, end):
         keys = _item_child_keys(lines, item_start, end, in_scalar)
         for rule in rules:
-            _respell_item_key(out, keys, rule.old, rule.new)
-    return out
+            _respell_item_key(lines, keys, rule.old, rule.new)
 
 
 def _apply_platform_item_fields(
     lines: list[str],
     header: int,
-    rules: tuple[MigrationRule, ...],
+    rules_by_platform: dict[str, list[MigrationRule]],
     in_scalar: list[bool],
-) -> list[str]:
-    """Rename child keys of the ``- platform:`` items under the domain block at *header*."""
+) -> None:
+    """Rename child keys of the ``- platform:`` items in the domain block at *header* in place."""
     end = block_end_index(lines, header)
-    out = list(lines)
     for item_start in top_list_item_starts(lines, header, end):
         keys = _item_child_keys(lines, item_start, end, in_scalar)
         platform = next(
@@ -268,28 +261,26 @@ def _apply_platform_item_fields(
         )
         if platform is None:
             continue
-        for rule in rules:
-            if rule.platform == platform:
-                _respell_item_key(out, keys, rule.old, rule.new)
-    return out
+        for rule in rules_by_platform.get(platform, ()):
+            _respell_item_key(lines, keys, rule.old, rule.new)
 
 
 def _respell_item_key(
-    out: list[str],
+    lines: list[str],
     keys: list[tuple[int, int, str]],
     old: str,
     new: str,
 ) -> None:
-    """Respell a list item's *old* depth-1 key in *out*; no-op on collision or absence."""
+    """Respell an item's *old* depth-1 key in *lines* and *keys*; no-op on collision or absence."""
     if any(key == new for _idx, _col, key in keys):
         return
     slot = next((i for i, (_idx, _col, key) in enumerate(keys) if key == old), None)
     if slot is None:
         return
     idx, col, _key = keys[slot]
-    content = out[idx].rstrip("\n\r")
-    eol = out[idx][len(content) :]
-    out[idx] = content[:col] + new + content[col + len(old) :] + eol
+    content = lines[idx].rstrip("\n\r")
+    eol = lines[idx][len(content) :]
+    lines[idx] = content[:col] + new + content[col + len(old) :] + eol
     keys[slot] = (idx, col, new)
 
 
@@ -368,18 +359,22 @@ def _child_block_span(
     return None
 
 
-def _respell_top_level_key(lines: list[str], legacy: str, canonical: str) -> list[str]:
+def _respell_top_level_key(
+    lines: list[str],
+    headers: dict[str, int],
+    legacy: str,
+    canonical: str,
+) -> None:
     """
-    Rename the column-0 ``legacy:`` block header to ``canonical:``.
+    Rename the column-0 ``legacy:`` header in place, keeping *headers* current.
 
     No-op when a ``canonical:`` block already exists.
     """
-    idx = find_block_header(lines, legacy)
-    if idx is None or find_block_header(lines, canonical) is not None:
-        return lines
-    out = list(lines)
-    out[idx] = canonical + lines[idx][len(legacy) :]
-    return out
+    idx = headers.get(legacy)
+    if idx is None or canonical in headers:
+        return
+    lines[idx] = canonical + lines[idx][len(legacy) :]
+    headers[canonical] = headers.pop(legacy)
 
 
 def _block_scalar_mask(lines: list[str]) -> list[bool]:

--- a/esphome_device_builder/helpers/yaml/scan.py
+++ b/esphome_device_builder/helpers/yaml/scan.py
@@ -31,6 +31,20 @@ def find_block_header(lines: list[str], key: str) -> int | None:
     return None
 
 
+#: Generic column-0 form of ``key_header_re`` — keep the two shapes in sync.
+_TOP_LEVEL_HEADER_RE = re.compile(r"^(\S+):\s*(?:#.*)?$")
+
+
+def top_level_key_index(lines: list[str]) -> dict[str, int]:
+    """First-occurrence index of every column-0 ``<key>:`` header line."""
+    index: dict[str, int] = {}
+    for idx, line in enumerate(lines):
+        match = _TOP_LEVEL_HEADER_RE.match(line.rstrip("\n\r"))
+        if match is not None:
+            index.setdefault(match.group(1), idx)
+    return index
+
+
 def block_end_index(lines: list[str], start: int) -> int:
     """First line after *start* that opens the next top-level block; ``len(lines)`` at EOF."""
     for idx in range(start + 1, len(lines)):

--- a/tests/test_config_migrations.py
+++ b/tests/test_config_migrations.py
@@ -595,6 +595,14 @@ def test_platform_item_rename_skips_block_scalars(generated_rules) -> None:
     assert render_migrations(text) is None
 
 
+def test_platform_item_platformless_item_untouched(generated_rules) -> None:
+    generated_rules(_VOC_RULE)
+    text = "sensor:\n  - voc: bare\n  - platform: sgp4x\n    voc: a\n"
+    new_text = _respell(text)
+    assert "  - voc: bare\n" in new_text
+    assert "    voc_index: a\n" in new_text
+
+
 def test_platform_value_tolerates_quotes_and_comment(generated_rules) -> None:
     generated_rules(_VOC_RULE)
     text = 'sensor:\n  - platform: "sgp4x"  # gas\n    voc:\n      name: x\n'

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -67,6 +67,7 @@ from esphome_device_builder.helpers.yaml.scalar import (
     _plain_is_fast_safe,
     _plain_is_safe,
 )
+from esphome_device_builder.helpers.yaml.scan import find_block_header, top_level_key_index
 from esphome_device_builder.models import ErrorCode
 from esphome_device_builder.models.common import ConfigEntry, ConfigEntryType
 from esphome_device_builder.models.components import (
@@ -2428,3 +2429,24 @@ def test_child_block_end_trims_shallow_banner_but_keeps_deep_comment() -> None:
     text = "api:\n  actions:\n  - action: a\n    # for a\n\n  # banner\n  encryption:\n    key: k\n"
     # The deep ``# for a`` stays inside; the blank + shallow banner trim off.
     assert _cbe(text, 1, "  ") == 4
+
+
+def test_top_level_key_index_matches_find_block_header() -> None:
+    lines = [
+        "esphome:\n",
+        "sensor:  # comment\n",
+        "wifi: !secret creds\n",
+        "logger:\n",
+        '"quoted":\n',
+        "a:b:\n",
+        "  nested:\n",
+        "- dash:\n",
+        "script: |\n",
+        "  fake:\n",
+        "ota :\n",
+        "sensor:\n",
+    ]
+    index = top_level_key_index(lines)
+    assert index == {"esphome": 0, "sensor": 1, "logger": 3, '"quoted"': 4, "a:b": 5}
+    for key in (*index, "wifi", "quoted", "a", "nested", "dash", "script", "fake", "ota"):
+        assert index.get(key) == find_block_header(lines, key)


### PR DESCRIPTION
# What does this implement/fix?

`_apply_generated_renames` looped every generated migration rule independently, so each rule whose target block exists rebuilt the block scalar mask, re-ran the header and block-end scans, and re-walked the item starts and child keys. With 45 rules in the current index (32 targeting `sensor`), a 256 line config with a sensor block paid that derivation 32 times, about 5.4ms of the 5.7ms `render_migrations` cost, scaling linearly with file size.

This groups the generated rules by target block and platform on each render (a microseconds scale pass over the cached rules index), indexes the top level headers in one pass, then computes the scalar mask lazily and the block end, item starts, and child keys once per present block, applying all of that block's rules against the materialized key list. `_respell_item_key` now updates the key list in place, so collision checks and chained renames keep the exact sequential semantics. Measured on the same configs: 5.10ms to 0.28ms at 262 lines, 21.1ms to 1.10ms at 1011 lines. This is the hot path for `editor/migrate_config` and the `has_pending_migrations` fall-through, which since #2563 also runs per device at scanner load.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2564

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
