### PR TITLE
Stop the benchmark CI job hanging on apt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -532,6 +532,7 @@ jobs:
   benchmarks:
     name: Run benchmarks (CodSpeed)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Benchmarks only run on PRs to ``main`` and pushes to ``main`` —
     # ``workflow_call`` runs (release preflight) skip them since
     # CodSpeed's instrumentation harness adds non-trivial wallclock
@@ -558,6 +559,26 @@ jobs:
 
       - name: Install package + test deps
         run: uv pip install --system -e '.[esphome,test]'
+
+      - name: Install libc6-dbg
+        # The CodSpeed runner installs this itself with a plain apt-get call
+        # that has no timeout, so a slow apt mirror hangs the job until
+        # timeout-minutes kills it. Installing it here with a bounded retry
+        # also lets the runner find it already present after restoring
+        # valgrind from its cache and skip apt entirely.
+        run: |
+          for attempt in 1 2 3; do
+            if timeout 300 sudo apt-get update \
+              && timeout 300 sudo DEBIAN_FRONTEND=noninteractive \
+                apt-get install -y libc6-dbg
+            then
+              exit 0
+            fi
+            echo "apt-get attempt ${attempt} failed, retrying"
+            sudo dpkg --configure -a || true
+            sleep 10
+          done
+          exit 1
 
       - name: Run benchmarks
         # ``simulation`` is the new name for what used to be called


### PR DESCRIPTION
# What does this implement/fix?

The CodSpeed runner installs `libc6-dbg` with a plain `apt-get` call that has no timeout, so a slow apt mirror hangs the benchmarks job. Install it ourselves first with a bounded retry so the runner finds it already present and skips apt, and cap the job at 30 minutes so a hang can no longer burn the runner's 6 hour default. Same fix as aio-libs/aiohttp#13489.

**Related issue or feature (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [ ] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
