### PR TITLE
Advertise the webSerial capability on the flasher ready frame

### DIFF
--- a/flasher/README.md
+++ b/flasher/README.md
@@ -37,7 +37,7 @@ defense in depth the opener should still open the flasher with
 without it the page falls back to `*` until the first inbound frame reveals it.
 
 1. Dashboard opens `…/#nonce=<random>` (ideally also `&origin=<dashboard-origin>`).
-2. Flasher posts `{type:"esphome-web-flash:ready", version}` to its opener (no nonce).
+2. Flasher posts `{type:"esphome-web-flash:ready", version, webSerial}` to its opener (no nonce); `webSerial` is whether this browser can flash, so the opener can decline the handoff up front.
 3. Dashboard posts `{type:"esphome-web-flash:firmware", nonce, name?, erase?, parts:[{address, data:ArrayBuffer}]}`.
 4. User presses **Connect & install**, picks the serial port (the required user
    gesture), and the page flashes via esptool-js.

--- a/flasher/src/main.ts
+++ b/flasher/src/main.ts
@@ -214,7 +214,14 @@ function stopReadyRetry(): void {
 }
 
 function sendReady(): void {
-  post({ type: "esphome-web-flash:ready", version: PROTOCOL_VERSION });
+  // Advertise whether this browser can actually flash so the opener can decline
+  // the handoff up front (see ReadyMessage.webSerial in protocol.ts). Same check
+  // that gates the install button below.
+  post({
+    type: "esphome-web-flash:ready",
+    version: PROTOCOL_VERSION,
+    webSerial: "serial" in navigator,
+  });
 }
 
 if (opener && nonce) {

--- a/flasher/src/protocol.ts
+++ b/flasher/src/protocol.ts
@@ -30,6 +30,13 @@ export const PROTOCOL_VERSION = 1;
 export interface ReadyMessage {
   type: "esphome-web-flash:ready";
   version: number;
+  // Whether the flasher's browser can actually flash (Web Serial present).
+  // The flasher runs on a secure origin, so it can feature-detect for real,
+  // unlike a dashboard on plain http. Additive (v1): older flashers omit it,
+  // and the opener declines the handoff only on an explicit false; when the
+  // field is absent the handoff proceeds and the flasher reports the error
+  // itself after the firmware arrives.
+  webSerial?: boolean;
 }
 
 // One image to write at a flash offset. Bytes ride as a transferable

--- a/flasher/test/handshake.test.mjs
+++ b/flasher/test/handshake.test.mjs
@@ -64,6 +64,9 @@ try {
   if (!ready) fail("no ready message received by opener");
   else if ("nonce" in ready) fail("ready frame leaked the nonce");
   else if (ready.version !== 1) fail("ready version mismatch");
+  // Headless Chromium on a secure (localhost) origin has Web Serial, so the
+  // capability field must be advertised as true, not omitted.
+  else if (ready.webSerial !== true) fail("ready did not advertise webSerial: true");
   else console.log("PASS: ready received, no nonce echoed, version", ready.version);
 
   // 1b. ready is re-announced until firmware arrives (handshake robustness)


### PR DESCRIPTION
# What does this implement/fix?

Documents the additive `webSerial` field on the flasher `ready` frame in the protocol reference, keeping it in sync with the frontend change. The flasher runs on a secure origin, so it can feature detect Web Serial for real; it advertises the result on `ready`, and the dashboard declines the handoff on an explicit `false` instead of transferring firmware to a tab that can never flash. Older flashers omit the field; the handoff then proceeds as before.

The dev flasher under `flasher/` also emits this frame, so it now advertises the field too (`"serial" in navigator`, the same check that gates its install button); the handshake test asserts it and the README step is updated. That keeps the dev rig able to exercise the decline path in the frontend PR.

**Related issue or feature (if applicable):**

- related to esphome/device-builder-frontend#1656

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#1659

## Checklist

- [x] The code change is tested and works locally.
- [ ] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [ ] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

