### PR TITLE
Install mosquitto and ccache through the cached apt action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -370,7 +370,7 @@ jobs:
         # mirror outage can't hang the job; the timeout bounds the
         # cold-cache install path.
         timeout-minutes: 10
-        uses: awalsh128/cache-apt-pkgs-action@a6c3917cc929dd0345bfb2d3feaf9101823370ad  # v1.4.2
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9  # v1.6.3
         with:
           packages: mosquitto
           version: 1.0
@@ -478,7 +478,7 @@ jobs:
         # a pre-set CCACHE_DIR, so the run step below points it at the
         # dedicated cached dir instead of the default inside the prefix.
         timeout-minutes: 10
-        uses: awalsh128/cache-apt-pkgs-action@a6c3917cc929dd0345bfb2d3feaf9101823370ad  # v1.4.2
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9  # v1.6.3
         with:
           packages: ccache
           version: 1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -365,8 +365,15 @@ jobs:
           python-version: "3.14"
           install-args: -c esphome-constraints.txt -e .[esphome,test]
 
-      - name: Install mosquitto
-        run: sudo apt-get update && sudo apt-get install -y mosquitto
+      - name: Install mosquitto (cached)
+        # Cache-hit restores skip ``apt-get update`` entirely, so an apt
+        # mirror outage can't hang the job; the timeout bounds the
+        # cold-cache install path.
+        timeout-minutes: 10
+        uses: awalsh128/cache-apt-pkgs-action@a6c3917cc929dd0345bfb2d3feaf9101823370ad  # v1.4.2
+        with:
+          packages: mosquitto
+          version: 1.0
 
       - name: Run MQTT discovery e2e
         timeout-minutes: 5
@@ -465,14 +472,16 @@ jobs:
           restore-keys: |
             e2e-espidf-ccache-${{ runner.os }}-
 
-      - name: Install ccache
+      - name: Install ccache (cached)
         # esphome's native-IDF build enables ccache whenever the binary is
         # on PATH (``espidf/framework.py``'s ``_ccache_env``) and respects
         # a pre-set CCACHE_DIR, so the run step below points it at the
         # dedicated cached dir instead of the default inside the prefix.
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends ccache
+        timeout-minutes: 10
+        uses: awalsh128/cache-apt-pkgs-action@a6c3917cc929dd0345bfb2d3feaf9101823370ad  # v1.4.2
+        with:
+          packages: ccache
+          version: 1.0
 
       - name: Run native ESP-IDF e2e
         # A cold native-IDF compile installs the IDF toolchain then runs


### PR DESCRIPTION
# What does this implement/fix?

The E2E MQTT job on #2585 spun for an hour inside `apt-get update`, retrying the Azure apt mirror until the run was cancelled. Install mosquitto and ccache through `awalsh128/cache-apt-pkgs-action` instead, the same pattern esphome CI uses; a cache hit restores the packages without running `apt-get update` at all, so a mirror outage can't hang the job, and a 10 minute step timeout bounds the cold cache path. The cache is seeded by push-to-main runs, so PR runs share it.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [ ] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
