### PR TITLE
Show the receiver esphome version only when it builds with it

### DIFF
--- a/esphome_device_builder/controllers/firmware/clean.py
+++ b/esphome_device_builder/controllers/firmware/clean.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ...models import (
-    FirmwareJob,
-    JobBuildSource,
-    JobType,
-)
+from esphome.const import __version__ as _offloader_esphome_version
+
+from ...helpers.build_scheduler import build_source_for_pairing
+from ...models import FirmwareJob, JobType
 from ...models.remote_build import PeerStatus
 
 if TYPE_CHECKING:
@@ -54,7 +53,7 @@ async def _fan_out_clean_to_connected_peers(
         remote_job = controller._create_job(
             configuration,
             JobType.CLEAN,
-            build_source=JobBuildSource.for_pairing(pairing),
+            build_source=build_source_for_pairing(pairing, _offloader_esphome_version),
         )
         # ``supersede=False``: the fan-out batch is N+1 jobs sharing
         # one ``configuration``; default supersede would leave only

--- a/esphome_device_builder/controllers/firmware/clean.py
+++ b/esphome_device_builder/controllers/firmware/clean.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from esphome.const import __version__ as _offloader_esphome_version
-
 from ...helpers.build_scheduler import build_source_for_pairing
 from ...models import FirmwareJob, JobType
 from ...models.remote_build import PeerStatus
@@ -53,7 +51,7 @@ async def _fan_out_clean_to_connected_peers(
         remote_job = controller._create_job(
             configuration,
             JobType.CLEAN,
-            build_source=build_source_for_pairing(pairing, _offloader_esphome_version),
+            build_source=build_source_for_pairing(pairing, snapshot.offloader_esphome_version),
         )
         # ``supersede=False``: the fan-out batch is N+1 jobs sharing
         # one ``configuration``; default supersede would leave only

--- a/esphome_device_builder/controllers/firmware/remote_dispatch.py
+++ b/esphome_device_builder/controllers/firmware/remote_dispatch.py
@@ -23,8 +23,6 @@ import logging
 from dataclasses import replace
 from typing import TYPE_CHECKING
 
-from esphome.const import __version__ as _offloader_esphome_version
-
 from ...helpers.build_scheduler import (
     DispatchOutcome,
     build_source_for_pairing,
@@ -136,7 +134,7 @@ def _dispatch_one(
     decision = pick_dispatch_target(inputs)
     if decision.outcome is DispatchOutcome.REMOTE:
         assert decision.pin_sha256 is not None  # narrowed by REMOTE
-        _dispatch_to_server(controller, job, decision.pin_sha256)
+        _dispatch_to_server(controller, job, decision.pin_sha256, snapshot)
         return False
     if decision.outcome is DispatchOutcome.LOCAL:
         _fallback_to_local(controller, job)
@@ -156,7 +154,12 @@ async def _flush_to_local(controller: FirmwareController) -> None:
         await controller._persist_jobs()
 
 
-def _dispatch_to_server(controller: FirmwareController, job: FirmwareJob, pin_sha256: str) -> None:
+def _dispatch_to_server(
+    controller: FirmwareController,
+    job: FirmwareJob,
+    pin_sha256: str,
+    snapshot: BuildSchedulerInputs,
+) -> None:
     """Bind *job* to the server behind *pin_sha256* and spawn its driver."""
     offloader = controller._db.remote_build_offloader
     pairing = offloader.get_pairing(pin_sha256) if offloader is not None else None
@@ -166,7 +169,7 @@ def _dispatch_to_server(controller: FirmwareController, job: FirmwareJob, pin_sh
         # can't strand the compile (the next pass picks a live server).
         controller.state.remote_dispatch.wake.set()
         return
-    job.apply_build_source(build_source_for_pairing(pairing, _offloader_esphome_version))
+    job.apply_build_source(build_source_for_pairing(pairing, snapshot.offloader_esphome_version))
     # ``create_background_task`` is eager: ``_drive_remote`` runs its
     # ``begin_run`` prologue (stamps RUNNING, fires JOB_STARTED) synchronously
     # before ``start()`` records the in-flight entry. That's safe — no

--- a/esphome_device_builder/controllers/firmware/remote_dispatch.py
+++ b/esphome_device_builder/controllers/firmware/remote_dispatch.py
@@ -23,12 +23,17 @@ import logging
 from dataclasses import replace
 from typing import TYPE_CHECKING
 
-from ...helpers.build_scheduler import DispatchOutcome, pick_dispatch_target
+from esphome.const import __version__ as _offloader_esphome_version
+
+from ...helpers.build_scheduler import (
+    DispatchOutcome,
+    build_source_for_pairing,
+    pick_dispatch_target,
+)
 from ...models import (
     LOCAL_JOB_BUILD_SOURCE,
     EventType,
     FirmwareJob,
-    JobBuildSource,
     JobStatus,
 )
 from . import lifecycle
@@ -161,7 +166,7 @@ def _dispatch_to_server(controller: FirmwareController, job: FirmwareJob, pin_sh
         # can't strand the compile (the next pass picks a live server).
         controller.state.remote_dispatch.wake.set()
         return
-    job.apply_build_source(JobBuildSource.for_pairing(pairing))
+    job.apply_build_source(build_source_for_pairing(pairing, _offloader_esphome_version))
     # ``create_background_task`` is eager: ``_drive_remote`` runs its
     # ``begin_run`` prologue (stamps RUNNING, fires JOB_STARTED) synchronously
     # before ``start()`` records the in-flight entry. That's safe — no

--- a/esphome_device_builder/controllers/remote_build/submit_job_commands.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job_commands.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from esphome.const import __version__ as _offloader_esphome_version
-
 from ...helpers.api import CommandError
 from ...helpers.async_ import run_in_executor
 from ...helpers.build_scheduler import build_source_for_pairing
@@ -98,7 +96,9 @@ async def reset_peer_build_env(controller: OffloaderController, *, pin_sha256: s
     job = firmware._create_job(
         "",
         JobType.RESET_BUILD_ENV,
-        build_source=build_source_for_pairing(pairing, _offloader_esphome_version),
+        build_source=build_source_for_pairing(
+            pairing, controller.build_scheduler_snapshot().offloader_esphome_version
+        ),
     )
     # supersede=False: reset jobs share the empty configuration key; the
     # default supersede would cancel an unrelated reset targeting another

--- a/esphome_device_builder/controllers/remote_build/submit_job_commands.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job_commands.py
@@ -11,9 +11,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from esphome.const import __version__ as _offloader_esphome_version
+
 from ...helpers.api import CommandError
 from ...helpers.async_ import run_in_executor
-from ...models import ErrorCode, FirmwareJob, JobBuildSource, JobType
+from ...helpers.build_scheduler import build_source_for_pairing
+from ...models import ErrorCode, FirmwareJob, JobType
 from ._validators import (
     download_artifacts_error_to_command_error,
     validate_pin_sha256,
@@ -95,7 +98,7 @@ async def reset_peer_build_env(controller: OffloaderController, *, pin_sha256: s
     job = firmware._create_job(
         "",
         JobType.RESET_BUILD_ENV,
-        build_source=JobBuildSource.for_pairing(pairing),
+        build_source=build_source_for_pairing(pairing, _offloader_esphome_version),
     )
     # supersede=False: reset jobs share the empty configuration key; the
     # default supersede would cancel an unrelated reset targeting another

--- a/esphome_device_builder/controllers/remote_build/submit_job_commands.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job_commands.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from esphome.const import __version__ as _offloader_esphome_version
+
 from ...helpers.api import CommandError
 from ...helpers.async_ import run_in_executor
 from ...helpers.build_scheduler import build_source_for_pairing
@@ -96,9 +98,7 @@ async def reset_peer_build_env(controller: OffloaderController, *, pin_sha256: s
     job = firmware._create_job(
         "",
         JobType.RESET_BUILD_ENV,
-        build_source=build_source_for_pairing(
-            pairing, controller.build_scheduler_snapshot().offloader_esphome_version
-        ),
+        build_source=build_source_for_pairing(pairing, _offloader_esphome_version),
     )
     # supersede=False: reset jobs share the empty configuration key; the
     # default supersede would cancel an unrelated reset targeting another

--- a/esphome_device_builder/helpers/build_scheduler.py
+++ b/esphome_device_builder/helpers/build_scheduler.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 
 from ..models.api import ErrorCode
+from ..models.firmware import JobBuildSource
 from ..models.remote_build import (
     PeerQueueStatusSnapshotEntry,
     PeerStatus,
@@ -211,6 +212,31 @@ def pick_dispatch_target(inputs: BuildSchedulerInputs) -> DispatchDecision:
     return DispatchDecision.local()
 
 
+def can_provision(pairing: StoredPairing, offloader_esphome_version: str) -> bool:
+    """Whether *pairing* can build *offloader_esphome_version* into a venv."""
+    return pairing.auto_provision_supported and is_pinnable_version(offloader_esphome_version)
+
+
+def receiver_build_version(pairing: StoredPairing, offloader_esphome_version: str) -> str:
+    """Return the esphome *pairing* builds our jobs with, or ``""`` when it builds with ours."""
+    if pairing.esphome_version == offloader_esphome_version or can_provision(
+        pairing, offloader_esphome_version
+    ):
+        return ""
+    return pairing.esphome_version
+
+
+def build_source_for_pairing(
+    pairing: StoredPairing, offloader_esphome_version: str
+) -> JobBuildSource:
+    """Bundle a REMOTE :class:`JobBuildSource` bound to the server behind *pairing*."""
+    return JobBuildSource.for_server(
+        pin_sha256=pairing.pin_sha256,
+        label=pairing.label,
+        esphome_version=receiver_build_version(pairing, offloader_esphome_version),
+    )
+
+
 @dataclass(frozen=True)
 class _FilterResult:
     """Outcome of the per-peer eligibility filter.
@@ -275,9 +301,7 @@ def _provisionable_mismatch(inputs: BuildSchedulerInputs, pairing: StoredPairing
     our own version is pinnable on PyPI (release or a/b/rc pre-release; a dev
     offloader can't be provisioned, so don't route a mismatch to it).
     """
-    return pairing.auto_provision_supported and is_pinnable_version(
-        inputs.offloader_esphome_version
-    )
+    return can_provision(pairing, inputs.offloader_esphome_version)
 
 
 def _eligible_pairings(inputs: BuildSchedulerInputs) -> _FilterResult:

--- a/esphome_device_builder/helpers/build_scheduler.py
+++ b/esphome_device_builder/helpers/build_scheduler.py
@@ -212,14 +212,9 @@ def pick_dispatch_target(inputs: BuildSchedulerInputs) -> DispatchDecision:
     return DispatchDecision.local()
 
 
-def can_provision(pairing: StoredPairing, offloader_esphome_version: str) -> bool:
-    """Whether *pairing* can build *offloader_esphome_version* into a venv."""
-    return pairing.auto_provision_supported and is_pinnable_version(offloader_esphome_version)
-
-
 def receiver_build_version(pairing: StoredPairing, offloader_esphome_version: str) -> str:
-    """Return the esphome *pairing* builds our jobs with, or ``""`` when it builds with ours."""
-    if pairing.esphome_version == offloader_esphome_version or can_provision(
+    """Return the esphome *pairing* compiles with, or ``""`` when it compiles with ours."""
+    if pairing.esphome_version == offloader_esphome_version or _can_provision(
         pairing, offloader_esphome_version
     ):
         return ""
@@ -293,15 +288,9 @@ def _no_compatible_peer_message(result: _FilterResult, inputs: BuildSchedulerInp
     )
 
 
-def _provisionable_mismatch(inputs: BuildSchedulerInputs, pairing: StoredPairing) -> bool:
-    """Whether *pairing* can auto-provision this offloader's esphome.
-
-    A version-mismatched receiver that advertises ``auto_provision_supported``
-    stays eligible because it builds our version into a venv — but only when
-    our own version is pinnable on PyPI (release or a/b/rc pre-release; a dev
-    offloader can't be provisioned, so don't route a mismatch to it).
-    """
-    return can_provision(pairing, inputs.offloader_esphome_version)
+def _can_provision(pairing: StoredPairing, offloader_esphome_version: str) -> bool:
+    """Whether *pairing* can build *offloader_esphome_version* into a venv."""
+    return pairing.auto_provision_supported and is_pinnable_version(offloader_esphome_version)
 
 
 def _eligible_pairings(inputs: BuildSchedulerInputs) -> _FilterResult:
@@ -325,7 +314,7 @@ def _eligible_pairings(inputs: BuildSchedulerInputs) -> _FilterResult:
             continue
         if not version_satisfies_policy(
             inputs.offloader_esphome_version, pairing.esphome_version, policy
-        ) and not _provisionable_mismatch(inputs, pairing):
+        ) and not _can_provision(pairing, inputs.offloader_esphome_version):
             _LOGGER.debug(
                 "pick_build_path: filtered %s on version policy %s (peer=%s, offloader=%s)",
                 pin_sha256,

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -5,12 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import TYPE_CHECKING, NamedTuple, TypedDict
+from typing import NamedTuple, TypedDict
 
 from .common import DashboardModel, EventType
-
-if TYPE_CHECKING:
-    pass
 
 
 def _now_iso() -> str:
@@ -305,12 +302,9 @@ class FirmwareJob(DashboardModel):
     # ``source_pin_sha256``; ``source_label`` is purely for
     # rendering.
     source_label: str = ""
-    # The receiver's installed esphome, snapshotted at job-creation
-    # time from :attr:`StoredPairing.esphome_version`, only when the
-    # receiver builds with it instead of ours. Empty for ``LOCAL``
-    # jobs, same-version receivers, receivers that provision our
-    # version into a venv, and pairings that hadn't yet completed a
-    # peer-link session.
+    # The receiver's esphome when it compiles with its own instead of
+    # ours; empty otherwise (LOCAL, same version, or the receiver
+    # provisions ours into a venv).
     source_esphome_version: str = ""
     # Receiver-side: the offloader's esphome version off the
     # SUBMIT_JOB header. When set and it differs from the

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, NamedTuple, TypedDict
 from .common import DashboardModel, EventType
 
 if TYPE_CHECKING:
-    from .remote_build import StoredPairing
+    pass
 
 
 def _now_iso() -> str:
@@ -129,15 +129,6 @@ class JobBuildSource:
             source_pin_sha256=pin_sha256,
             source_label=label,
             source_esphome_version=esphome_version,
-        )
-
-    @classmethod
-    def for_pairing(cls, pairing: StoredPairing) -> JobBuildSource:
-        """Bundle a REMOTE source bound to the server behind *pairing*."""
-        return cls.for_server(
-            pin_sha256=pairing.pin_sha256,
-            label=pairing.label,
-            esphome_version=pairing.esphome_version,
         )
 
 
@@ -314,11 +305,12 @@ class FirmwareJob(DashboardModel):
     # ``source_pin_sha256``; ``source_label`` is purely for
     # rendering.
     source_label: str = ""
-    # Receiver's ``esphome.const.__version__`` at job-creation
-    # time, snapshotted from :attr:`StoredPairing.esphome_version`.
-    # Empty for ``LOCAL`` jobs and for ``REMOTE`` jobs whose
-    # pairing hadn't yet completed a peer-link session (the
-    # pairing field populates on every session-open).
+    # The receiver's installed esphome, snapshotted at job-creation
+    # time from :attr:`StoredPairing.esphome_version`, only when the
+    # receiver builds with it instead of ours. Empty for ``LOCAL``
+    # jobs, same-version receivers, receivers that provision our
+    # version into a venv, and pairings that hadn't yet completed a
+    # peer-link session.
     source_esphome_version: str = ""
     # Receiver-side: the offloader's esphome version off the
     # SUBMIT_JOB header. When set and it differs from the

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -303,8 +303,8 @@ class FirmwareJob(DashboardModel):
     # rendering.
     source_label: str = ""
     # The receiver's esphome when it compiles with its own instead of
-    # ours; empty otherwise (LOCAL, same version, or the receiver
-    # provisions ours into a venv).
+    # ours; empty otherwise (LOCAL, same version, the receiver
+    # provisions ours into a venv, or its version isn't known yet).
     source_esphome_version: str = ""
     # Receiver-side: the offloader's esphome version off the
     # SUBMIT_JOB header. When set and it differs from the

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -563,6 +563,7 @@ def stub_pairing(
     esphome_version: str = "",
     status: PeerStatus = PeerStatus.APPROVED,
     enabled: bool = True,
+    auto_provision_supported: bool = False,
 ) -> StoredPairing:
     """Build a :class:`StoredPairing` for the build-scheduler tests."""
     return StoredPairing(
@@ -575,6 +576,7 @@ def stub_pairing(
         status=status,
         esphome_version=esphome_version,
         enabled=enabled,
+        auto_provision_supported=auto_provision_supported,
     )
 
 

--- a/tests/controllers/firmware/test_remote_dispatch.py
+++ b/tests/controllers/firmware/test_remote_dispatch.py
@@ -187,6 +187,36 @@ async def test_one_job_per_server(
     assert set(pool.pending) == {"j2", "j3"}
 
 
+@pytest.mark.parametrize(
+    ("auto_provision", "expected_version"),
+    [
+        pytest.param(True, "", id="provisions_our_version"),
+        pytest.param(False, "2026.8.0", id="builds_with_its_own"),
+    ],
+)
+async def test_dispatch_stamps_receiver_version_only_when_it_builds_with_it(
+    firmware_controller_factory: FirmwareControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+    auto_provision: bool,
+    expected_version: str,
+) -> None:
+    """A mismatched receiver's version reaches the job only when no venv will replace it."""
+    controller = firmware_controller_factory(with_queue=True, with_real_bus=True)
+    pairing = _pairing(_PIN_A, paired_at=1.0, version="2026.8.0")
+    pairing.auto_provision_supported = auto_provision
+    _stub_offloader(
+        controller,
+        _snapshot([pairing], open_pins={_PIN_A}, idle_pins={_PIN_A}, offloader_version="2026.8.1"),
+    )
+    monkeypatch.setattr(remote_dispatch, "_offloader_esphome_version", "2026.8.1")
+    job = _add_pending(controller, "j1")
+
+    await remote_dispatch._dispatch_pending(controller)
+
+    assert job.source is JobSource.REMOTE
+    assert job.source_esphome_version == expected_version
+
+
 async def test_no_server_connected_falls_back_to_local(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:

--- a/tests/controllers/firmware/test_remote_dispatch.py
+++ b/tests/controllers/firmware/test_remote_dispatch.py
@@ -52,8 +52,21 @@ _PIN_C = "c" * 64
 _stub_offloader = stub_offloader
 
 
-def _pairing(pin: str, *, paired_at: float, label: str = "srv", version: str = "") -> StoredPairing:
-    return _pairing_kw(pin_sha256=pin, paired_at=paired_at, label=label, esphome_version=version)
+def _pairing(
+    pin: str,
+    *,
+    paired_at: float,
+    label: str = "srv",
+    version: str = "",
+    auto_provision: bool = False,
+) -> StoredPairing:
+    return _pairing_kw(
+        pin_sha256=pin,
+        paired_at=paired_at,
+        label=label,
+        esphome_version=version,
+        auto_provision_supported=auto_provision,
+    )
 
 
 def _snapshot(
@@ -196,19 +209,16 @@ async def test_one_job_per_server(
 )
 async def test_dispatch_stamps_receiver_version_only_when_it_builds_with_it(
     firmware_controller_factory: FirmwareControllerFactory,
-    monkeypatch: pytest.MonkeyPatch,
     auto_provision: bool,
     expected_version: str,
 ) -> None:
     """A mismatched receiver's version reaches the job only when no venv will replace it."""
     controller = firmware_controller_factory(with_queue=True, with_real_bus=True)
-    pairing = _pairing(_PIN_A, paired_at=1.0, version="2026.8.0")
-    pairing.auto_provision_supported = auto_provision
+    pairing = _pairing(_PIN_A, paired_at=1.0, version="2026.8.0", auto_provision=auto_provision)
     _stub_offloader(
         controller,
         _snapshot([pairing], open_pins={_PIN_A}, idle_pins={_PIN_A}, offloader_version="2026.8.1"),
     )
-    monkeypatch.setattr(remote_dispatch, "_offloader_esphome_version", "2026.8.1")
     job = _add_pending(controller, "j1")
 
     await remote_dispatch._dispatch_pending(controller)

--- a/tests/models/test_firmware_job.py
+++ b/tests/models/test_firmware_job.py
@@ -26,7 +26,6 @@ from esphome_device_builder.models.firmware import (
     JobStatus,
     JobType,
 )
-from esphome_device_builder.models.remote_build import StoredPairing
 
 
 def _make_job(**overrides: Any) -> FirmwareJob:
@@ -310,25 +309,6 @@ def test_for_server_bundles_a_remote_source() -> None:
     assert build_source.source_pin_sha256 == "a" * 64
     assert build_source.source_label == "desktop"
     assert build_source.source_esphome_version == "2026.5.0"
-
-
-def test_for_pairing_matches_for_server_field_for_field() -> None:
-    """``for_pairing`` projects exactly the fields ``for_server`` takes."""
-    pairing = StoredPairing(
-        receiver_hostname="r",
-        receiver_port=6055,
-        pin_sha256="a" * 64,
-        static_x25519_pub=b"\x01" * 32,
-        label="desktop",
-        paired_at=1.0,
-        esphome_version="2026.5.0",
-    )
-
-    assert JobBuildSource.for_pairing(pairing) == JobBuildSource.for_server(
-        pin_sha256=pairing.pin_sha256,
-        label=pairing.label,
-        esphome_version=pairing.esphome_version,
-    )
 
 
 def test_apply_build_source_stamps_the_job() -> None:

--- a/tests/test_build_scheduler.py
+++ b/tests/test_build_scheduler.py
@@ -1167,5 +1167,3 @@ def test_build_source_for_pairing_projects_pin_label_and_build_version() -> None
         source_label="laptop",
         source_esphome_version="2026.8.0",
     )
-    pairing.auto_provision_supported = True
-    assert build_source_for_pairing(pairing, "2026.8.1").source_esphome_version == ""

--- a/tests/test_build_scheduler.py
+++ b/tests/test_build_scheduler.py
@@ -18,11 +18,14 @@ from esphome_device_builder.helpers.build_scheduler import (
     BuildSchedulerInputs,
     DispatchDecision,
     DispatchOutcome,
+    build_source_for_pairing,
     pick_build_path,
     pick_dispatch_target,
+    receiver_build_version,
 )
 from esphome_device_builder.helpers.version_compat import VersionMatchPolicy
 from esphome_device_builder.models.api import ErrorCode
+from esphome_device_builder.models.firmware import JobBuildSource, JobSource
 from esphome_device_builder.models.remote_build import (
     PeerQueueStatusSnapshotEntry,
     PeerStatus,
@@ -1127,3 +1130,42 @@ def test_dispatch_include_local_does_not_override_exact_required() -> None:
         )
     )
     assert decision.outcome is DispatchOutcome.NO_COMPATIBLE_PEER
+
+
+# ---------------------------------------------------------------------------
+# receiver_build_version / build_source_for_pairing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("receiver_version", "auto_provision", "offloader_version", "expected"),
+    [
+        pytest.param("2026.8.1", False, "2026.8.1", "", id="same_version"),
+        pytest.param("2026.8.0", True, "2026.8.1", "", id="provisionable_mismatch"),
+        pytest.param("2026.8.0", True, "2026.9.0-dev", "2026.8.0", id="dev_offloader"),
+        pytest.param("2026.8.0", False, "2026.8.1", "2026.8.0", id="plain_mismatch"),
+        pytest.param("", False, "2026.8.1", "", id="unknown_receiver_version"),
+    ],
+)
+def test_receiver_build_version(
+    receiver_version: str, auto_provision: bool, offloader_version: str, expected: str
+) -> None:
+    """The receiver's version surfaces only when it builds with it instead of ours."""
+    pairing = _stub_pairing(
+        esphome_version=receiver_version, auto_provision_supported=auto_provision
+    )
+    assert receiver_build_version(pairing, offloader_version) == expected
+
+
+def test_build_source_for_pairing_projects_pin_label_and_build_version() -> None:
+    """``build_source_for_pairing`` binds REMOTE to the pairing's pin / label / build version."""
+    pairing = _stub_pairing(pin_sha256="b" * 64, label="laptop", esphome_version="2026.8.0")
+
+    assert build_source_for_pairing(pairing, "2026.8.1") == JobBuildSource(
+        source=JobSource.REMOTE,
+        source_pin_sha256="b" * 64,
+        source_label="laptop",
+        source_esphome_version="2026.8.0",
+    )
+    pairing.auto_provision_supported = True
+    assert build_source_for_pairing(pairing, "2026.8.1").source_esphome_version == ""


### PR DESCRIPTION
# What does this implement/fix?

The firmware tasks drawer showed "Building on windoze (2026.8.0)" while the receiver was actually compiling with 2026.8.1 in a provisioned venv. The job snapshotted the pairing's installed esphome verbatim, so a receiver that auto provisions our version was labelled with the wrong one.

The version now only rides on the job when the receiver really builds with its own esphome: a version mismatch with no venv provisioning. Same version, or a provisionable mismatch, shows just the receiver name. The rule lives next to the scheduler's eligibility check in `helpers/build_scheduler.py` (`receiver_build_version` / `build_source_for_pairing`), and `JobBuildSource.for_pairing` is gone since the model can't reach the version helpers.

**Related issue or feature (if applicable):**

- fixes N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#1676

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
