### PR TITLE
Rename find_esphome_cmd and find_esptool_cmd to public names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -857,7 +857,7 @@ When changing the sync script or catalog handling, watch for these:
 
 - **Don't swap `sys.executable` for a sibling `python`.** It silently
   jumps to a different interpreter (e.g. system Python without `esphome`)
-  → "No module named esphome" at compile time. `_find_esphome_cmd` uses
+  → "No module named esphome" at compile time. `find_esphome_cmd` uses
   `sys.executable` directly.
 - **`extends:` references need a deep merge.** The schema uses partial
   overrides — `dht.sensor.humidity.config_vars.device_class` carries only

--- a/esphome_device_builder/controllers/config/chip_detect.py
+++ b/esphome_device_builder/controllers/config/chip_detect.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from ...definitions import load_platform_capabilities_index
 from ...helpers.chips import normalize_chip_variant
-from ...helpers.sibling_cli import _find_esptool_cmd
+from ...helpers.sibling_cli import find_esptool_cmd
 from ...helpers.subprocess import run_subprocess_capture
 
 _LOGGER = logging.getLogger(__name__)
@@ -256,7 +256,7 @@ def _parse_chip_family_line(output: str) -> dict[str, str] | None:
 async def _run_esptool(args: list[str], timeout: float) -> tuple[int, bytes, bool]:
     """Spawn esptool with *args* and capture stdout+stderr.
 
-    Uses :func:`helpers.sibling_cli._find_esptool_cmd` to
+    Uses :func:`helpers.sibling_cli.find_esptool_cmd` to
     pick the right invocation (sibling script preferred over
     ``python -m esptool``) and runs through
     :func:`helpers.subprocess.run_subprocess_capture` — the same
@@ -267,7 +267,7 @@ async def _run_esptool(args: list[str], timeout: float) -> tuple[int, bytes, boo
     error message can recommend an unplug/replug rather than
     pointing at the cable.
     """
-    cmd = _find_esptool_cmd()
+    cmd = find_esptool_cmd()
     result = await run_subprocess_capture(*cmd, *args, timeout=timeout)
     rc = result.returncode if result.returncode is not None else -1
     return rc, result.stdout, result.timed_out

--- a/esphome_device_builder/controllers/devices/_state.py
+++ b/esphome_device_builder/controllers/devices/_state.py
@@ -93,7 +93,7 @@ class DevicesState:
 
     # ``esphome`` CLI invocation discovered at ``start()`` —
     # ``[sys.executable, "-m", "esphome"]`` or the on-PATH
-    # ``esphome`` binary, whichever ``_find_esphome_cmd``
+    # ``esphome`` binary, whichever ``find_esphome_cmd``
     # picks first.
     esphome_cmd: list[str] = field(default_factory=list)
 

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -31,7 +31,7 @@ from ...helpers.secrets_state import (
     wifi_secrets_defined,
     write_wifi_secrets,
 )
-from ...helpers.sibling_cli import _find_esphome_cmd
+from ...helpers.sibling_cli import find_esphome_cmd
 from ...helpers.storage import ShutdownCallback, drain_shutdown_callbacks
 from ...helpers.yaml import write_user_yaml
 from ...models import (
@@ -278,7 +278,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         """Initialise — load state, scan files, start mDNS + ping + MQTT discovery."""
         self._stopped = False
         self._mqtt_coordinator.resume()
-        self.state.esphome_cmd = _find_esphome_cmd()
+        self.state.esphome_cmd = find_esphome_cmd()
         # Store seed + migrations + ignore-list are independent; all
         # must land before the scanner (the resolver reads off them).
         # TaskGroup so a failing leg cancels its siblings instead of

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -20,7 +20,7 @@ from ..helpers.api import api_command
 from ..helpers.async_ import drain_tasks, run_in_executor
 from ..helpers.json import JSONDecodeError, dumps, loads
 from ..helpers.process import kill_quietly
-from ..helpers.sibling_cli import _find_esphome_cmd
+from ..helpers.sibling_cli import find_esphome_cmd
 from ..helpers.subprocess import create_subprocess_exec
 from ..models.automations import MigrateConfigResponse
 from .migrations import render_migrations
@@ -98,7 +98,7 @@ class EditorController:
     async def start(self) -> None:
         """Async initialize the controller."""
         # resolve the `esphome` CLI invocation used to spawn validator subprocesses
-        self._esphome_cmd = _find_esphome_cmd()
+        self._esphome_cmd = find_esphome_cmd()
         self._reaper_task = asyncio.create_task(
             self._reaper_loop(), name="editor-subprocess-reaper"
         )

--- a/esphome_device_builder/controllers/firmware/_state.py
+++ b/esphome_device_builder/controllers/firmware/_state.py
@@ -155,7 +155,7 @@ class FirmwareState:
 
     # ``esphome`` CLI invocation discovered at ``start()`` —
     # ``[sys.executable, "-m", "esphome"]`` or the on-PATH
-    # ``esphome`` binary, whichever ``_find_esphome_cmd``
+    # ``esphome`` binary, whichever ``find_esphome_cmd``
     # picks first. ``cli`` reads it to build the subprocess argv.
     esphome_cmd: list[str] = field(default_factory=list)
 

--- a/esphome_device_builder/controllers/firmware/cli.py
+++ b/esphome_device_builder/controllers/firmware/cli.py
@@ -13,7 +13,7 @@ from esphome.storage_json import StorageJSON
 
 from ...helpers.async_ import run_in_executor
 from ...helpers.remote_build_layout import parse_from_configuration as parse_remote_build_path
-from ...helpers.sibling_cli import _find_esptool_cmd
+from ...helpers.sibling_cli import find_esptool_cmd
 from ...helpers.storage_path import resolve_storage_path
 from ...models import OTA_PORT, FirmwareJob, JobType
 from . import lifecycle
@@ -136,7 +136,7 @@ async def verify_chip(controller: FirmwareController, job: FirmwareJob) -> None:
 
     async with controller._tracked_subprocess(
         job,
-        *_find_esptool_cmd(),
+        *find_esptool_cmd(),
         "--port",
         job.port,
         "chip-id",

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -27,7 +27,7 @@ from ...helpers.api import CommandError, api_command
 from ...helpers.async_ import create_eager_task, drain_tasks, run_in_executor
 from ...helpers.device_yaml import configuration_filename
 from ...helpers.event_bus import Event
-from ...helpers.sibling_cli import _find_esphome_cmd
+from ...helpers.sibling_cli import find_esphome_cmd
 from ...models import (
     COMPILING_JOB_TYPES,
     LOCAL_JOB_BUILD_SOURCE,
@@ -197,7 +197,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
 
     async def start(self) -> None:
         """Start the queue processor and restore persisted jobs."""
-        self.state.esphome_cmd = _find_esphome_cmd()
+        self.state.esphome_cmd = find_esphome_cmd()
         _LOGGER.info(
             "ESPHome command: %s (interpreter: %s)",
             " ".join(self.state.esphome_cmd),

--- a/esphome_device_builder/helpers/config_bundle.py
+++ b/esphome_device_builder/helpers/config_bundle.py
@@ -25,7 +25,7 @@ build:
   sees the wrong layout.
 * Matches the existing pattern the firmware controller uses
   for every compile / upload (subprocess, same
-  :func:`_find_esphome_cmd` resolver), so a future ESPHome
+  :func:`find_esphome_cmd` resolver), so a future ESPHome
   bump only has to be validated against one integration
   surface.
 
@@ -49,7 +49,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from .async_ import run_in_executor
-from .sibling_cli import _find_esphome_cmd
+from .sibling_cli import find_esphome_cmd
 from .subprocess import run_subprocess_capture
 
 _LOGGER = logging.getLogger(__name__)
@@ -98,7 +98,7 @@ async def build_yaml_bundle(
     caller being cancelled mid-build).
     """
     # Every filesystem syscall here (``is_file`` → ``os.stat``,
-    # ``_find_esphome_cmd`` → ``Path.exists`` → ``os.stat``,
+    # ``find_esphome_cmd`` → ``Path.exists`` → ``os.stat``,
     # ``NamedTemporaryFile`` → ``os.open``, ``read_bytes`` →
     # ``os.read``, ``unlink`` → ``os.unlink``) is blocking;
     # blockbuster catches them when run on the event loop in CI.
@@ -140,7 +140,7 @@ def _prepare_build_bundle(yaml_path: Path) -> tuple[list[str], Path]:
     if not yaml_path.is_file():
         msg = f"YAML not found: {yaml_path}"
         raise FileNotFoundError(msg)
-    return _find_esphome_cmd(), _allocate_temp_bundle_path()
+    return find_esphome_cmd(), _allocate_temp_bundle_path()
 
 
 def _allocate_temp_bundle_path() -> Path:

--- a/esphome_device_builder/helpers/sibling_cli.py
+++ b/esphome_device_builder/helpers/sibling_cli.py
@@ -17,7 +17,7 @@ def helper_cli_cmd() -> tuple[str, ...]:
     return _find_sibling_cli("device-builder-helper", "esphome_device_builder.helper_cli")
 
 
-def _find_esphome_cmd() -> list[str]:
+def find_esphome_cmd() -> list[str]:
     """Locate the ``esphome`` CLI, preferring the same interpreter as ours.
 
     The backend's own interpreter (``sys.executable``) is the
@@ -37,10 +37,10 @@ def _find_esphome_cmd() -> list[str]:
     return list(_find_sibling_cli("esphome"))
 
 
-def _find_esptool_cmd() -> list[str]:
+def find_esptool_cmd() -> list[str]:
     """Locate the ``esptool`` CLI, preferring the same interpreter as ours.
 
-    Same sibling-script-first lookup as :func:`_find_esphome_cmd`.
+    Same sibling-script-first lookup as :func:`find_esphome_cmd`.
     The sibling script's shebang is pinned to our interpreter so it
     can't accidentally jump to a different Python — and it dodges
     the ``"No module named esptool"`` failure mode under VS Code's

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -852,7 +852,7 @@ def make_ws_device_builder(
 def _hermetic_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
     """Stub the network / subprocess surfaces so ``DeviceBuilder.start()`` runs hermetically.
 
-    - ``_find_esphome_cmd`` returns a fake invocation so the resolver
+    - ``find_esphome_cmd`` returns a fake invocation so the resolver
       doesn't depend on a real esphome install.
     - ``_verify_esphome_importable`` short-circuits to ``(True, "")``
       so the firmware controller's startup probe doesn't spawn a
@@ -880,7 +880,7 @@ def _hermetic_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
         "esphome_device_builder.controllers.editor",
         "esphome_device_builder.controllers.devices.controller",
     ):
-        monkeypatch.setattr(f"{module}._find_esphome_cmd", lambda: fake_cmd)
+        monkeypatch.setattr(f"{module}.find_esphome_cmd", lambda: fake_cmd)
     monkeypatch.setattr(FirmwareController, "_load_jobs", AsyncMock())
     monkeypatch.setattr(
         "esphome_device_builder.controllers.firmware.controller._verify_esphome_importable",

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -499,11 +499,11 @@ async def test_get_api_key_fallback_skipped_when_esphome_cmd_unset(
     Pre-``start()`` controllers (and the bypass-init test factory
     that doesn't pass ``esphome_cmd=``) don't have the binary
     resolved. Production hits this only during the brief startup
-    window before ``_find_esphome_cmd`` runs, but the same guard
+    window before ``find_esphome_cmd`` runs, but the same guard
     keeps the test factory's default path working without
     requiring every test to set ``esphome_cmd=`` defensively.
     Empty list is the documented "no esphome found" sentinel from
-    ``_find_esphome_cmd``.
+    ``find_esphome_cmd``.
     """
     # Note: ``esphome_cmd`` deliberately NOT set on the factory.
     controller = make_controller(tmp_path)

--- a/tests/controllers/devices/test_lifecycle_e2e.py
+++ b/tests/controllers/devices/test_lifecycle_e2e.py
@@ -156,7 +156,7 @@ async def test_start_runs_full_initialisation_chain(
     cold-start.
     """
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.controller._find_esphome_cmd",
+        "esphome_device_builder.controllers.devices.controller.find_esphome_cmd",
         lambda: ["python", "-m", "esphome"],
     )
     db = make_db(tmp_path)
@@ -192,7 +192,7 @@ async def test_start_pre_scan_loads_complete_before_scan(
 ) -> None:
     """The gathered store/migration/ignore loads all land before the scanner runs."""
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.controller._find_esphome_cmd",
+        "esphome_device_builder.controllers.devices.controller.find_esphome_cmd",
         lambda: ["python", "-m", "esphome"],
     )
     db = make_db(tmp_path)
@@ -226,7 +226,7 @@ async def test_build_size_worker_starts_live_with_delayed_sweep(
 ) -> None:
     """The worker spawns at ``start()`` with its fleet sweep held on the cold-start delay."""
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.controller._find_esphome_cmd",
+        "esphome_device_builder.controllers.devices.controller.find_esphome_cmd",
         lambda: ["python", "-m", "esphome"],
     )
     db = make_db(tmp_path)
@@ -250,7 +250,7 @@ async def test_start_refines_shallow_seed_then_reconciles(
 ) -> None:
     """The refine task deep-reloads the seeded fleet and re-runs the MQTT reconcile."""
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.controller._find_esphome_cmd",
+        "esphome_device_builder.controllers.devices.controller.find_esphome_cmd",
         list,
     )
     # ``logger.baud_rate`` is resolved-only: the shallow seed carries
@@ -285,7 +285,7 @@ async def test_stop_cancels_refine_mid_drain(
 ) -> None:
     """A shutdown during the refine drain cancels the task and skips the trailing reconcile."""
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.controller._find_esphome_cmd",
+        "esphome_device_builder.controllers.devices.controller.find_esphome_cmd",
         list,
     )
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")

--- a/tests/controllers/firmware/test_persistence.py
+++ b/tests/controllers/firmware/test_persistence.py
@@ -67,9 +67,9 @@ from tests.controllers.firmware.conftest import FirmwareControllerFactory
 
 @pytest.fixture
 def patch_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Stub ``_find_esphome_cmd`` so ``start()`` runs without probing the interpreter."""
+    """Stub ``find_esphome_cmd`` so ``start()`` runs without probing the interpreter."""
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.firmware.controller._find_esphome_cmd",
+        "esphome_device_builder.controllers.firmware.controller.find_esphome_cmd",
         lambda: ["fake-esphome"],
     )
 
@@ -489,7 +489,7 @@ async def test_start_schedules_esphome_sanity_probe(
 ) -> None:
     """A pip/dev install gets the CLI sanity probe as a background task."""
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.firmware.controller._find_esphome_cmd",
+        "esphome_device_builder.controllers.firmware.controller.find_esphome_cmd",
         lambda: ["fake-esphome"],
     )
     # A desktop-app shell exporting these would flip the prebuilt gate.
@@ -509,7 +509,7 @@ async def test_start_skips_esphome_sanity_probe_on_prebuilt_environment(
 ) -> None:
     """A pre-built environment (HA add-on, desktop app) schedules no sanity probe."""
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.firmware.controller._find_esphome_cmd",
+        "esphome_device_builder.controllers.firmware.controller.find_esphome_cmd",
         lambda: ["fake-esphome"],
     )
     spy = MagicMock()

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -11,11 +11,11 @@ and the recorded subprocess invocations) drive the assertions.
 touches; it's the runner entry point and exists to be driven
 in tests this way.
 
-The chip-id check spawns ``[*_find_esptool_cmd(), '--port', <port>,
+The chip-id check spawns ``[*find_esptool_cmd(), '--port', <port>,
 'chip-id']`` via ``create_subprocess_exec``. The resolved command is
 either a sibling ``esptool`` script next to ``sys.executable`` or
 ``[sys.executable, '-m', 'esptool']`` as a fallback (see
-``_find_esptool_cmd`` in ``helpers.sibling_cli``). Tests
+``find_esptool_cmd`` in ``helpers.sibling_cli``). Tests
 substitute ``create_subprocess_exec`` module-level so each one's
 "esptool" output can be controlled while the real subsequent build
 still runs through the same wrapper (substitute returns a no-op
@@ -141,7 +141,7 @@ _BUILD_SCRIPT_OK = "import sys\nsys.exit(0)\n"
 
 
 def _is_esptool_spawn(args: tuple[Any, ...]) -> bool:
-    """Match either esptool-spawn argv shape ``_find_esptool_cmd`` produces.
+    """Match either esptool-spawn argv shape ``find_esptool_cmd`` produces.
 
     Sibling script (``<bin>/esptool``) on dev venvs;
     ``[sys.executable, '-m', 'esptool']`` fallback on slim images.

--- a/tests/helpers/test_sibling_cli.py
+++ b/tests/helpers/test_sibling_cli.py
@@ -9,9 +9,9 @@ from typing import Any
 import pytest
 
 from esphome_device_builder.helpers.sibling_cli import (
-    _find_esphome_cmd,
-    _find_esptool_cmd,
     _find_sibling_cli,
+    find_esphome_cmd,
+    find_esptool_cmd,
 )
 
 
@@ -56,7 +56,7 @@ def test_find_esphome_cmd_prefers_sibling_binary_when_present(
     sibling.write_text("#!/bin/sh\necho fake-esphome\n", encoding="utf-8")
 
     monkeypatch.setattr(sys, "executable", str(fake_python))
-    cmd = _find_esphome_cmd()
+    cmd = find_esphome_cmd()
 
     assert cmd == [str(sibling)]
 
@@ -82,7 +82,7 @@ def test_find_esphome_cmd_falls_back_to_python_dash_m(
     # Deliberately don't create a sibling esphome script.
 
     monkeypatch.setattr(sys, "executable", str(fake_python))
-    cmd = _find_esphome_cmd()
+    cmd = find_esphome_cmd()
 
     assert cmd == [str(fake_python), "-m", "esphome"]
 
@@ -113,7 +113,7 @@ def test_find_esphome_cmd_picks_bare_esphome_on_posix(
     (bin_dir / "esphome").write_text("#!/bin/sh\n", encoding="utf-8")
 
     monkeypatch.setattr(sys, "executable", str(fake_python))
-    cmd = _find_esphome_cmd()
+    cmd = find_esphome_cmd()
 
     assert cmd == [str(bin_dir / "esphome")]
 
@@ -138,7 +138,7 @@ def test_find_esphome_cmd_picks_esphome_exe_on_windows(
     (bin_dir / "esphome.exe").write_text("MZ\n", encoding="utf-8")
 
     monkeypatch.setattr(sys, "executable", str(fake_python))
-    cmd = _find_esphome_cmd()
+    cmd = find_esphome_cmd()
 
     assert cmd == [str(bin_dir / "esphome.exe")]
 
@@ -156,7 +156,7 @@ def test_find_esptool_cmd_prefers_sibling_script(
 
     monkeypatch.setattr(sys, "executable", str(fake_python))
 
-    assert _find_esptool_cmd() == [str(sibling)]
+    assert find_esptool_cmd() == [str(sibling)]
 
 
 def test_find_esptool_cmd_falls_back_to_python_dash_m(
@@ -170,7 +170,7 @@ def test_find_esptool_cmd_falls_back_to_python_dash_m(
 
     monkeypatch.setattr(sys, "executable", str(fake_python))
 
-    assert _find_esptool_cmd() == [str(fake_python), "-m", "esptool"]
+    assert find_esptool_cmd() == [str(fake_python), "-m", "esptool"]
 
 
 def test_find_esphome_cmd_does_not_substitute_sibling_python(
@@ -200,7 +200,7 @@ def test_find_esphome_cmd_does_not_substitute_sibling_python(
     # No sibling esphome → expect the fallback.
 
     monkeypatch.setattr(sys, "executable", str(weird))
-    cmd = _find_esphome_cmd()
+    cmd = find_esphome_cmd()
 
     assert cmd == [str(weird), "-m", "esphome"]
     assert str(bin_dir / "python") not in cmd

--- a/tests/test_config_bundle.py
+++ b/tests/test_config_bundle.py
@@ -2,7 +2,7 @@
 Unit tests for :mod:`helpers.config_bundle`.
 
 The bundle helper spawns ``esphome bundle <yaml> -o <tarball>`` and
-streams its output. Tests monkeypatch ``_find_esphome_cmd`` to a tiny
+streams its output. Tests monkeypatch ``find_esphome_cmd`` to a tiny
 ``sys.executable`` script standing in for esphome, so the helper's
 plumbing (streaming, temp-file lifecycle, error mapping, timeout,
 missing-yaml pre-check) is exercised against a real subprocess.
@@ -32,10 +32,10 @@ def _install_fake_esphome(
     *,
     patch_output_path: bool = True,
 ) -> Path:
-    """Point ``_find_esphome_cmd`` at a stand-in script; return the reserved output path."""
+    """Point ``find_esphome_cmd`` at a stand-in script; return the reserved output path."""
     script = tmp_path / "fake_esphome.py"
     script.write_text(_SCRIPT_PRELUDE + body, encoding="utf-8")
-    monkeypatch.setattr(config_bundle, "_find_esphome_cmd", lambda: [sys.executable, str(script)])
+    monkeypatch.setattr(config_bundle, "find_esphome_cmd", lambda: [sys.executable, str(script)])
     output_path = tmp_path / "bundle-out.tar.gz"
     if patch_output_path:
         monkeypatch.setattr(config_bundle, "_allocate_temp_bundle_path", lambda: output_path)

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -1513,7 +1513,7 @@ def test_read_descriptor_file_returns_none_on_oserror(tmp_path: Path) -> None:
 async def test_run_esptool_calls_run_subprocess_capture_with_resolved_cmd(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``_run_esptool`` resolves the CLI via ``_find_esptool_cmd`` and forwards args.
+    """``_run_esptool`` resolves the CLI via ``find_esptool_cmd`` and forwards args.
 
     Mocks ``run_subprocess_capture`` (the underlying one-shot helper) and
     asserts the full argv shape — sibling-script first slot, then the

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -387,7 +387,7 @@ def test_init_sets_default_state() -> None:
 async def test_start_resolves_esphome_command(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``start()`` populates ``_esphome_cmd`` via ``_find_esphome_cmd``.
+    """``start()`` populates ``_esphome_cmd`` via ``find_esphome_cmd``.
 
     The cmd is later spliced with ``vscode <config_dir> --ace`` to
     spawn the validator. Pin the lookup so a refactor that moved
@@ -398,7 +398,7 @@ async def test_start_resolves_esphome_command(
     controller._esphome_cmd = []  # ensure start() actually populates it
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.editor._find_esphome_cmd",
+        "esphome_device_builder.controllers.editor.find_esphome_cmd",
         lambda: ["python", "-m", "esphome"],
     )
 
@@ -1044,7 +1044,7 @@ async def test_start_creates_reaper_task_stop_cancels_it(
     """``start()`` launches the reaper; ``stop()`` cancels and clears it."""
     controller = _make_controller(tmp_path)
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.editor._find_esphome_cmd",
+        "esphome_device_builder.controllers.editor.find_esphome_cmd",
         lambda: ["esphome"],
     )
 


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #2567. The sibling-CLI resolvers moved to `helpers/sibling_cli.py` but kept their underscore prefixes, and esphbot's review pointed out that misrepresents visibility; `_find_esphome_cmd` and `_find_esptool_cmd` are imported by five modules across three packages, so they are cross-package API. This renames them to `find_esphome_cmd` / `find_esptool_cmd` everywhere (importers, string-based monkeypatch targets in tests, docstring references) and keeps `_find_sibling_cli` private. Pure mechanical rename, no behaviour change.

**Related issue or feature (if applicable):**

- follow-up to #2567

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
