### PR TITLE
Fix nRF52 catalog id collision with Hardware Model v2 board strings

### DIFF
--- a/script/sync_boards.py
+++ b/script/sync_boards.py
@@ -883,6 +883,12 @@ def _augment_nrf52_boards(boards: list[BoardCatalogEntry]) -> None:
     served by an id-keyed catalog, so it's skipped with a warning rather than
     shadowed onto the other platform's pinout. Also deduped on display name so a
     curated nRF52 board claiming a Zephyr id under a different id isn't twinned.
+
+    Some ``BOARDS_ZEPHYR`` names carry a Zephyr Hardware Model v2 qualifier, e.g.
+    ``adafruit_itsybitsy/nrf52840`` -- the flat, id-keyed on-disk catalog rejects
+    any id containing ``/`` as traversal-shaped, so ``catalog_id`` substitutes
+    ``_`` for ``/`` while ``esphome.board`` keeps the literal Zephyr board string
+    ESPHome expects.
     """
     platform_by_id = {b.id: b.esphome.platform.value for b in boards}
     _, names = _generation_dedup_keys(boards)
@@ -890,24 +896,25 @@ def _augment_nrf52_boards(boards: list[BoardCatalogEntry]) -> None:
     const_module = importlib.import_module("esphome.components.nrf52.const")
     adc_gpios = set(const_module.AIN_TO_GPIO.values())
     for name in boards_module.BOARDS_ZEPHYR:
-        owner = platform_by_id.get(name)
+        catalog_id = name.replace("/", "_")
+        owner = platform_by_id.get(catalog_id)
         if owner is not None:
             if owner != _NRF52_PLATFORM:
                 _LOGGER.warning(
                     "nRF52 board %r shares a catalog id with an existing %s board; "
                     "not generating it (an id-keyed catalog can't serve both — needs "
                     "platform-aware board resolution)",
-                    name,
+                    catalog_id,
                     owner,
                 )
             continue
         display = _NRF52_BOARD_NAMES.get(name, name)
         if _name_already_listed(Platform.NRF52, name, display, names):
             continue
-        boards.append(
-            _generated_board(Platform.NRF52, name, display, _derive_nrf52_pins(adc_gpios))
-        )
-        platform_by_id[name] = _NRF52_PLATFORM
+        board = _generated_board(Platform.NRF52, name, display, _derive_nrf52_pins(adc_gpios))
+        board.id = catalog_id
+        boards.append(board)
+        platform_by_id[catalog_id] = _NRF52_PLATFORM
         names.add((Platform.NRF52, display))
 
 

--- a/script/sync_boards.py
+++ b/script/sync_boards.py
@@ -277,10 +277,12 @@ def _generated_board(
     display_name: str,
     pins: list[BoardPin],
     variant: str | None = None,
+    *,
+    board_id: str | None = None,
 ) -> BoardCatalogEntry:
     """Build a minimal catalog entry (identity + derived pins) for an unmanifested board."""
     return BoardCatalogEntry(
-        id=name,
+        id=board_id or name,
         name=display_name,
         description="",
         manufacturer="",
@@ -891,26 +893,39 @@ def _augment_nrf52_boards(boards: list[BoardCatalogEntry]) -> None:
     boards_module = importlib.import_module("esphome.components.nrf52.boards")
     const_module = importlib.import_module("esphome.components.nrf52.const")
     adc_gpios = set(const_module.AIN_TO_GPIO.values())
+    generated_from: dict[str, str] = {}
     for name in boards_module.BOARDS_ZEPHYR:
         catalog_id = name.replace("/", "_")
         owner = platform_by_id.get(catalog_id)
         if owner is not None:
             if owner != _NRF52_PLATFORM:
                 _LOGGER.warning(
-                    "nRF52 board %r shares a catalog id with an existing %s board; "
-                    "not generating it (an id-keyed catalog can't serve both — needs "
-                    "platform-aware board resolution)",
+                    "nRF52 board %r (catalog id %r) shares a catalog id with an existing "
+                    "%s board; not generating it (an id-keyed catalog can't serve both — "
+                    "needs platform-aware board resolution)",
+                    name,
                     catalog_id,
                     owner,
+                )
+            elif catalog_id in generated_from:
+                _LOGGER.warning(
+                    "nRF52 boards %r and %r flatten to the same catalog id %r; keeping %r",
+                    generated_from[catalog_id],
+                    name,
+                    catalog_id,
+                    generated_from[catalog_id],
                 )
             continue
         display = _NRF52_BOARD_NAMES.get(catalog_id, name)
         if _name_already_listed(Platform.NRF52, name, display, names):
             continue
-        board = _generated_board(Platform.NRF52, name, display, _derive_nrf52_pins(adc_gpios))
-        board.id = catalog_id
-        boards.append(board)
+        boards.append(
+            _generated_board(
+                Platform.NRF52, name, display, _derive_nrf52_pins(adc_gpios), board_id=catalog_id
+            )
+        )
         platform_by_id[catalog_id] = _NRF52_PLATFORM
+        generated_from[catalog_id] = name
         names.add((Platform.NRF52, display))
 
 

--- a/script/sync_boards.py
+++ b/script/sync_boards.py
@@ -884,11 +884,7 @@ def _augment_nrf52_boards(boards: list[BoardCatalogEntry]) -> None:
     shadowed onto the other platform's pinout. Also deduped on display name so a
     curated nRF52 board claiming a Zephyr id under a different id isn't twinned.
 
-    Some ``BOARDS_ZEPHYR`` names carry a Zephyr Hardware Model v2 qualifier, e.g.
-    ``adafruit_itsybitsy/nrf52840`` -- the flat, id-keyed on-disk catalog rejects
-    any id containing ``/`` as traversal-shaped, so ``catalog_id`` substitutes
-    ``_`` for ``/`` while ``esphome.board`` keeps the literal Zephyr board string
-    ESPHome expects.
+    Hardware Model v2 ``/`` qualifiers become ``_`` only in catalog ids.
     """
     platform_by_id = {b.id: b.esphome.platform.value for b in boards}
     _, names = _generation_dedup_keys(boards)
@@ -908,7 +904,7 @@ def _augment_nrf52_boards(boards: list[BoardCatalogEntry]) -> None:
                     owner,
                 )
             continue
-        display = _NRF52_BOARD_NAMES.get(name, name)
+        display = _NRF52_BOARD_NAMES.get(catalog_id, name)
         if _name_already_listed(Platform.NRF52, name, display, names):
             continue
         board = _generated_board(Platform.NRF52, name, display, _derive_nrf52_pins(adc_gpios))

--- a/script/sync_boards.py
+++ b/script/sync_boards.py
@@ -308,8 +308,8 @@ def _name_already_listed(
     Return True when ``(platform, display)`` is already in the catalog; log the skip.
 
     A curated/generated twin today; the log surfaces a future upstream board
-    shadowed by a name collision (generated ``id == board key``, so it would
-    otherwise vanish without a catalog entry).
+    shadowed by a name collision that would otherwise vanish without a
+    catalog entry.
     """
     if (platform, display) not in names:
         return False

--- a/tests/test_nrf52_board_pins.py
+++ b/tests/test_nrf52_board_pins.py
@@ -78,3 +78,27 @@ def test_nrf52_hwmv2_qualified_name_flattens_id_but_not_board_or_label(
     assert board.id == "adafruit_itsybitsy_nrf52840"
     assert board.esphome.board == "adafruit_itsybitsy/nrf52840"
     assert board.name == _NRF52_BOARD_NAMES["adafruit_itsybitsy_nrf52840"]
+
+
+def test_nrf52_flatten_collision_keeps_first_and_warns(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # A legacy flat key and its '/'-qualified spelling collapse to one catalog id.
+    import esphome.components.nrf52.boards as boards_module  # noqa: PLC0415
+
+    monkeypatch.setattr(
+        boards_module,
+        "BOARDS_ZEPHYR",
+        {"adafruit_itsybitsy_nrf52840": {}, "adafruit_itsybitsy/nrf52840": {}},
+    )
+    boards: list[BoardCatalogEntry] = []
+    with caplog.at_level(logging.WARNING, logger="script.sync_boards"):
+        _augment_nrf52_boards(boards)
+    assert len(boards) == 1
+    assert boards[0].esphome.board == "adafruit_itsybitsy_nrf52840"
+    assert any(
+        "flatten to the same catalog id" in r.getMessage()
+        and "adafruit_itsybitsy/nrf52840" in r.getMessage()
+        for r in caplog.records
+    )

--- a/tests/test_nrf52_board_pins.py
+++ b/tests/test_nrf52_board_pins.py
@@ -6,8 +6,8 @@ import logging
 
 import pytest
 
-from esphome_device_builder.models import BoardCatalogResponse, PinFeature
-from script.sync_boards import _derive_nrf52_pins
+from esphome_device_builder.models import BoardCatalogEntry, BoardCatalogResponse, PinFeature
+from script.sync_boards import _NRF52_BOARD_NAMES, _augment_nrf52_boards, _derive_nrf52_pins
 
 pytestmark = pytest.mark.xdist_group("board_sync")
 
@@ -62,3 +62,19 @@ def test_nrf52_id_clash_logs_warning(
         "adafruit_itsybitsy" in r.getMessage() and "shares a catalog id" in r.getMessage()
         for r in records
     )
+
+
+def test_nrf52_hwmv2_qualified_name_flattens_id_but_not_board_or_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The pinned ESPHome has no '/'-qualified BOARDS_ZEPHYR entry yet.
+    import esphome.components.nrf52.boards as boards_module  # noqa: PLC0415
+
+    monkeypatch.setattr(boards_module, "BOARDS_ZEPHYR", {"adafruit_itsybitsy/nrf52840": {}})
+    boards: list[BoardCatalogEntry] = []
+    _augment_nrf52_boards(boards)
+    assert len(boards) == 1
+    board = boards[0]
+    assert board.id == "adafruit_itsybitsy_nrf52840"
+    assert board.esphome.board == "adafruit_itsybitsy/nrf52840"
+    assert board.name == _NRF52_BOARD_NAMES["adafruit_itsybitsy_nrf52840"]


### PR DESCRIPTION
# What does this implement/fix?

I have a PR to move nRF52 to nRF Connect SDK 3.4.0
(esphome/esphome#18550). That SDK's bundled Zephyr (4.4) moved to Hardware Model v2
board addressing, so ESPHome's `BOARDS_ZEPHYR` board string for the ItsyBitsy
board changed from `adafruit_itsybitsy_nrf52840` to
`adafruit_itsybitsy/nrf52840` -- the old flat name no longer resolves under
NCS 3.4.0.

`_augment_nrf52_boards()` in `script/sync_boards.py` used that board string
directly as both the catalog `id` and `esphome.board`. That was safe as long
as ESPHome board strings were filesystem-safe, which was true for every
platform until now: the flat, id-keyed on-disk catalog (`script/_catalog_split.py`)
rejects any id containing `/` via `is_unsafe_catalog_id()` -- a deliberate
path-traversal guard, since the id becomes a file path
(`body_dir / f"{cid}.json"`).

This PR sanitizes only the catalog id (`/` -> `_`, restoring the
pre-migration id `adafruit_itsybitsy_nrf52840` exactly) while
`esphome.board` keeps the literal Zephyr board string ESPHome needs to
build. `str.replace` handles any qualifier depth in one pass (real Zephyr
board identifiers can nest up to 5 `/`-separated segments, e.g.
`rpi_pico2/rp2350a/m33/w/mcuboot`), not just the single-level case nRF52
happens to use today.

Fixes two tests that fail when this repo's test suite runs against the
esphome#18550 branch (verified locally against that branch, see below):
`tests/test_nrf52_board_pins.py::test_nrf52_does_not_steal_rp2040_itsybitsy`
and both `tests/test_sync_boards_single.py::test_single_board_*` tests.
Against the currently-pinned esphome release (no `/`-qualified nRF52 board
strings yet), this change is a no-op -- `.replace("/", "_")` has nothing to
replace.

**Related issue or feature (if applicable):**

- Companion PR: esphome/esphome#18550

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
