### PR TITLE
Harden the fingerprint scans and re-run validates raced by writes

### DIFF
--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -447,7 +447,7 @@ class EditorController:
                 configuration,
                 "re-running" if retry_left else "returning the raced result uncached",
             )
-        if result is None:
+        if result is None:  # pragma: no cover — attempt one either raises or sets result
             raise ValidatorUnavailableError("validator produced no result")
         return result
 

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -388,15 +388,12 @@ class EditorController:
         """
         Run the validation round-trip, re-running once when a config-dir write races it.
 
-        Caller must hold ``session.lock``. The re-run gets the remaining
-        *timeout* budget; a re-run failure falls back to the first
+        Caller must hold ``session.lock``. The re-run gets whatever is
+        left of *timeout* (round-trip only; subprocess startup stays
+        outside the budget); a re-run failure falls back to the first
         attempt's verdict, returned uncached.
         """
-        # A config-dir write landing mid round-trip means the result was
-        # computed against pre-write state; re-run once, on the remaining
-        # budget, so the caller gets a post-write verdict instead of a
-        # known-stale one.
-        deadline = time.monotonic() + timeout
+        remaining = timeout
         result: dict[str, Any] | None = None
         for retry_left in (True, False):
             ok = False
@@ -407,10 +404,12 @@ class EditorController:
                 await self._ensure_subprocess(
                     session, extract_component_source_fingerprint(content)
                 )
+                round_trip_started = time.monotonic()
                 attempt = await asyncio.wait_for(
                     self._validate_locked(session, configuration, content),
-                    timeout=max(0.0, deadline - time.monotonic()),
+                    timeout=remaining,
                 )
+                remaining -= time.monotonic() - round_trip_started
                 result = attempt
                 ok = True
                 if session.invalidation_epoch == epoch:
@@ -418,14 +417,15 @@ class EditorController:
                         content_hash=content_hash, result=attempt, at=time.monotonic()
                     )
                     break
-            except Exception:
+            except (TimeoutError, ValidatorUnavailableError, OSError) as err:
                 # A failed re-run must not turn the first attempt's
                 # verdict into an error; return it uncached instead.
                 if result is None:
                     raise
-                _LOGGER.debug(
-                    "Re-validation of %s failed; returning the pre-write result",
+                _LOGGER.warning(
+                    "Re-validation of %s failed (%r); returning the pre-write result",
                     configuration,
+                    err,
                 )
                 break
             finally:
@@ -435,12 +435,20 @@ class EditorController:
                 # exception (typed for callers) propagates unchanged.
                 if not ok:
                     await self._terminate_subprocess(session)
+            if retry_left and remaining <= 0.0:
+                _LOGGER.debug(
+                    "Validate of %s raced a config-dir write; budget exhausted, "
+                    "returning the raced result uncached",
+                    configuration,
+                )
+                break
             _LOGGER.debug(
                 "Validate of %s raced a config-dir write; %s",
                 configuration,
                 "re-running" if retry_left else "returning the raced result uncached",
             )
-        assert result is not None
+        if result is None:
+            raise ValidatorUnavailableError("validator produced no result")
         return result
 
     async def _validate_locked(

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -373,30 +373,40 @@ class EditorController:
             cached = session.cached
             if cached is not None and cached.is_fresh_for(content_hash):
                 return cached.result
-            ok = False
-            epoch = session.invalidation_epoch
-            try:
-                # Warm the subprocess outside the budget so a cold start
-                # (own ``_STARTUP_TIMEOUT``) doesn't eat a short import timeout.
-                await self._ensure_subprocess(
-                    session, extract_component_source_fingerprint(content)
-                )
-                result = await asyncio.wait_for(
-                    self._validate_locked(session, configuration, content),
-                    timeout=timeout,
-                )
-                ok = True
-            finally:
-                # Any failure (timeout, subprocess loss, a bug, cancellation)
-                # can leave the stateful stdin/stdout protocol mid-message;
-                # kill it so the next call respawns clean. The exception (typed
-                # for callers) propagates unchanged.
-                if not ok:
-                    await self._terminate_subprocess(session)
-            if session.invalidation_epoch == epoch:
-                session.cached = _CachedValidation(
-                    content_hash=content_hash, result=result, at=time.monotonic()
-                )
+            # A config-dir write landing mid round-trip means the result was
+            # computed against pre-write state; re-run once so the caller
+            # gets a post-write verdict instead of a known-stale one.
+            for retry_left in (True, False):
+                ok = False
+                epoch = session.invalidation_epoch
+                try:
+                    # Warm the subprocess outside the budget so a cold start
+                    # (own ``_STARTUP_TIMEOUT``) doesn't eat a short import timeout.
+                    await self._ensure_subprocess(
+                        session, extract_component_source_fingerprint(content)
+                    )
+                    result = await asyncio.wait_for(
+                        self._validate_locked(session, configuration, content),
+                        timeout=timeout,
+                    )
+                    ok = True
+                finally:
+                    # Any failure (timeout, subprocess loss, a bug, cancellation)
+                    # can leave the stateful stdin/stdout protocol mid-message;
+                    # kill it so the next call respawns clean. The exception (typed
+                    # for callers) propagates unchanged.
+                    if not ok:
+                        await self._terminate_subprocess(session)
+                if session.invalidation_epoch == epoch:
+                    session.cached = _CachedValidation(
+                        content_hash=content_hash, result=result, at=time.monotonic()
+                    )
+                    break
+                if retry_left:
+                    _LOGGER.debug(
+                        "Re-validating %s: config-dir write landed mid round-trip",
+                        configuration,
+                    )
             return result
 
     async def _validate_locked(

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -48,6 +48,9 @@ _VALIDATE_CACHE_TTL = 60.0
 # user leaves.
 _IDLE_SUBPROCESS_TIMEOUT = 600.0
 _REAP_INTERVAL = 60.0
+# Below this remaining budget a raced re-run is near-certain to time out;
+# skip it and return the raced result uncached instead.
+_MIN_RERUN_BUDGET = 1.0
 # ``_EditorSession.source_fingerprint`` sentinel that matches no real
 # digest, so the next validate respawns the subprocess.
 _STALE_SOURCES = "stale"
@@ -435,18 +438,15 @@ class EditorController:
                 # exception (typed for callers) propagates unchanged.
                 if not ok:
                     await self._terminate_subprocess(session)
-            if retry_left and remaining <= 0.0:
-                _LOGGER.debug(
-                    "Validate of %s raced a config-dir write; budget exhausted, "
-                    "returning the raced result uncached",
-                    configuration,
-                )
-                break
-            _LOGGER.debug(
-                "Validate of %s raced a config-dir write; %s",
+            if retry_left and remaining > _MIN_RERUN_BUDGET:
+                _LOGGER.debug("Validate of %s raced a config-dir write; re-running", configuration)
+                continue
+            _LOGGER.info(
+                "Validate of %s raced a config-dir write; %s, returning the raced result uncached",
                 configuration,
-                "re-running" if retry_left else "returning the raced result uncached",
+                "budget exhausted" if retry_left else "raced again",
             )
+            break
         if result is None:  # pragma: no cover — attempt one either raises or sets result
             raise ValidatorUnavailableError("validator produced no result")
         return result

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -373,41 +373,75 @@ class EditorController:
             cached = session.cached
             if cached is not None and cached.is_fresh_for(content_hash):
                 return cached.result
-            # A config-dir write landing mid round-trip means the result was
-            # computed against pre-write state; re-run once so the caller
-            # gets a post-write verdict instead of a known-stale one.
-            for retry_left in (True, False):
-                ok = False
-                epoch = session.invalidation_epoch
-                try:
-                    # Warm the subprocess outside the budget so a cold start
-                    # (own ``_STARTUP_TIMEOUT``) doesn't eat a short import timeout.
-                    await self._ensure_subprocess(
-                        session, extract_component_source_fingerprint(content)
-                    )
-                    result = await asyncio.wait_for(
-                        self._validate_locked(session, configuration, content),
-                        timeout=timeout,
-                    )
-                    ok = True
-                finally:
-                    # Any failure (timeout, subprocess loss, a bug, cancellation)
-                    # can leave the stateful stdin/stdout protocol mid-message;
-                    # kill it so the next call respawns clean. The exception (typed
-                    # for callers) propagates unchanged.
-                    if not ok:
-                        await self._terminate_subprocess(session)
+            return await self._validate_with_retry(
+                session, configuration, content, content_hash, timeout
+            )
+
+    async def _validate_with_retry(
+        self,
+        session: _EditorSession,
+        configuration: str,
+        content: str,
+        content_hash: int,
+        timeout: float,
+    ) -> dict:
+        """
+        Run the validation round-trip, re-running once when a config-dir write races it.
+
+        Caller must hold ``session.lock``. The re-run gets the remaining
+        *timeout* budget; a re-run failure falls back to the first
+        attempt's verdict, returned uncached.
+        """
+        # A config-dir write landing mid round-trip means the result was
+        # computed against pre-write state; re-run once, on the remaining
+        # budget, so the caller gets a post-write verdict instead of a
+        # known-stale one.
+        deadline = time.monotonic() + timeout
+        result: dict[str, Any] | None = None
+        for retry_left in (True, False):
+            ok = False
+            epoch = session.invalidation_epoch
+            try:
+                # Warm the subprocess outside the budget so a cold start
+                # (own ``_STARTUP_TIMEOUT``) doesn't eat a short import timeout.
+                await self._ensure_subprocess(
+                    session, extract_component_source_fingerprint(content)
+                )
+                attempt = await asyncio.wait_for(
+                    self._validate_locked(session, configuration, content),
+                    timeout=max(0.0, deadline - time.monotonic()),
+                )
+                result = attempt
+                ok = True
                 if session.invalidation_epoch == epoch:
                     session.cached = _CachedValidation(
-                        content_hash=content_hash, result=result, at=time.monotonic()
+                        content_hash=content_hash, result=attempt, at=time.monotonic()
                     )
                     break
-                if retry_left:
-                    _LOGGER.debug(
-                        "Re-validating %s: config-dir write landed mid round-trip",
-                        configuration,
-                    )
-            return result
+            except Exception:
+                # A failed re-run must not turn the first attempt's
+                # verdict into an error; return it uncached instead.
+                if result is None:
+                    raise
+                _LOGGER.debug(
+                    "Re-validation of %s failed; returning the pre-write result",
+                    configuration,
+                )
+                break
+            finally:
+                # Any failure (timeout, subprocess loss, a bug, cancellation)
+                # can leave the stateful stdin/stdout protocol mid-message;
+                # kill it so the next call respawns clean. A first-attempt
+                # exception (typed for callers) propagates unchanged.
+                if not ok:
+                    await self._terminate_subprocess(session)
+            _LOGGER.debug(
+                "Validate of %s raced a config-dir write; %s",
+                configuration,
+                "re-running" if retry_left else "returning the raced result uncached",
+            )
+        assert result is not None
+        return result
 
     async def _validate_locked(
         self, session: _EditorSession, configuration: str, content: str

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -193,10 +193,10 @@ def device_uses_mqtt(yaml_content: str) -> bool:
 # (esphome's ``CORE.address`` reads the first present one), plus the
 # blocks that feed it indirectly: ``esphome:`` (an absent
 # ``use_address`` derives from ``name``), ``substitutions:`` for the
-# ``use_address: ${var}`` spelling, and ``packages:`` for a network
-# block pulled in by reference.
+# ``use_address: ${var}`` spelling, and ``packages:`` / a top-level
+# ``<<:`` merge key for a network block pulled in by reference.
 _ADDRESS_SOURCE_KEYS = frozenset(
-    {"wifi", "ethernet", "openthread", "esphome", "substitutions", "packages"}
+    {"wifi", "ethernet", "openthread", "esphome", "substitutions", "packages", "<<"}
 )
 
 
@@ -689,14 +689,15 @@ def _match_top_level_key(line: str) -> str | None:
     """
     Return the key for a top-level ``key:`` line, or ``None``.
 
-    Skips blank lines, indented lines, comments, and lines without
-    a colon, so a top-level ``# Comment: ...`` doesn't masquerade as
-    a real YAML key and prematurely close the block being scanned.
+    Skips blank lines, indented lines, comments, zero-indent sequence
+    items, and lines without a colon, so neither a top-level
+    ``# Comment: ...`` nor a ``- source: ...`` list item masquerades as
+    a real YAML key and prematurely closes the block being scanned.
     """
     if not line or line[0].isspace():
         return None
     stripped = line.strip()
-    if stripped.startswith("#") or ":" not in stripped:
+    if stripped.startswith(("#", "- ")) or ":" not in stripped:
         return None
     return stripped.split(":", 1)[0].strip()
 

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -917,6 +917,31 @@ def test_extract_component_source_fingerprint_covers_root_merge_key() -> None:
     )
 
 
+def test_extract_component_source_fingerprint_captures_zero_indent_sequence() -> None:
+    """A zero-indent list under a source block is part of the block; its edits move the digest."""
+    yaml_content = (
+        "external_components:\n"
+        "- source: github://a/b@main\n"
+        "  components: [esp32]\n"
+        "esp32:\n  board: esp32dev\n"
+    )
+    fingerprint = extract_component_source_fingerprint(yaml_content)
+    assert fingerprint != extract_component_source_fingerprint(
+        yaml_content.replace("@main", "@dev")
+    )
+    assert fingerprint != extract_component_source_fingerprint(
+        yaml_content.replace("[esp32]", "[esp32, ota]")
+    )
+
+
+def test_extract_network_address_fingerprint_covers_root_merge_key() -> None:
+    """Repointing a top-level merge include moves the digest."""
+    yaml_content = "esphome:\n  name: dev\n<<: !include base.yaml\nlogger:\n"
+    assert extract_network_address_fingerprint(yaml_content) != extract_network_address_fingerprint(
+        yaml_content.replace("base.yaml", "base2.yaml")
+    )
+
+
 def test_extract_component_source_fingerprint_covers_packages() -> None:
     """A packages edit moves the digest; a package can carry external_components."""
     yaml_content = "esphome:\n  name: dev\npackages:\n  base: !include common/base.yaml\nlogger:\n"

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import time
+import unittest.mock
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -848,7 +849,8 @@ async def test_validate_yaml_warms_subprocess_outside_round_trip_budget(
 
     # Startup happened before the budgeted wait_for, which wrapped only the round-trip.
     assert events == ["ensure", "wait_for", "validate"]
-    assert captured["timeout"] == 0.5
+    # The budget is deadline-derived, so a hair under the requested value.
+    assert captured["timeout"] == pytest.approx(0.5, abs=0.05)
 
 
 async def test_validate_yaml_ignores_client_supplied_timeout(
@@ -877,7 +879,7 @@ async def test_validate_yaml_ignores_client_supplied_timeout(
         configuration="kitchen.yaml", content="", timeout=0.001, client=object()
     )
 
-    assert captured["timeout"] == _VALIDATE_TIMEOUT
+    assert captured["timeout"] == pytest.approx(_VALIDATE_TIMEOUT, abs=0.05)
 
 
 # ---------------------------------------------------------------------------
@@ -1066,6 +1068,65 @@ async def test_invalidate_cache_mid_validate_reruns_once(tmp_path: Path) -> None
     assert result == {"yaml_errors": [], "validation_errors": []}
     assert calls == 2
     assert controller._sessions["kitchen.yaml"].cached is not None
+
+
+async def test_invalidate_cache_mid_validate_rerun_shares_the_budget(tmp_path: Path) -> None:
+    """The re-run gets the remaining budget, not a fresh one."""
+    controller = _make_controller(tmp_path)
+    controller._ensure_subprocess = AsyncMock()  # type: ignore[method-assign]
+    timeouts: list[float] = []
+    real_wait_for = asyncio.wait_for
+    calls = 0
+
+    async def _wait_for(awaitable: Any, *, timeout: float) -> Any:
+        timeouts.append(timeout)
+        return await real_wait_for(awaitable, timeout=timeout)
+
+    async def _raced_once(*_args: Any, **_kwargs: Any) -> dict:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            await asyncio.sleep(0.05)
+            controller.invalidate_cache()
+        return {"yaml_errors": [], "validation_errors": []}
+
+    controller._validate_locked = _raced_once  # type: ignore[method-assign]
+
+    with unittest.mock.patch(
+        "esphome_device_builder.controllers.editor.asyncio.wait_for", _wait_for
+    ):
+        await controller.validate_yaml(
+            configuration="kitchen.yaml", content="esphome:\n", timeout=1.0
+        )
+
+    assert calls == 2
+    assert timeouts[0] <= 1.0
+    assert timeouts[1] <= timeouts[0] - 0.05
+
+
+async def test_invalidate_cache_mid_validate_rerun_failure_returns_first_result(
+    tmp_path: Path,
+) -> None:
+    """A re-run that fails falls back to the first attempt's verdict, uncached."""
+    controller = _make_controller(tmp_path)
+    controller._ensure_subprocess = AsyncMock()  # type: ignore[method-assign]
+    calls = 0
+
+    async def _second_call_dies(*_args: Any, **_kwargs: Any) -> dict:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            controller.invalidate_cache()
+            return {"yaml_errors": [], "validation_errors": []}
+        raise ValidatorUnavailableError("respawn failed")
+
+    controller._validate_locked = _second_call_dies  # type: ignore[method-assign]
+
+    result = await controller.validate_yaml(configuration="kitchen.yaml", content="esphome:\n")
+
+    assert result == {"yaml_errors": [], "validation_errors": []}
+    assert calls == 2
+    assert controller._sessions["kitchen.yaml"].cached is None
 
 
 async def test_invalidate_cache_mid_validate_rerun_is_bounded(tmp_path: Path) -> None:

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -826,6 +826,8 @@ async def test_validate_yaml_warms_subprocess_outside_round_trip_budget(
     events: list[str] = []
 
     async def _ensure(_session: _EditorSession, _fingerprint: str) -> None:
+        # A slow cold start must not shrink the round-trip budget below.
+        await asyncio.sleep(0.02)
         events.append("ensure")
 
     async def _locked(*_args: Any, **_kwargs: Any) -> dict:
@@ -849,8 +851,7 @@ async def test_validate_yaml_warms_subprocess_outside_round_trip_budget(
 
     # Startup happened before the budgeted wait_for, which wrapped only the round-trip.
     assert events == ["ensure", "wait_for", "validate"]
-    # The budget is deadline-derived, so a hair under the requested value.
-    assert captured["timeout"] == pytest.approx(0.5, abs=0.05)
+    assert captured["timeout"] == 0.5
 
 
 async def test_validate_yaml_ignores_client_supplied_timeout(
@@ -879,7 +880,7 @@ async def test_validate_yaml_ignores_client_supplied_timeout(
         configuration="kitchen.yaml", content="", timeout=0.001, client=object()
     )
 
-    assert captured["timeout"] == pytest.approx(_VALIDATE_TIMEOUT, abs=0.05)
+    assert captured["timeout"] == _VALIDATE_TIMEOUT
 
 
 # ---------------------------------------------------------------------------
@@ -1102,6 +1103,39 @@ async def test_invalidate_cache_mid_validate_rerun_shares_the_budget(tmp_path: P
     assert calls == 2
     assert timeouts[0] <= 1.0
     assert timeouts[1] <= timeouts[0] - 0.05
+
+
+async def test_invalidate_cache_mid_validate_rerun_skipped_when_budget_spent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A raced first attempt that consumed the budget returns uncached without a re-run."""
+    controller = _make_controller(tmp_path)
+    controller._ensure_subprocess = AsyncMock()  # type: ignore[method-assign]
+    clock = 1000.0
+
+    def _monotonic() -> float:
+        nonlocal clock
+        clock += 10.0
+        return clock
+
+    monkeypatch.setattr("esphome_device_builder.controllers.editor.time.monotonic", _monotonic)
+    calls = 0
+
+    async def _raced(*_args: Any, **_kwargs: Any) -> dict:
+        nonlocal calls
+        calls += 1
+        controller.invalidate_cache()
+        return {"yaml_errors": [], "validation_errors": []}
+
+    controller._validate_locked = _raced  # type: ignore[method-assign]
+
+    result = await controller.validate_yaml(
+        configuration="kitchen.yaml", content="esphome:\n", timeout=5.0
+    )
+
+    assert result == {"yaml_errors": [], "validation_errors": []}
+    assert calls == 1
+    assert controller._sessions["kitchen.yaml"].cached is None
 
 
 async def test_invalidate_cache_mid_validate_rerun_failure_returns_first_result(

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -1097,40 +1097,35 @@ async def test_invalidate_cache_mid_validate_rerun_shares_the_budget(tmp_path: P
         "esphome_device_builder.controllers.editor.asyncio.wait_for", _wait_for
     ):
         await controller.validate_yaml(
-            configuration="kitchen.yaml", content="esphome:\n", timeout=1.0
+            configuration="kitchen.yaml", content="esphome:\n", timeout=5.0
         )
 
     assert calls == 2
-    assert timeouts[0] <= 1.0
+    assert timeouts[0] == 5.0
     assert timeouts[1] <= timeouts[0] - 0.05
 
 
 async def test_invalidate_cache_mid_validate_rerun_skipped_when_budget_spent(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
 ) -> None:
-    """A raced first attempt that consumed the budget returns uncached without a re-run."""
+    """A raced first attempt that left under the re-run floor returns uncached without a re-run."""
     controller = _make_controller(tmp_path)
     controller._ensure_subprocess = AsyncMock()  # type: ignore[method-assign]
-    clock = 1000.0
-
-    def _monotonic() -> float:
-        nonlocal clock
-        clock += 10.0
-        return clock
-
-    monkeypatch.setattr("esphome_device_builder.controllers.editor.time.monotonic", _monotonic)
     calls = 0
 
     async def _raced(*_args: Any, **_kwargs: Any) -> dict:
         nonlocal calls
         calls += 1
+        # Consume enough of the 1.2s budget that the remainder sits
+        # under ``_MIN_RERUN_BUDGET`` (1.0) no matter the jitter.
+        await asyncio.sleep(0.25)
         controller.invalidate_cache()
         return {"yaml_errors": [], "validation_errors": []}
 
     controller._validate_locked = _raced  # type: ignore[method-assign]
 
     result = await controller.validate_yaml(
-        configuration="kitchen.yaml", content="esphome:\n", timeout=5.0
+        configuration="kitchen.yaml", content="esphome:\n", timeout=1.2
     )
 
     assert result == {"yaml_errors": [], "validation_errors": []}

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -1037,16 +1037,20 @@ async def test_invalidate_cache_stales_sourced_sessions(
     assert controller._sessions["kitchen.yaml"].proc is spawned[-1]
 
 
-async def test_invalidate_cache_mid_validate_discards_inflight_result(tmp_path: Path) -> None:
-    """A validate overlapping a config-dir write must not reinstate its pre-write result."""
+async def test_invalidate_cache_mid_validate_reruns_once(tmp_path: Path) -> None:
+    """A validate overlapping a config-dir write re-runs once and caches the post-write result."""
     controller = _make_controller(tmp_path)
     controller._ensure_subprocess = AsyncMock()  # type: ignore[method-assign]
     in_flight = asyncio.Event()
     release = asyncio.Event()
+    calls = 0
 
     async def _blocked(*_args: Any, **_kwargs: Any) -> dict:
-        in_flight.set()
-        await release.wait()
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            in_flight.set()
+            await release.wait()
         return {"yaml_errors": [], "validation_errors": []}
 
     controller._validate_locked = _blocked  # type: ignore[method-assign]
@@ -1060,6 +1064,28 @@ async def test_invalidate_cache_mid_validate_discards_inflight_result(tmp_path: 
     result = await task
 
     assert result == {"yaml_errors": [], "validation_errors": []}
+    assert calls == 2
+    assert controller._sessions["kitchen.yaml"].cached is not None
+
+
+async def test_invalidate_cache_mid_validate_rerun_is_bounded(tmp_path: Path) -> None:
+    """Writes landing on every round-trip stop the re-run at one; the result stays uncached."""
+    controller = _make_controller(tmp_path)
+    controller._ensure_subprocess = AsyncMock()  # type: ignore[method-assign]
+    calls = 0
+
+    async def _always_raced(*_args: Any, **_kwargs: Any) -> dict:
+        nonlocal calls
+        calls += 1
+        controller.invalidate_cache()
+        return {"yaml_errors": [], "validation_errors": []}
+
+    controller._validate_locked = _always_raced  # type: ignore[method-assign]
+
+    result = await controller.validate_yaml(configuration="kitchen.yaml", content="esphome:\n")
+
+    assert result == {"yaml_errors": [], "validation_errors": []}
+    assert calls == 2
     assert controller._sessions["kitchen.yaml"].cached is None
 
 


### PR DESCRIPTION
# What does this implement/fix?

Follow up to the post merge review rounds on #2591, closing the three remaining findings. A zero indent list under a source block (`external_components:` followed by `- source:` at column 0, valid YAML) was truncating the block capture to the bare key line, so source edits in that shape never moved the fingerprint and the warm validator kept its stale modules; `_match_top_level_key` now treats zero indent sequence items as block continuations, which also fixes the same truncation in the network address fingerprint. `_ADDRESS_SOURCE_KEYS` gains the top level `<<:` merge key, matching what #2591 taught the component source set, so repointing a root merge include at a different base file schedules the StorageJSON regen. And a validate raced by a config dir write now re-runs once (bounded) instead of returning the known pre-write result uncached, so the caller gets a post write verdict.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/pull/2591#issuecomment-5336045423

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
