### PR TITLE
Prefer the component's own domain page when a docs content match is ambiguous

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -2340,15 +2340,17 @@ def _find_docs_page_by_content(
     A config-example match wins and carries the section slug; a component
     documented without one (a supported-platforms table row) matches on an
     inline ``<stem>`` code span with no slug. Either scan bails unless
-    exactly one page matches.
+    exactly one page matches; an ambiguous config-example scan first narrows
+    to pages under the component's own domain directory.
     """
     matches: list[tuple[str, str]] = []
     for path, text in pages.items():
         slug = _find_component_section(text, component_id)
         if slug is not None:
             matches.append((path, slug))
-            if len(matches) > 1:
-                break
+    if len(matches) > 1 and "." in component_id:
+        domain = component_id.split(".", 1)[0]
+        matches = [m for m in matches if m[0].split("/", 1)[0] == domain] or matches
     if len(matches) == 1:
         return matches[0]
     # Blockquote mentions are commentary about the component, not its docs.

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -2255,17 +2255,15 @@ def _page_anchor_set(text: str) -> frozenset[str]:
     return frozenset(slug for _, slug in headings) | explicit
 
 
-def _component_example_re(component_id: str) -> re.Pattern[str]:
-    """Matcher for a config example naming *component_id* in a docs page."""
-    stem = component_id.split(".", 1)[-1]
-    if "." in component_id:
-        return re.compile(rf"^\s*-\s+platform:\s+{re.escape(stem)}\s*$", re.MULTILINE)
-    return re.compile(rf"^{re.escape(component_id)}:\s*$", re.MULTILINE)
-
-
 def _find_component_section(text: str, component_id: str) -> str | None:
+    """Anchor slug of the section documenting *component_id* inside a docs page."""
+    found = _find_component_section_kinded(text, component_id)
+    return found[0] if found else None
+
+
+def _find_component_section_kinded(text: str, component_id: str) -> tuple[str, bool] | None:
     """
-    Anchor slug of the section documenting *component_id* inside a docs page.
+    ``(slug, from_example)`` of the section documenting *component_id* inside a docs page.
 
     Matched on the first config example naming it (``- platform: <stem>``
     for a dotted id, a top-level ``<id>:`` key otherwise) → the nearest
@@ -2274,15 +2272,18 @@ def _find_component_section(text: str, component_id: str) -> str | None:
     """
     stem = component_id.split(".", 1)[-1]
     body = _strip_mdx_frontmatter(text)
-    example = _component_example_re(component_id)
+    if "." in component_id:
+        example = re.compile(rf"^\s*-\s+platform:\s+{re.escape(stem)}\s*$", re.MULTILINE)
+    else:
+        example = re.compile(rf"^{re.escape(component_id)}:\s*$", re.MULTILINE)
     headings, _ = _page_anchor_index(text)
     if m := example.search(body):
         preceding = [slug for start, slug in headings if start <= m.start()]
-        return preceding[-1] if preceding else ""
+        return (preceding[-1] if preceding else ""), True
     names = {stem, stem.replace("_", "-")}
     for _, slug in headings:
         if slug in names:
-            return slug
+            return slug, False
     return None
 
 
@@ -2349,17 +2350,14 @@ def _find_docs_page_by_content(
     set to pages under the component's own domain directory; either scan
     bails unless exactly one page remains.
     """
-    example = _component_example_re(component_id)
     example_matches: list[tuple[str, str]] = []
     heading_matches: list[tuple[str, str]] = []
     for path, text in pages.items():
-        slug = _find_component_section(text, component_id)
-        if slug is None:
+        found = _find_component_section_kinded(text, component_id)
+        if found is None:
             continue
-        bucket = (
-            example_matches if example.search(_strip_mdx_frontmatter(text)) else heading_matches
-        )
-        bucket.append((path, slug))
+        slug, from_example = found
+        (example_matches if from_example else heading_matches).append((path, slug))
     matches = example_matches or heading_matches
     if len(matches) > 1 and "." in component_id:
         domain = component_id.split(".", 1)[0]

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -2255,6 +2255,14 @@ def _page_anchor_set(text: str) -> frozenset[str]:
     return frozenset(slug for _, slug in headings) | explicit
 
 
+def _component_example_re(component_id: str) -> re.Pattern[str]:
+    """Matcher for a config example naming *component_id* in a docs page."""
+    stem = component_id.split(".", 1)[-1]
+    if "." in component_id:
+        return re.compile(rf"^\s*-\s+platform:\s+{re.escape(stem)}\s*$", re.MULTILINE)
+    return re.compile(rf"^{re.escape(component_id)}:\s*$", re.MULTILINE)
+
+
 def _find_component_section(text: str, component_id: str) -> str | None:
     """
     Anchor slug of the section documenting *component_id* inside a docs page.
@@ -2266,10 +2274,7 @@ def _find_component_section(text: str, component_id: str) -> str | None:
     """
     stem = component_id.split(".", 1)[-1]
     body = _strip_mdx_frontmatter(text)
-    if "." in component_id:
-        example = re.compile(rf"^\s*-\s+platform:\s+{re.escape(stem)}\s*$", re.MULTILINE)
-    else:
-        example = re.compile(rf"^{re.escape(component_id)}:\s*$", re.MULTILINE)
+    example = _component_example_re(component_id)
     headings, _ = _page_anchor_index(text)
     if m := example.search(body):
         preceding = [slug for start, slug in headings if start <= m.start()]
@@ -2339,15 +2344,23 @@ def _find_docs_page_by_content(
 
     A config-example match wins and carries the section slug; a component
     documented without one (a supported-platforms table row) matches on an
-    inline ``<stem>`` code span with no slug. Either scan bails unless
-    exactly one page matches; an ambiguous config-example scan first narrows
-    to pages under the component's own domain directory.
+    inline ``<stem>`` code span with no slug. Section matches rank
+    config-example pages above stem-heading pages, then narrow an ambiguous
+    set to pages under the component's own domain directory; either scan
+    bails unless exactly one page remains.
     """
-    matches: list[tuple[str, str]] = []
+    example = _component_example_re(component_id)
+    example_matches: list[tuple[str, str]] = []
+    heading_matches: list[tuple[str, str]] = []
     for path, text in pages.items():
         slug = _find_component_section(text, component_id)
-        if slug is not None:
-            matches.append((path, slug))
+        if slug is None:
+            continue
+        bucket = (
+            example_matches if example.search(_strip_mdx_frontmatter(text)) else heading_matches
+        )
+        bucket.append((path, slug))
+    matches = example_matches or heading_matches
     if len(matches) > 1 and "." in component_id:
         domain = component_id.split(".", 1)[0]
         matches = [m for m in matches if m[0].split("/", 1)[0] == domain] or matches

--- a/tests/test_sync_components_docs_url_validation.py
+++ b/tests/test_sync_components_docs_url_validation.py
@@ -124,6 +124,13 @@ def test_ambiguous_config_example_within_own_domain_yields_no_link() -> None:
     assert _resolve_docs_url("", "sensor.xiaomi_lywsd03mmc", pages) == ("", None)
 
 
+def test_ambiguous_stem_heading_prefers_own_domain_page() -> None:
+    pages = {"sensor/p": "## Foo\n", "light/q": "## Foo\n"}
+    url, anchor = _resolve_docs_url("", "sensor.foo", pages)
+    assert url == "https://esphome.io/components/sensor/p"
+    assert anchor == ("sensor/p", "foo")
+
+
 def test_config_example_outranks_own_domain_stem_heading() -> None:
     pages = {
         "sensor/other": "## Xiaomi Lywsd03mmc\n\ntext\n",

--- a/tests/test_sync_components_docs_url_validation.py
+++ b/tests/test_sync_components_docs_url_validation.py
@@ -124,6 +124,16 @@ def test_ambiguous_config_example_within_own_domain_yields_no_link() -> None:
     assert _resolve_docs_url("", "sensor.xiaomi_lywsd03mmc", pages) == ("", None)
 
 
+def test_config_example_outranks_own_domain_stem_heading() -> None:
+    pages = {
+        "sensor/other": "## Xiaomi Lywsd03mmc\n\ntext\n",
+        "ble/real": _XIAOMI_PAGE,
+    }
+    url, anchor = _resolve_docs_url("", "sensor.xiaomi_lywsd03mmc", pages)
+    assert url == "https://esphome.io/components/ble/real"
+    assert anchor == ("ble/real", "lywsd03mmc")
+
+
 def test_undocumented_component_yields_no_link() -> None:
     assert _resolve_docs_url("", "climate.coolix", {"light": ""}) == ("", None)
 

--- a/tests/test_sync_components_docs_url_validation.py
+++ b/tests/test_sync_components_docs_url_validation.py
@@ -108,6 +108,22 @@ def test_ambiguous_config_example_yields_no_link() -> None:
     assert _resolve_docs_url("", "weikai", {"a": _WEIKAI_PAGE, "b": _WEIKAI_PAGE}) == ("", None)
 
 
+def test_ambiguous_config_example_prefers_own_domain_page() -> None:
+    pages = {
+        "sensor/xiaomi_ble": _XIAOMI_PAGE,
+        "bk72xx_ble_tracker": _XIAOMI_PAGE,
+        "ln882h_ble_tracker": _XIAOMI_PAGE,
+    }
+    url, anchor = _resolve_docs_url("", "sensor.xiaomi_lywsd03mmc", pages)
+    assert url == "https://esphome.io/components/sensor/xiaomi_ble"
+    assert anchor == ("sensor/xiaomi_ble", "lywsd03mmc")
+
+
+def test_ambiguous_config_example_within_own_domain_yields_no_link() -> None:
+    pages = {"sensor/a": _XIAOMI_PAGE, "sensor/b": _XIAOMI_PAGE}
+    assert _resolve_docs_url("", "sensor.xiaomi_lywsd03mmc", pages) == ("", None)
+
+
 def test_undocumented_component_yields_no_link() -> None:
     assert _resolve_docs_url("", "climate.coolix", {"light": ""}) == ("", None)
 


### PR DESCRIPTION
# What does this implement/fix?

The docs content search bails as soon as two pages match, and the new bk72xx and ln882h BLE tracker docs pages both carry a `- platform: xiaomi_lywsd03mmc` config example; `sensor.xiaomi_lywsd03mmc` therefore lost its docs link in the 2026.8.0 sync. When the config example scan is ambiguous, rank pages carrying a real config example above pages that only have a stem-named heading, then narrow to pages under the component's own domain directory before giving up. Sweeping the resolver over the full catalog against the current docs clone, this restores the `sensor/xiaomi_ble#lywsd03mmc` link, gives the previously linkless `preferences` component its real home at `esphome#preferences-component`, and `display.lcd_pcf8574` gains a section anchor on the page it already links to.

**Related issue or feature (if applicable):**

- follow-up to #2608

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

