### PR TITLE
Reclaim an idle offloader's build data dir in the remote-build sweep

### DIFF
--- a/esphome_device_builder/controllers/remote_build/cleanup_loop.py
+++ b/esphome_device_builder/controllers/remote_build/cleanup_loop.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import asyncio
 import logging
 from functools import partial
+from pathlib import Path
 from typing import TYPE_CHECKING
+
+from esphome.core import CORE
 
 from ...helpers.async_ import run_in_executor
 from ...helpers.remote_build_cleanup import sweep_remote_builds
@@ -31,6 +34,7 @@ async def run_cleanup_loop(controller: ReceiverController) -> None:
     the sleep.
     """
     config_dir = controller._db.settings.config_dir
+    data_dir = Path(CORE.data_dir)
     while True:
         await asyncio.sleep(_CLEANUP_SWEEP_INTERVAL_SECONDS)
         try:
@@ -49,6 +53,7 @@ async def run_cleanup_loop(controller: ReceiverController) -> None:
                 partial(
                     sweep_remote_builds,
                     config_dir,
+                    data_dir=data_dir,
                     ttl_seconds=settings.cleanup_ttl_seconds,
                     in_flight_keys=in_flight_keys,
                 ),

--- a/esphome_device_builder/controllers/remote_build/cleanup_loop.py
+++ b/esphome_device_builder/controllers/remote_build/cleanup_loop.py
@@ -57,7 +57,7 @@ async def run_cleanup_loop(controller: ReceiverController) -> None:
                 ),
             )
             if deleted:
-                _LOGGER.info("remote-build cleanup: swept %d cold subtree(s)", deleted)
+                _LOGGER.info("remote-build cleanup: reclaimed %d cold subtree(s)", deleted)
         except Exception:
             _LOGGER.exception("remote-build cleanup sweep failed")
 
@@ -65,7 +65,7 @@ async def run_cleanup_loop(controller: ReceiverController) -> None:
 def _sweep(
     config_dir: Path, *, ttl_seconds: float, in_flight_keys: frozenset[RemoteBuildPath]
 ) -> int:
-    """Run one sweep; resolves ``CORE.data_dir`` here because it stats the config dir."""
+    """Run one sweep with ``CORE.data_dir`` resolved on the executor thread."""
     return sweep_remote_builds(
         config_dir,
         data_dir=Path(CORE.data_dir),

--- a/esphome_device_builder/controllers/remote_build/cleanup_loop.py
+++ b/esphome_device_builder/controllers/remote_build/cleanup_loop.py
@@ -12,7 +12,7 @@ from esphome.core import CORE
 
 from ...helpers.async_ import run_in_executor
 from ...helpers.remote_build_cleanup import sweep_remote_builds
-from ...helpers.remote_build_layout import parse_from_configuration
+from ...helpers.remote_build_layout import RemoteBuildPath, parse_from_configuration
 
 if TYPE_CHECKING:
     from .receiver import ReceiverController
@@ -34,7 +34,6 @@ async def run_cleanup_loop(controller: ReceiverController) -> None:
     the sleep.
     """
     config_dir = controller._db.settings.config_dir
-    data_dir = Path(CORE.data_dir)
     while True:
         await asyncio.sleep(_CLEANUP_SWEEP_INTERVAL_SECONDS)
         try:
@@ -51,9 +50,8 @@ async def run_cleanup_loop(controller: ReceiverController) -> None:
             )
             deleted = await run_in_executor(
                 partial(
-                    sweep_remote_builds,
+                    _sweep,
                     config_dir,
-                    data_dir=data_dir,
                     ttl_seconds=settings.cleanup_ttl_seconds,
                     in_flight_keys=in_flight_keys,
                 ),
@@ -62,3 +60,15 @@ async def run_cleanup_loop(controller: ReceiverController) -> None:
                 _LOGGER.info("remote-build cleanup: swept %d cold subtree(s)", deleted)
         except Exception:
             _LOGGER.exception("remote-build cleanup sweep failed")
+
+
+def _sweep(
+    config_dir: Path, *, ttl_seconds: float, in_flight_keys: frozenset[RemoteBuildPath]
+) -> int:
+    """Run one sweep; resolves ``CORE.data_dir`` here because it stats the config dir."""
+    return sweep_remote_builds(
+        config_dir,
+        data_dir=Path(CORE.data_dir),
+        ttl_seconds=ttl_seconds,
+        in_flight_keys=in_flight_keys,
+    )

--- a/esphome_device_builder/helpers/remote_build_cleanup.py
+++ b/esphome_device_builder/helpers/remote_build_cleanup.py
@@ -101,16 +101,23 @@ def sweep_remote_builds(
     # data dir under a second root; walk the union so a dashboard whose
     # config-root dir was pruned on an earlier sweep is still reclaimed.
     data_root = data_dir / REMOTE_BUILDS_NAME
-    # Skip if either root is a symlink — ``is_dir()`` would
+    # Skip if the root itself is a symlink — ``is_dir()`` would
     # follow it and the sweep would walk into whatever directory
     # the symlink targets, potentially deleting subtrees outside
-    # the canonical layout. The canonical writers (submit_job,
-    # the compile subprocess) create these roots as real
-    # directories; a symlink here is operator-or-attacker-placed
-    # and outside trust scope. Defense-in-depth matching the
-    # symlink skips at the dashboard_dir and entry levels below.
-    if root.is_symlink() or data_root.is_symlink():
+    # the canonical layout. The canonical writer (submit_job)
+    # creates this root as a real directory; a symlink here is
+    # operator-or-attacker-placed and outside trust scope.
+    # Defense-in-depth matching the symlink skips at the
+    # dashboard_dir and entry levels below.
+    if root.is_symlink():
         return 0
+    # Same stance for the data root, scoped to what lives under it:
+    # the config-root subtree sweep still runs.
+    reclaim_data_dirs = not data_root.is_symlink()
+    if not reclaim_data_dirs:
+        _LOGGER.warning(
+            "remote-build cleanup: %s is a symlink; leaving build data dirs alone", data_root
+        )
 
     in_flight_dir_ids = frozenset(key.dir_id for key in in_flight_keys)
     deleted = 0
@@ -138,9 +145,10 @@ def sweep_remote_builds(
             continue
         # Nothing references this offloader any more: reclaim its
         # build data dir, then prune the empty parents on both roots.
-        deleted += _reclaim_dashboard_data_dir(name, data_dir)
+        if reclaim_data_dirs:
+            deleted += _reclaim_dashboard_data_dir(name, data_dir)
+            _prune_empty_dir(data_root / name)
         _prune_empty_dir(dashboard_dir)
-        _prune_empty_dir(data_root / name)
     return deleted
 
 
@@ -155,10 +163,21 @@ def _dashboard_names(*roots: Path) -> set[str]:
 
 
 def _holds_live_entries(dashboard_dir: Path) -> bool:
-    """Return ``True`` while anything but the data dir or macOS metadata sits in *dashboard_dir*."""
+    """
+    Return ``True`` while anything but the data dir or macOS metadata sits in *dashboard_dir*.
+
+    A directory that can't be listed counts as live; a missing one doesn't.
+    """
+    try:
+        entries = list(dashboard_dir.iterdir())
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        _LOGGER.debug("remote-build cleanup: iterdir(%s) failed: %s", dashboard_dir, exc)
+        return True
     return any(
         entry.name.casefold() != DATA_DIR_NAME and not _is_macos_metadata(entry.name)
-        for entry in _safe_iterdir(dashboard_dir)
+        for entry in entries
     )
 
 

--- a/esphome_device_builder/helpers/remote_build_cleanup.py
+++ b/esphome_device_builder/helpers/remote_build_cleanup.py
@@ -89,28 +89,29 @@ def sweep_remote_builds(
             deterministic.
 
     Returns:
-        Number of subtrees deleted. Useful for the caller's log
-        line so operators can see the cleanup running.
+        Number of subtrees deleted, device extracts and idle
+        build data dirs alike. Useful for the caller's log line
+        so operators can see the cleanup running.
     """
     if now is None:
         now = time.time()
     cutoff = now - ttl_seconds
     root = config_dir / REMOTE_BUILDS_SUBDIR
-    # Skip if the root itself is a symlink — ``is_dir()`` would
-    # follow it and the sweep would walk into whatever directory
-    # the symlink targets, potentially deleting subtrees outside
-    # the canonical layout. The canonical writer (submit_job)
-    # creates this root as a real directory; a symlink here is
-    # operator-or-attacker-placed and outside trust scope.
-    # Defense-in-depth matching the symlink skips at the
-    # dashboard_dir and entry levels below.
-    if root.is_symlink():
-        return 0
-
     # Split-root deployments (HA add-on, ``ESPHOME_DATA_DIR``) hold the
     # data dir under a second root; walk the union so a dashboard whose
     # config-root dir was pruned on an earlier sweep is still reclaimed.
     data_root = data_dir / REMOTE_BUILDS_NAME
+    # Skip if either root is a symlink — ``is_dir()`` would
+    # follow it and the sweep would walk into whatever directory
+    # the symlink targets, potentially deleting subtrees outside
+    # the canonical layout. The canonical writers (submit_job,
+    # the compile subprocess) create these roots as real
+    # directories; a symlink here is operator-or-attacker-placed
+    # and outside trust scope. Defense-in-depth matching the
+    # symlink skips at the dashboard_dir and entry levels below.
+    if root.is_symlink() or data_root.is_symlink():
+        return 0
+
     in_flight_dir_ids = frozenset(key.dir_id for key in in_flight_keys)
     deleted = 0
     for name in _dashboard_names(root, data_root):

--- a/esphome_device_builder/helpers/remote_build_cleanup.py
+++ b/esphome_device_builder/helpers/remote_build_cleanup.py
@@ -22,9 +22,11 @@ QUEUED case (waiting in the receiver's queue before
 ``JOB_STARTED`` fires) and for the brief gap between a job
 completing and the next submission.
 
-Empty ``<dashboard_id>/`` parents are pruned after the subtree
-sweep so an offloader that's been removed entirely doesn't
-leave a permanent empty directory behind.
+An offloader's shared build data dir
+(``<data_dir>/.remote_builds/<dashboard_id>/.esphome``) is
+reclaimed once nothing remains under its ``<dashboard_id>/``
+and no job targeting it is in flight; empty parents are pruned
+on both roots.
 
 Best-effort: per-subtree exceptions (permission denied, races
 against a concurrent submit) get logged and the walk continues.
@@ -42,9 +44,11 @@ from esphome.helpers import rmtree
 from .remote_build_layout import (
     BUNDLE_SUFFIX,
     DATA_DIR_NAME,
+    REMOTE_BUILDS_NAME,
     REMOTE_BUILDS_SUBDIR,
     VENVS_NAME,
     RemoteBuildPath,
+    per_dashboard_data_dir,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -53,6 +57,7 @@ _LOGGER = logging.getLogger(__name__)
 def sweep_remote_builds(
     config_dir: Path,
     *,
+    data_dir: Path,
     ttl_seconds: float,
     in_flight_keys: frozenset[RemoteBuildPath],
     now: float | None = None,
@@ -66,6 +71,9 @@ def sweep_remote_builds(
         config_dir: The receiver's ``CORE.config_dir`` — the
             sweep operates on
             ``config_dir / REMOTE_BUILDS_SUBDIR``.
+        data_dir: The receiver's ``CORE.data_dir``; holds each
+            offloader's shared build data dir, reclaimed once
+            nothing under its ``<dashboard_id>/`` remains.
         ttl_seconds: Delete every subtree whose ``st_mtime`` is
             older than ``now - ttl_seconds``. Values <= 0 are
             treated as "delete everything not in-flight"; the
@@ -96,14 +104,17 @@ def sweep_remote_builds(
     # operator-or-attacker-placed and outside trust scope.
     # Defense-in-depth matching the symlink skips at the
     # dashboard_dir and entry levels below.
-    if root.is_symlink() or not root.is_dir():
+    if root.is_symlink():
         return 0
 
+    # Split-root deployments (HA add-on, ``ESPHOME_DATA_DIR``) hold the
+    # data dir under a second root; walk the union so a dashboard whose
+    # config-root dir was pruned on an earlier sweep is still reclaimed.
+    data_root = data_dir / REMOTE_BUILDS_NAME
+    in_flight_dir_ids = frozenset(key.dir_id for key in in_flight_keys)
     deleted = 0
-    for dashboard_dir in _safe_iterdir(root):
-        # Standalone-install sibling of the dashboard dirs, not one of them.
-        if dashboard_dir.name.casefold() == VENVS_NAME:
-            continue
+    for name in _dashboard_names(root, data_root):
+        dashboard_dir = root / name
         # Symlinks at any level are skipped outright. ``is_dir()``
         # follows symlinks by default, so a symlink to a directory
         # would pass the next check; ``rmtree`` on that symlink
@@ -113,20 +124,55 @@ def sweep_remote_builds(
         # against an operator (or attacker with write access to
         # the remote-builds root) placing a symlink that points
         # outside the canonical subtree.
-        if dashboard_dir.is_symlink() or not dashboard_dir.is_dir():
+        if dashboard_dir.is_symlink() or (dashboard_dir.exists() and not dashboard_dir.is_dir()):
             _LOGGER.debug(
                 "remote-build cleanup: skipping non-directory under %s: %s",
                 root,
                 dashboard_dir,
             )
             continue
-        deleted += _sweep_dashboard_dir(dashboard_dir, config_dir, in_flight_keys, cutoff)
-        # An offloader that was paired once and never came back
-        # leaves an otherwise-permanent empty dashboard_id dir;
-        # prune here so the filesystem stays tidy without a
-        # separate housekeeping pass.
+        if dashboard_dir.is_dir():
+            deleted += _sweep_dashboard_dir(dashboard_dir, config_dir, in_flight_keys, cutoff)
+        if name in in_flight_dir_ids or _holds_live_entries(dashboard_dir):
+            continue
+        # Nothing references this offloader any more: reclaim its
+        # build data dir, then prune the empty parents on both roots.
+        deleted += _reclaim_dashboard_data_dir(name, data_dir)
         _prune_empty_dir(dashboard_dir)
+        _prune_empty_dir(data_root / name)
     return deleted
+
+
+def _dashboard_names(*roots: Path) -> set[str]:
+    """Return the ``<dashboard_id>`` entry names across *roots*, minus the venv cache."""
+    names: set[str] = set()
+    for root in roots:
+        if root.is_symlink() or not root.is_dir():
+            continue
+        names.update(entry.name for entry in _safe_iterdir(root))
+    return {name for name in names if name.casefold() != VENVS_NAME}
+
+
+def _holds_live_entries(dashboard_dir: Path) -> bool:
+    """Return ``True`` while anything but the data dir or macOS metadata sits in *dashboard_dir*."""
+    return any(
+        entry.name.casefold() != DATA_DIR_NAME and not _is_macos_metadata(entry.name)
+        for entry in _safe_iterdir(dashboard_dir)
+    )
+
+
+def _reclaim_dashboard_data_dir(dir_id: str, data_dir: Path) -> int:
+    """Delete *dir_id*'s shared build data dir; return the delete count."""
+    target = per_dashboard_data_dir(data_dir, dir_id)
+    if target.parent.is_symlink() or target.is_symlink() or not target.is_dir():
+        return 0
+    try:
+        rmtree(target)
+    except OSError as exc:
+        _LOGGER.warning("remote-build cleanup: rmtree(%s) failed: %s", target, exc)
+        return 0
+    _LOGGER.info("remote-build cleanup: removed idle build data dir %s", target)
+    return 1
 
 
 def _sweep_dashboard_dir(
@@ -279,14 +325,18 @@ def _reclaim_orphan_bundle(
     _LOGGER.info("remote-build cleanup: removed orphan bundle %s", bundle)
 
 
+def _is_macos_metadata(name: str) -> bool:
+    """Return ``True`` for Finder droppings (``.DS_Store``, AppleDouble ``._*``)."""
+    return name == ".DS_Store" or name.startswith("._")
+
+
 def _prune_empty_dir(directory: Path) -> None:
     """Remove *directory* when empty or holding only macOS metadata."""
+    if directory.is_symlink() or not directory.is_dir():
+        return
     metadata: list[Path] = []
     for entry in _safe_iterdir(directory):
-        if entry.is_symlink():
-            return
-        name = entry.name
-        if name != ".DS_Store" and not name.startswith("._"):
+        if entry.is_symlink() or not _is_macos_metadata(entry.name):
             return
         metadata.append(entry)
     for entry in metadata:

--- a/esphome_device_builder/helpers/remote_build_layout.py
+++ b/esphome_device_builder/helpers/remote_build_layout.py
@@ -56,6 +56,11 @@ def venvs_dir(data_dir: Path) -> Path:
     return data_dir / REMOTE_BUILDS_NAME / VENVS_NAME
 
 
+def per_dashboard_data_dir(data_dir: Path, dir_id: str) -> Path:
+    """Return the ``ESPHOME_DATA_DIR`` shared by every remote build from one offloader."""
+    return data_dir / REMOTE_BUILDS_NAME / dir_id / DATA_DIR_NAME
+
+
 # POSIX-form parts of ``REMOTE_BUILDS_SUBDIR``, pre-split once.
 # :attr:`FirmwareJob.configuration` is forward-slash on every
 # platform so the reverse parse uses these directly.
@@ -144,7 +149,7 @@ class RemoteBuildPath:
         pre-extract wipe off the deep ``build/<env>/.pioenvs``
         tree (PR #578).
         """
-        return dashboard_data_dir / REMOTE_BUILDS_NAME / self.dir_id / DATA_DIR_NAME
+        return per_dashboard_data_dir(dashboard_data_dir, self.dir_id)
 
 
 def parse_from_configuration(configuration: str) -> RemoteBuildPath | None:

--- a/tests/test_remote_build_cleanup.py
+++ b/tests/test_remote_build_cleanup.py
@@ -9,6 +9,7 @@ disk-side branches all surface here.
 
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import Callable
 from pathlib import Path
@@ -266,6 +267,60 @@ def test_sweep_keeps_data_dir_while_a_job_is_in_flight(tmp_path: Path, split: bo
     )
     assert deleted == 0
     assert data_dir.is_dir()
+
+
+def test_sweep_skips_when_data_root_is_symlink(tmp_path: Path) -> None:
+    """A symlinked ``<data_dir>/.remote_builds`` disables the sweep outright."""
+    now = 1_000_000.0
+    config_dir, data_root = _roots(tmp_path, split=True)
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    _populate(config_dir, key, age_seconds=3600, now=now)
+    real = tmp_path / "elsewhere" / "alpha" / DATA_DIR_NAME
+    real.mkdir(parents=True)
+    data_root.mkdir()
+    (data_root / REMOTE_BUILDS_NAME).symlink_to(tmp_path / "elsewhere")
+
+    deleted = sweep_remote_builds(
+        config_dir, data_dir=data_root, ttl_seconds=600, in_flight_keys=frozenset(), now=now
+    )
+    assert deleted == 0
+    assert key.subtree(config_dir).is_dir()
+    assert real.is_dir()
+
+
+def test_sweep_leaves_symlinked_data_dir_and_its_parent_alone(tmp_path: Path) -> None:
+    """A symlink at the data dir's position is neither followed nor removed; it blocks the prune."""
+    real = tmp_path / "elsewhere"
+    real.mkdir()
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    link = key.data_dir(tmp_path / DATA_DIR_NAME)
+    link.parent.mkdir(parents=True)
+    link.symlink_to(real)
+
+    deleted = _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset())
+    assert deleted == 0
+    assert link.is_symlink()
+    assert real.is_dir()
+    assert link.parent.is_dir()
+
+
+def test_sweep_logs_data_dir_rmtree_failure_and_keeps_parent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A failing data-dir ``rmtree`` is logged, not counted, and leaves the parent in place."""
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    data_dir = key.data_dir(tmp_path / DATA_DIR_NAME)
+    data_dir.mkdir(parents=True)
+
+    def _fail(_path: Path) -> None:
+        raise OSError("simulated rmtree failure")
+
+    monkeypatch.setattr("esphome_device_builder.helpers.remote_build_cleanup.rmtree", _fail)
+    with caplog.at_level(logging.WARNING):
+        deleted = _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset())
+    assert deleted == 0
+    assert data_dir.is_dir()
+    assert "simulated rmtree failure" in caplog.text
 
 
 def test_sweep_keeps_data_dir_while_a_sibling_subtree_is_warm(tmp_path: Path) -> None:

--- a/tests/test_remote_build_cleanup.py
+++ b/tests/test_remote_build_cleanup.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -269,8 +269,10 @@ def test_sweep_keeps_data_dir_while_a_job_is_in_flight(tmp_path: Path, split: bo
     assert data_dir.is_dir()
 
 
-def test_sweep_skips_when_data_root_is_symlink(tmp_path: Path) -> None:
-    """A symlinked ``<data_dir>/.remote_builds`` disables the sweep outright."""
+def test_sweep_leaves_data_dirs_alone_when_data_root_is_symlink(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A symlinked ``<data_dir>/.remote_builds`` is warned about; only the subtree sweep runs."""
     now = 1_000_000.0
     config_dir, data_root = _roots(tmp_path, split=True)
     key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
@@ -280,12 +282,35 @@ def test_sweep_skips_when_data_root_is_symlink(tmp_path: Path) -> None:
     data_root.mkdir()
     (data_root / REMOTE_BUILDS_NAME).symlink_to(tmp_path / "elsewhere")
 
-    deleted = sweep_remote_builds(
-        config_dir, data_dir=data_root, ttl_seconds=600, in_flight_keys=frozenset(), now=now
-    )
-    assert deleted == 0
-    assert key.subtree(config_dir).is_dir()
+    with caplog.at_level(logging.WARNING):
+        deleted = sweep_remote_builds(
+            config_dir, data_dir=data_root, ttl_seconds=600, in_flight_keys=frozenset(), now=now
+        )
+    assert deleted == 1
+    assert not key.subtree(config_dir).exists()
     assert real.is_dir()
+    assert "is a symlink" in caplog.text
+
+
+def test_sweep_keeps_data_dir_when_dashboard_dir_is_unlistable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A ``<dashboard_id>/`` that can't be listed counts as live; its data dir stays."""
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    data_dir = key.data_dir(tmp_path / DATA_DIR_NAME)
+    data_dir.mkdir(parents=True)
+    dashboard_dir = data_dir.parent
+    real_iterdir = Path.iterdir
+
+    def _iterdir(self: Path) -> Iterator[Path]:
+        if self == dashboard_dir:
+            raise PermissionError("simulated EACCES")
+        return real_iterdir(self)
+
+    monkeypatch.setattr(Path, "iterdir", _iterdir)
+    deleted = _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset())
+    assert deleted == 0
+    assert data_dir.is_dir()
 
 
 def test_sweep_leaves_symlinked_data_dir_and_its_parent_alone(tmp_path: Path) -> None:
@@ -323,17 +348,21 @@ def test_sweep_logs_data_dir_rmtree_failure_and_keeps_parent(
     assert "simulated rmtree failure" in caplog.text
 
 
-def test_sweep_keeps_data_dir_while_a_sibling_subtree_is_warm(tmp_path: Path) -> None:
+@_ROOT_SHAPES
+def test_sweep_keeps_data_dir_while_a_sibling_subtree_is_warm(tmp_path: Path, split: bool) -> None:
     """A warm device under the dashboard keeps its shared build data dir."""
     now = 1_000_000.0
+    config_dir, data_root = _roots(tmp_path, split)
     cold = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
     warm = RemoteBuildPath(dashboard_id="alpha", device_name="garage")
-    _populate(tmp_path, cold, age_seconds=3600, now=now)
-    _populate(tmp_path, warm, age_seconds=60, now=now)
-    data_dir = cold.data_dir(tmp_path / DATA_DIR_NAME)
+    _populate(config_dir, cold, age_seconds=3600, now=now)
+    _populate(config_dir, warm, age_seconds=60, now=now)
+    data_dir = cold.data_dir(data_root)
     data_dir.mkdir(parents=True)
 
-    deleted = _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    deleted = sweep_remote_builds(
+        config_dir, data_dir=data_root, ttl_seconds=600, in_flight_keys=frozenset(), now=now
+    )
     assert deleted == 1
     assert data_dir.is_dir()
 

--- a/tests/test_remote_build_cleanup.py
+++ b/tests/test_remote_build_cleanup.py
@@ -24,10 +24,12 @@ from esphome_device_builder.helpers.remote_build_cleanup import (
 )
 from esphome_device_builder.helpers.remote_build_layout import (
     DATA_DIR_NAME,
+    REMOTE_BUILDS_NAME,
     REMOTE_BUILDS_SUBDIR,
     VENVS_NAME,
     RemoteBuildPath,
     parse_from_configuration,
+    venvs_dir,
 )
 
 
@@ -47,9 +49,33 @@ def _populate(config_dir: Path, key: RemoteBuildPath, *, age_seconds: float, now
     os.utime(subtree, (target_mtime, target_mtime))
 
 
+def _sweep(
+    config_dir: Path,
+    *,
+    ttl_seconds: float,
+    in_flight_keys: frozenset[RemoteBuildPath],
+    now: float | None = None,
+) -> int:
+    """Run the sweep in the standalone shape, where ``data_dir`` is ``<config_dir>/.esphome``."""
+    return sweep_remote_builds(
+        config_dir,
+        data_dir=config_dir / DATA_DIR_NAME,
+        ttl_seconds=ttl_seconds,
+        in_flight_keys=in_flight_keys,
+        now=now,
+    )
+
+
+def _roots(tmp_path: Path, split: bool) -> tuple[Path, Path]:
+    """Return ``(config_dir, data_dir)`` for the standalone or add-on on-disk shape."""
+    if split:
+        return tmp_path / "config", tmp_path / "data"
+    return tmp_path, tmp_path / DATA_DIR_NAME
+
+
 def test_sweep_returns_zero_on_missing_remote_builds_root(tmp_path: Path) -> None:
     """A fresh receiver with no submissions yet → no-op + zero deletes."""
-    assert sweep_remote_builds(tmp_path, ttl_seconds=10, in_flight_keys=frozenset()) == 0
+    assert _sweep(tmp_path, ttl_seconds=10, in_flight_keys=frozenset()) == 0
 
 
 def test_sweep_deletes_subtree_and_bundle_when_cold(tmp_path: Path) -> None:
@@ -58,7 +84,7 @@ def test_sweep_deletes_subtree_and_bundle_when_cold(tmp_path: Path) -> None:
     key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
     _populate(tmp_path, key, age_seconds=3600, now=now)
 
-    deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    deleted = _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     assert deleted == 1
     assert not key.subtree(tmp_path).exists()
     assert not key.bundle(tmp_path).exists()
@@ -70,7 +96,7 @@ def test_sweep_keeps_fresh_subtree(tmp_path: Path) -> None:
     key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
     _populate(tmp_path, key, age_seconds=60, now=now)
 
-    deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    deleted = _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     assert deleted == 0
     assert key.subtree(tmp_path).is_dir()
     assert key.bundle(tmp_path).is_file()
@@ -82,7 +108,7 @@ def test_sweep_skips_in_flight_even_when_cold(tmp_path: Path) -> None:
     key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
     _populate(tmp_path, key, age_seconds=3600, now=now)
 
-    deleted = sweep_remote_builds(
+    deleted = _sweep(
         tmp_path,
         ttl_seconds=600,
         in_flight_keys=frozenset({key}),
@@ -98,7 +124,7 @@ def test_sweep_prunes_empty_dashboard_parent(tmp_path: Path) -> None:
     key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
     _populate(tmp_path, key, age_seconds=3600, now=now)
 
-    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     parent = tmp_path / REMOTE_BUILDS_SUBDIR / "alpha"
     assert not parent.exists()
 
@@ -112,7 +138,7 @@ def test_sweep_prunes_dashboard_parent_with_macos_metadata(tmp_path: Path) -> No
     (dashboard_dir / ".DS_Store").write_bytes(b"\x00\x00\x00\x01Bud1")
     (dashboard_dir / "._kitchen").write_bytes(b"AppleDouble")
 
-    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     assert not dashboard_dir.exists()
 
 
@@ -127,7 +153,7 @@ def test_sweep_leaves_macos_metadata_alongside_warm_subtree(tmp_path: Path) -> N
     ds_store.write_bytes(b"\x00\x00\x00\x01Bud1")
     apple_double.write_bytes(b"AppleDouble")
 
-    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     assert warm.subtree(tmp_path).is_dir()
     assert ds_store.is_file()
     assert apple_double.is_file()
@@ -141,7 +167,7 @@ def test_sweep_keeps_dashboard_parent_when_sibling_still_warm(tmp_path: Path) ->
     _populate(tmp_path, cold, age_seconds=3600, now=now)
     _populate(tmp_path, warm, age_seconds=60, now=now)
 
-    deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    deleted = _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     assert deleted == 1
     assert not cold.subtree(tmp_path).exists()
     assert warm.subtree(tmp_path).is_dir()
@@ -156,7 +182,7 @@ def test_sweep_handles_multiple_dashboards(tmp_path: Path) -> None:
     _populate(tmp_path, alpha_kitchen, age_seconds=3600, now=now)
     _populate(tmp_path, beta_kitchen, age_seconds=60, now=now)
 
-    deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    deleted = _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     assert deleted == 1
     assert not alpha_kitchen.subtree(tmp_path).exists()
     assert beta_kitchen.subtree(tmp_path).is_dir()
@@ -166,10 +192,12 @@ def test_sweep_handles_multiple_dashboards(tmp_path: Path) -> None:
 def test_sweep_skips_venv_cache_and_per_dashboard_data_dir(
     tmp_path: Path, spelling: Callable[[str], str]
 ) -> None:
-    """Standalone-install siblings of the swept dirs are never deleted, in any case."""
+    """Standalone-install siblings of the swept dirs are never swept as subtrees, in any case."""
     now = 1_000_000.0
     key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    warm = RemoteBuildPath(dashboard_id="alpha", device_name="garage")
     _populate(tmp_path, key, age_seconds=3600, now=now)
+    _populate(tmp_path, warm, age_seconds=60, now=now)
     root = tmp_path / REMOTE_BUILDS_SUBDIR
     venv = root / spelling(VENVS_NAME) / "esphome-2026.7.4"
     data_dir = root / "alpha" / spelling(DATA_DIR_NAME)
@@ -177,12 +205,82 @@ def test_sweep_skips_venv_cache_and_per_dashboard_data_dir(
         cold.mkdir(parents=True)
         os.utime(cold, (now - 3600, now - 3600))
 
-    deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    deleted = _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     assert deleted == 1
     assert not key.subtree(tmp_path).exists()
     assert venv.is_dir()
     assert data_dir.is_dir()
     assert (tmp_path / REMOTE_BUILDS_SUBDIR / "alpha").is_dir()
+
+
+_ROOT_SHAPES = pytest.mark.parametrize("split", [False, True], ids=["standalone", "addon"])
+
+
+@_ROOT_SHAPES
+def test_sweep_reclaims_data_dir_once_dashboard_is_idle(tmp_path: Path, split: bool) -> None:
+    """With the last device subtree gone, the shared build data dir and both parents go too."""
+    now = 1_000_000.0
+    config_dir, data_root = _roots(tmp_path, split)
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    _populate(config_dir, key, age_seconds=3600, now=now)
+    data_dir = key.data_dir(data_root)
+    (data_dir / "build" / "kitchen").mkdir(parents=True)
+    venv = venvs_dir(data_root) / "esphome-2026.7.4"
+    venv.mkdir(parents=True)
+
+    deleted = sweep_remote_builds(
+        config_dir, data_dir=data_root, ttl_seconds=600, in_flight_keys=frozenset(), now=now
+    )
+    assert deleted == 2
+    assert not (config_dir / REMOTE_BUILDS_SUBDIR / "alpha").exists()
+    assert not data_dir.parent.exists()
+    assert venv.is_dir()
+
+
+@_ROOT_SHAPES
+def test_sweep_reclaims_data_dir_with_no_config_root_dashboard(tmp_path: Path, split: bool) -> None:
+    """A data dir whose ``<dashboard_id>/`` holds nothing else is reclaimed."""
+    config_dir, data_root = _roots(tmp_path, split)
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    data_dir = key.data_dir(data_root)
+    data_dir.mkdir(parents=True)
+
+    deleted = sweep_remote_builds(
+        config_dir, data_dir=data_root, ttl_seconds=600, in_flight_keys=frozenset()
+    )
+    assert deleted == 1
+    assert not data_dir.parent.exists()
+    assert (data_root / REMOTE_BUILDS_NAME).is_dir()
+
+
+@_ROOT_SHAPES
+def test_sweep_keeps_data_dir_while_a_job_is_in_flight(tmp_path: Path, split: bool) -> None:
+    """An in-flight key for the dashboard blocks the data-dir reclaim even with no subtree."""
+    config_dir, data_root = _roots(tmp_path, split)
+    key = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    data_dir = key.data_dir(data_root)
+    data_dir.mkdir(parents=True)
+
+    deleted = sweep_remote_builds(
+        config_dir, data_dir=data_root, ttl_seconds=600, in_flight_keys=frozenset({key})
+    )
+    assert deleted == 0
+    assert data_dir.is_dir()
+
+
+def test_sweep_keeps_data_dir_while_a_sibling_subtree_is_warm(tmp_path: Path) -> None:
+    """A warm device under the dashboard keeps its shared build data dir."""
+    now = 1_000_000.0
+    cold = RemoteBuildPath(dashboard_id="alpha", device_name="kitchen")
+    warm = RemoteBuildPath(dashboard_id="alpha", device_name="garage")
+    _populate(tmp_path, cold, age_seconds=3600, now=now)
+    _populate(tmp_path, warm, age_seconds=60, now=now)
+    data_dir = cold.data_dir(tmp_path / DATA_DIR_NAME)
+    data_dir.mkdir(parents=True)
+
+    deleted = _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    assert deleted == 1
+    assert data_dir.is_dir()
 
 
 def test_sweep_ignores_stray_files_under_root(tmp_path: Path) -> None:
@@ -199,7 +297,7 @@ def test_sweep_ignores_stray_files_under_root(tmp_path: Path) -> None:
     stray = root / "readme.txt"
     stray.write_text("hands off")
 
-    deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    deleted = _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     assert deleted == 0
     assert stray.is_file()
 
@@ -223,7 +321,7 @@ def test_sweep_reclaims_cold_orphan_bundle(tmp_path: Path) -> None:
     age_seconds = 3600
     os.utime(bundle, (now - age_seconds, now - age_seconds))
 
-    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     assert not bundle.exists()
 
 
@@ -236,7 +334,7 @@ def test_sweep_keeps_fresh_orphan_bundle(tmp_path: Path) -> None:
     bundle.write_bytes(b"fresh orphan")
     os.utime(bundle, (now - 60, now - 60))
 
-    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     assert bundle.is_file()
 
 
@@ -255,7 +353,7 @@ def test_sweep_skips_in_flight_orphan_bundle(tmp_path: Path) -> None:
     bundle.write_bytes(b"in-flight bundle")
     os.utime(bundle, (now - 3600, now - 3600))
 
-    sweep_remote_builds(
+    _sweep(
         tmp_path,
         ttl_seconds=600,
         in_flight_keys=frozenset({key}),
@@ -282,7 +380,7 @@ def test_sweep_does_not_unlink_bundle_when_subtree_still_exists(tmp_path: Path) 
     assert key.subtree(tmp_path).is_dir()
     assert key.bundle(tmp_path).is_file()
 
-    deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    deleted = _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     assert deleted == 1
     assert not key.subtree(tmp_path).exists()
     assert not key.bundle(tmp_path).exists()
@@ -315,7 +413,7 @@ def test_sweep_skips_when_root_itself_is_symlink(tmp_path: Path) -> None:
     (tmp_path / ".esphome").mkdir()
     (tmp_path / ".esphome" / ".remote_builds").symlink_to(real_root)
 
-    deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    deleted = _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     assert deleted == 0
     assert (real_root / "alpha" / "kitchen" / "important.txt").is_file()
 
@@ -340,7 +438,7 @@ def test_sweep_skips_symlink_at_dashboard_level(tmp_path: Path) -> None:
     link = root / "alpha"
     link.symlink_to(real_dir)
 
-    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     # The symlink stays in place because the dashboard-level
     # ``is_symlink()`` skip in ``sweep_remote_builds`` does
     # ``continue`` before reaching ``_prune_empty_dir``; the
@@ -362,7 +460,7 @@ def test_sweep_skips_symlink_at_subtree_level(tmp_path: Path) -> None:
     link = dashboard_dir / "kitchen"
     link.symlink_to(real_dir)
 
-    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     assert (real_dir / "important.txt").is_file()
 
 
@@ -383,7 +481,7 @@ def test_sweep_leaves_bare_dot_tar_gz_alone(tmp_path: Path) -> None:
     weird.write_bytes(b"weirdo")
     os.utime(weird, (now - 3600, now - 3600))
 
-    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     assert weird.is_file()
 
 
@@ -437,7 +535,7 @@ def test_sweep_logs_sibling_unlink_failure_but_still_counts_delete(
 
     monkeypatch.setattr(Path, "unlink", _flaky_unlink)
 
-    deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    deleted = _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     assert deleted == 1
     assert not key.subtree(tmp_path).exists()
     # Bundle unlink failed → bundle still on disk; the next
@@ -468,7 +566,7 @@ def test_sweep_logs_orphan_unlink_failure(tmp_path: Path, monkeypatch: pytest.Mo
     monkeypatch.setattr(Path, "unlink", _flaky_unlink)
 
     # Should not raise.
-    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     assert bundle.is_file()
 
 
@@ -494,7 +592,7 @@ def test_sweep_logs_macos_metadata_unlink_failure(
     # Should not raise. Both defensive arms fire: the unlink
     # OSError is logged, then the rmdir OSError (dir still
     # holds the .DS_Store) is logged too.
-    sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     assert dashboard_dir.is_dir()
     assert ds_store.is_file()
 
@@ -528,7 +626,7 @@ def test_sweep_continues_after_subtree_rmtree_failure(
 
     monkeypatch.setattr("esphome_device_builder.helpers.remote_build_cleanup.rmtree", _flaky)
 
-    deleted = sweep_remote_builds(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
+    deleted = _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset(), now=now)
     # One success out of two attempts; the failed subtree still
     # exists, the successful one is gone.
     assert deleted == 1
@@ -550,8 +648,6 @@ def test_sweep_protects_in_flight_subtree_with_long_dashboard_id(tmp_path: Path)
     in_flight = parse_from_configuration(configuration)
     assert in_flight is not None
 
-    deleted = sweep_remote_builds(
-        tmp_path, ttl_seconds=600, in_flight_keys=frozenset({in_flight}), now=now
-    )
+    deleted = _sweep(tmp_path, ttl_seconds=600, in_flight_keys=frozenset({in_flight}), now=now)
     assert deleted == 0
     assert key.subtree(tmp_path).exists()


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #2594. That fix stopped the sweep from deleting the per-offloader build data dir (`<data_dir>/.remote_builds/<dir_id>/.esphome`) as if it were a device subtree, but it left nothing to reclaim it at all; on a standalone install a revoked or long idle offloader now kept its build cache forever, and on the add-on it always had, since that dir sits under `/data` outside the sweep root.

The sweep now takes `data_dir` (`CORE.data_dir`, passed from the cleanup loop) and walks the union of `<dir_id>` names under both roots. Once a `<dir_id>/` holds no device subtree or bundle and no in-flight job targets it, the shared data dir is removed and the empty parents pruned on both roots; on split-root deployments that also catches a data dir whose config-root `<dir_id>/` was pruned on an earlier sweep. The trigger is the existing TTL: the data dir goes when the last device under it has been cold, so an active offloader keeps its cache and a departed one leaves nothing behind. Per device `build/<name>/` reclaim while sibling devices stay warm is keyed on the esphome name in the receiver's StorageJSON, not the YAML stem, so it stays a separate follow-up.

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/device-builder/issues/2592

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
