### PR TITLE
Reap orphaned subprocesses when running as PID 1

### DIFF
--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -56,6 +56,19 @@ GIT_COMMIT_ERRORS: tuple[type[Exception], ...] = (OSError, subprocess.CalledProc
 _COMMIT_NAME = "ESPHome Device Builder"
 _COMMIT_EMAIL = "device-builder@esphome.io"
 
+# Policy flags on every invocation. --no-optional-locks stops reads from
+# grabbing index.lock for an optional refresh, so an unlocked read can't
+# contend with a commit; the required lock add/commit take is unaffected.
+# autoDetach=false keeps auto gc/maintenance in the foreground so ``_run``
+# reaps it instead of git daemonizing a child we never wait on.
+_GLOBAL_GIT_ARGS = (
+    "--no-optional-locks",
+    "-c",
+    "gc.autoDetach=false",
+    "-c",
+    "maintenance.autoDetach=false",
+)
+
 # Files Device Builder must never let into git history: its own
 # machine state (sidecars, locks), identity key, and remote-build peer
 # credentials, plus ESPHome build artifacts and OS noise. None of these
@@ -755,22 +768,8 @@ class GitRepo:
         # close_fds=True makes the child iterate the fd table before
         # exec, which is pure overhead on memory-pressured systems; our
         # spawns don't rely on inherited fds being closed at the boundary.
-        # --no-optional-locks stops reads from grabbing index.lock for an
-        # optional refresh, so an unlocked read can't contend with a commit;
-        # the required lock add/commit take is unaffected.
-        # autoDetach=false keeps auto gc/maintenance in the foreground so
-        # this run() reaps it; a detached one orphans to PID 1 in the
-        # container and stays defunct (#2635).
         result = subprocess.run(  # noqa: S603
-            [
-                self.git_bin,
-                "--no-optional-locks",
-                "-c",
-                "gc.autoDetach=false",
-                "-c",
-                "maintenance.autoDetach=false",
-                *args,
-            ],
+            [self.git_bin, *_GLOBAL_GIT_ARGS, *args],
             cwd=str(cwd or self.toplevel or self.config_dir),
             input=input_text,
             capture_output=True,

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -758,8 +758,19 @@ class GitRepo:
         # --no-optional-locks stops reads from grabbing index.lock for an
         # optional refresh, so an unlocked read can't contend with a commit;
         # the required lock add/commit take is unaffected.
+        # autoDetach=false keeps auto gc/maintenance in the foreground so
+        # this run() reaps it; a detached one orphans to PID 1 in the
+        # container and stays defunct (#2635).
         result = subprocess.run(  # noqa: S603
-            [self.git_bin, "--no-optional-locks", *args],
+            [
+                self.git_bin,
+                "--no-optional-locks",
+                "-c",
+                "gc.autoDetach=false",
+                "-c",
+                "maintenance.autoDetach=false",
+                *args,
+            ],
             cwd=str(cwd or self.toplevel or self.config_dir),
             input=input_text,
             capture_output=True,

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -52,6 +52,7 @@ from .helpers.dashboard_identity import get_or_create_identity as get_or_create_
 from .helpers.event_bus import Event, EventBus, StreamControls, stream_events
 from .helpers.json import cors_middleware, json_response
 from .helpers.network_interfaces import ensure_single_host_for_ephemeral_port, resolve_bind_host
+from .helpers.orphan_reaper import maybe_start_orphan_reaper
 from .helpers.peer_link_identity import PeerLinkIdentityStore
 from .helpers.presence_gated_loop import PresenceGatedLoop
 from .helpers.secrets_state import write_secrets_locked
@@ -279,6 +280,7 @@ class DeviceBuilder:
         self._background_tasks: set[asyncio.Task] = set()
         self._bg_task: asyncio.Task | None = None
         self._advertise_task: asyncio.Task | None = None
+        self._orphan_reaper_task: asyncio.Task | None = None
         self._serving_event = asyncio.Event()
         self._bg_poll: _BackgroundPollLoop | None = None
 
@@ -566,9 +568,7 @@ class DeviceBuilder:
 
         self._register_command_handlers()
 
-        # Start background polling
-        self._bg_poll = _BackgroundPollLoop(self)
-        self._bg_task = create_eager_task(self._bg_poll.run())
+        self._start_background_loops()
 
         _LOGGER.info(
             "Device Builder ready — config dir: %s, %d commands registered",
@@ -607,6 +607,9 @@ class DeviceBuilder:
             return
         if self._bg_task:
             await drain_tasks((self._bg_task,), log_exceptions=True)
+        if self._orphan_reaper_task:
+            await drain_tasks((self._orphan_reaper_task,), log_exceptions=True)
+            self._orphan_reaper_task = None
         if self._bg_poll is not None:
             self._bg_poll.unsubscribe()
         if self.devices is not None:
@@ -639,6 +642,14 @@ class DeviceBuilder:
         # Latch only after a full pass, so a partial teardown (a step raising in
         # the swallowing on_shutdown hook) can still be retried by stop().
         self._network_stopped = True
+
+    def _start_background_loops(self) -> None:
+        """Start the background poll loop and, as PID 1, the orphan reaper."""
+        self._bg_poll = _BackgroundPollLoop(self)
+        self._bg_task = create_eager_task(self._bg_poll.run())
+        # As PID 1 in the container, orphans reparent to us and nothing
+        # else waits on them.
+        self._orphan_reaper_task = maybe_start_orphan_reaper()
 
     async def _stop_local(self) -> None:
         """Flush local state (editor, version history, settings) and drain the executor pool."""

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -13,7 +13,7 @@ import html
 import logging
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
-from functools import lru_cache
+from functools import lru_cache, partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -45,7 +45,7 @@ from .controllers.remote_build import OffloaderController, ReceiverController
 from .controllers.remote_build.discovery import start_discovery as start_peer_discovery
 from .controllers.version_history import VersionHistoryController
 from .helpers.api import CommandHandler, collect_api_commands
-from .helpers.async_ import create_eager_task, drain_tasks
+from .helpers.async_ import create_eager_task, drain_tasks, log_task_exit
 from .helpers.auth import HASHED_FILENAME_RE, auth_middleware, ingress_peer_guard
 from .helpers.dashboard_advertise import DashboardAdvertiser
 from .helpers.dashboard_identity import get_or_create_identity as get_or_create_dashboard_identity
@@ -645,7 +645,8 @@ class DeviceBuilder:
         self._bg_poll = _BackgroundPollLoop(self)
         self._bg_task = create_eager_task(self._bg_poll.run())
         if should_reap_orphans():
-            self.create_background_task(OrphanReaperLoop().run())
+            task = self.create_background_task(OrphanReaperLoop().run())
+            task.add_done_callback(partial(log_task_exit, "Orphan reaper"))
 
     async def _stop_local(self) -> None:
         """Flush local state (editor, version history, settings) and drain the executor pool."""

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -52,7 +52,7 @@ from .helpers.dashboard_identity import get_or_create_identity as get_or_create_
 from .helpers.event_bus import Event, EventBus, StreamControls, stream_events
 from .helpers.json import cors_middleware, json_response
 from .helpers.network_interfaces import ensure_single_host_for_ephemeral_port, resolve_bind_host
-from .helpers.orphan_reaper import maybe_start_orphan_reaper
+from .helpers.orphan_reaper import OrphanReaperLoop, should_reap_orphans
 from .helpers.peer_link_identity import PeerLinkIdentityStore
 from .helpers.presence_gated_loop import PresenceGatedLoop
 from .helpers.secrets_state import write_secrets_locked
@@ -280,7 +280,6 @@ class DeviceBuilder:
         self._background_tasks: set[asyncio.Task] = set()
         self._bg_task: asyncio.Task | None = None
         self._advertise_task: asyncio.Task | None = None
-        self._orphan_reaper_task: asyncio.Task | None = None
         self._serving_event = asyncio.Event()
         self._bg_poll: _BackgroundPollLoop | None = None
 
@@ -607,9 +606,6 @@ class DeviceBuilder:
             return
         if self._bg_task:
             await drain_tasks((self._bg_task,), log_exceptions=True)
-        if self._orphan_reaper_task:
-            await drain_tasks((self._orphan_reaper_task,), log_exceptions=True)
-            self._orphan_reaper_task = None
         if self._bg_poll is not None:
             self._bg_poll.unsubscribe()
         if self.devices is not None:
@@ -644,12 +640,12 @@ class DeviceBuilder:
         self._network_stopped = True
 
     def _start_background_loops(self) -> None:
-        """Start the background poll loop and, as PID 1, the orphan reaper."""
+        """Start the process-lifetime background loops."""
+        # Start background polling
         self._bg_poll = _BackgroundPollLoop(self)
         self._bg_task = create_eager_task(self._bg_poll.run())
-        # As PID 1 in the container, orphans reparent to us and nothing
-        # else waits on them.
-        self._orphan_reaper_task = maybe_start_orphan_reaper()
+        if should_reap_orphans():
+            self.create_background_task(OrphanReaperLoop().run())
 
     async def _stop_local(self) -> None:
         """Flush local state (editor, version history, settings) and drain the executor pool."""

--- a/esphome_device_builder/helpers/orphan_reaper.py
+++ b/esphome_device_builder/helpers/orphan_reaper.py
@@ -30,6 +30,8 @@ class OrphanReaperLoop(PresenceGatedLoop[None]):
     _interval = _SCAN_INTERVAL_SECONDS
 
     def __init__(self) -> None:
+        # presence=None runs the loop ungated: orphans accrue whether
+        # or not a dashboard client is connected.
         super().__init__(None)
         self._pid = os.getpid()
         self._pending: set[int] = set()

--- a/esphome_device_builder/helpers/orphan_reaper.py
+++ b/esphome_device_builder/helpers/orphan_reaper.py
@@ -1,87 +1,79 @@
-"""Reap orphaned child processes when running as PID 1.
-
-In the plain Docker image the dashboard is PID 1 with no init in front,
-so every orphaned process (git's self-detached auto-maintenance, the
-survivors of a killed compile tree) is reparented to us, and nothing
-ever waits on it — asyncio's child watcher and ``subprocess.run`` only
-reap pids they spawned themselves — leaving it ``<defunct>`` forever
-(issue #2635).
-"""
+"""Reap orphaned child processes when running as PID 1."""
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
-import pathlib
 import sys
+from collections.abc import Set as AbstractSet
+from pathlib import Path
 
-from .async_ import create_eager_task
+from .async_ import run_in_executor
+from .presence_gated_loop import PresenceGatedLoop
 from .subprocess import live_child_pids
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = 30.0
+_SCAN_INTERVAL_SECONDS = 30.0
 
 
-def maybe_start_orphan_reaper() -> asyncio.Task[None] | None:
-    """Start the reaper loop when this process must reap orphans itself (Linux PID 1)."""
-    if sys.platform != "linux" or os.getpid() != 1:
-        return None
-    return create_eager_task(run_reaper_loop())
+def should_reap_orphans() -> bool:
+    """Whether this process must reap orphans itself (Linux PID 1, no init in front)."""
+    return sys.platform == "linux" and os.getpid() == 1
 
 
-async def run_reaper_loop() -> None:
-    """Periodically reap confirmed-zombie children; runs until cancelled."""
-    loop = asyncio.get_running_loop()
-    pid = os.getpid()
-    pending: set[int] = set()
-    while True:
-        await asyncio.sleep(SCAN_INTERVAL)
-        pending = await loop.run_in_executor(None, reap_once, pid, pending, live_child_pids())
+class OrphanReaperLoop(PresenceGatedLoop[None]):
+    """Periodically wait on zombie children this process never spawned."""
+
+    _label = "orphan reaper"
+    _bootstrap_delay = _SCAN_INTERVAL_SECONDS
+    _interval = _SCAN_INTERVAL_SECONDS
+
+    def __init__(self) -> None:
+        super().__init__(None)
+        self._pid = os.getpid()
+        self._pending: set[int] = set()
+
+    async def _work(self) -> None:
+        self._pending = await run_in_executor(
+            _reap_once, self._pid, self._pending, live_child_pids()
+        )
 
 
-def reap_once(pid: int, pending: set[int], exclude: set[int]) -> set[int]:
+def _reap_once(pid: int, pending: set[int], exclude: AbstractSet[int]) -> set[int]:
     """
-    Wait on *pid*'s zombie children present in *pending*; return this scan's zombies.
+    Wait on *pid*'s zombie children seen in *pending*; return this scan's zombies.
 
-    A pid in *exclude* (an asyncio-spawned child the loop still owns) is
-    never touched. Beyond that, only a pid in zombie state on two
-    consecutive scans is reaped: an in-process spawn is collected by its
-    own waiter within milliseconds of exiting, so it can't survive a
-    scan interval — the gate keeps a pid whose owner still needs its
-    return code from being stolen.
+    Only a pid in zombie state on two consecutive scans is reaped, and
+    a pid in *exclude* is never touched.
     """
-    zombies = _zombie_children(pid) - exclude
+    zombies = _zombie_children(pid, exclude)
     for child in zombies & pending:
         try:
             os.waitpid(child, os.WNOHANG)
-        except (ChildProcessError, OSError):
+        except OSError:
             continue
         _LOGGER.debug("Reaped orphaned process %d", child)
     return zombies - pending
 
 
-def _zombie_children(pid: int) -> set[int]:
-    """Return *pid*'s direct children currently in zombie state."""
+def _zombie_children(pid: int, exclude: AbstractSet[int] = frozenset()) -> set[int]:
+    """Return *pid*'s direct children in zombie state, skipping *exclude* unread."""
     try:
-        children = _read_proc(f"/proc/{pid}/task/{pid}/children").split()
+        children = Path(f"/proc/{pid}/task/{pid}/children").read_text(encoding="ascii").split()
     except OSError:
         return set()
     zombies: set[int] = set()
-    for child in children:
+    for token in children:
+        child = int(token)
+        if child in exclude:
+            continue
         try:
-            stat = _read_proc(f"/proc/{child}/stat")
+            stat = Path(f"/proc/{child}/stat").read_text(encoding="ascii")
         except OSError:
             continue
         # comm (field 2) may contain spaces/parens; the state field is
         # the first token after the closing paren.
         if stat.rpartition(")")[2].split()[0] == "Z":
-            zombies.add(int(child))
+            zombies.add(child)
     return zombies
-
-
-def _read_proc(path: str) -> str:
-    """Read a small /proc file as text."""
-    with pathlib.Path(path).open(encoding="ascii") as f:
-        return f.read()

--- a/esphome_device_builder/helpers/orphan_reaper.py
+++ b/esphome_device_builder/helpers/orphan_reaper.py
@@ -36,6 +36,17 @@ class OrphanReaperLoop(PresenceGatedLoop[None]):
         self._pid = os.getpid()
         self._pending: set[int] = set()
 
+    async def _prepare(self) -> bool:
+        """Probe the /proc children listing; an unreadable one disables the loop loudly."""
+        if await run_in_executor(_children_listing_readable, self._pid):
+            return True
+        _LOGGER.warning(
+            "Cannot read /proc/%d/task/%d/children; orphan reaping disabled",
+            self._pid,
+            self._pid,
+        )
+        return False
+
     async def _work(self) -> None:
         self._pending = await run_in_executor(
             _reap_once, self._pid, self._pending, live_child_pids()
@@ -52,17 +63,30 @@ def _reap_once(pid: int, pending: set[int], exclude: AbstractSet[int]) -> set[in
     zombies = _zombie_children(pid, exclude)
     for child in zombies & pending:
         try:
-            os.waitpid(child, os.WNOHANG)
-        except OSError:
+            reaped, _ = os.waitpid(child, os.WNOHANG)
+        except ChildProcessError:
             continue
-        _LOGGER.debug("Reaped orphaned process %d", child)
+        except OSError as err:
+            _LOGGER.debug("waitpid(%d) failed: %s", child, err)
+            continue
+        if reaped:
+            _LOGGER.debug("Reaped orphaned process %d", child)
     return zombies - pending
+
+
+def _children_listing_readable(pid: int) -> bool:
+    """Whether the /proc children listing the scans depend on can be read."""
+    try:
+        _children_path(pid).read_text(encoding="ascii")
+    except OSError:
+        return False
+    return True
 
 
 def _zombie_children(pid: int, exclude: AbstractSet[int] = frozenset()) -> set[int]:
     """Return *pid*'s direct children in zombie state, skipping *exclude* unread."""
     try:
-        children = Path(f"/proc/{pid}/task/{pid}/children").read_text(encoding="ascii").split()
+        children = _children_path(pid).read_text(encoding="ascii").split()
     except OSError:
         return set()
     zombies: set[int] = set()
@@ -79,3 +103,8 @@ def _zombie_children(pid: int, exclude: AbstractSet[int] = frozenset()) -> set[i
         if stat.rpartition(")")[2].split()[0] == "Z":
             zombies.add(child)
     return zombies
+
+
+def _children_path(pid: int) -> Path:
+    """Path of the kernel's per-task children listing for *pid*'s main thread."""
+    return Path(f"/proc/{pid}/task/{pid}/children")

--- a/esphome_device_builder/helpers/orphan_reaper.py
+++ b/esphome_device_builder/helpers/orphan_reaper.py
@@ -1,0 +1,87 @@
+"""Reap orphaned child processes when running as PID 1.
+
+In the plain Docker image the dashboard is PID 1 with no init in front,
+so every orphaned process (git's self-detached auto-maintenance, the
+survivors of a killed compile tree) is reparented to us, and nothing
+ever waits on it — asyncio's child watcher and ``subprocess.run`` only
+reap pids they spawned themselves — leaving it ``<defunct>`` forever
+(issue #2635).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import pathlib
+import sys
+
+from .async_ import create_eager_task
+from .subprocess import live_child_pids
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = 30.0
+
+
+def maybe_start_orphan_reaper() -> asyncio.Task[None] | None:
+    """Start the reaper loop when this process must reap orphans itself (Linux PID 1)."""
+    if sys.platform != "linux" or os.getpid() != 1:
+        return None
+    return create_eager_task(run_reaper_loop())
+
+
+async def run_reaper_loop() -> None:
+    """Periodically reap confirmed-zombie children; runs until cancelled."""
+    loop = asyncio.get_running_loop()
+    pid = os.getpid()
+    pending: set[int] = set()
+    while True:
+        await asyncio.sleep(SCAN_INTERVAL)
+        pending = await loop.run_in_executor(None, reap_once, pid, pending, live_child_pids())
+
+
+def reap_once(pid: int, pending: set[int], exclude: set[int]) -> set[int]:
+    """
+    Wait on *pid*'s zombie children present in *pending*; return this scan's zombies.
+
+    A pid in *exclude* (an asyncio-spawned child the loop still owns) is
+    never touched. Beyond that, only a pid in zombie state on two
+    consecutive scans is reaped: an in-process spawn is collected by its
+    own waiter within milliseconds of exiting, so it can't survive a
+    scan interval — the gate keeps a pid whose owner still needs its
+    return code from being stolen.
+    """
+    zombies = _zombie_children(pid) - exclude
+    for child in zombies & pending:
+        try:
+            os.waitpid(child, os.WNOHANG)
+        except (ChildProcessError, OSError):
+            continue
+        _LOGGER.debug("Reaped orphaned process %d", child)
+    return zombies - pending
+
+
+def _zombie_children(pid: int) -> set[int]:
+    """Return *pid*'s direct children currently in zombie state."""
+    try:
+        children = _read_proc(f"/proc/{pid}/task/{pid}/children").split()
+    except OSError:
+        return set()
+    zombies: set[int] = set()
+    for child in children:
+        try:
+            stat = _read_proc(f"/proc/{child}/stat")
+        except OSError:
+            continue
+        # comm (field 2) may contain spaces/parens; the state field is
+        # the first token after the closing paren.
+        if stat.rpartition(")")[2].split()[0] == "Z":
+            zombies.add(int(child))
+    return zombies
+
+
+def _read_proc(path: str) -> str:
+    """Read a small /proc file as text."""
+    with pathlib.Path(path).open(encoding="ascii") as f:
+        return f.read()

--- a/esphome_device_builder/helpers/subprocess.py
+++ b/esphome_device_builder/helpers/subprocess.py
@@ -26,6 +26,8 @@ from typing import Any
 # it because the StreamReader will keep filling on demand.
 _STREAM_READ_SIZE = 4096
 
+_live_children: dict[int, asyncio.subprocess.Process] = {}
+
 
 async def create_subprocess_exec(
     *args: str,
@@ -41,7 +43,16 @@ async def create_subprocess_exec(
     ``asyncio.create_subprocess_exec`` directly.
     """
     kwargs["close_fds"] = False
-    return await asyncio.create_subprocess_exec(*args, **kwargs)
+    proc = await asyncio.create_subprocess_exec(*args, **kwargs)
+    _purge_reaped_children()
+    _live_children[proc.pid] = proc
+    return proc
+
+
+def live_child_pids() -> set[int]:
+    """Pids of asyncio-spawned children the loop hasn't reaped yet."""
+    _purge_reaped_children()
+    return set(_live_children)
 
 
 def kill_quietly(proc: asyncio.subprocess.Process) -> None:
@@ -245,3 +256,9 @@ async def _write_stdin(proc: asyncio.subprocess.Process, data: bytes) -> None:
         return
     finally:
         proc.stdin.close()
+
+
+def _purge_reaped_children() -> None:
+    for pid, proc in list(_live_children.items()):
+        if proc.returncode is not None:
+            _live_children.pop(pid, None)

--- a/esphome_device_builder/helpers/subprocess.py
+++ b/esphome_device_builder/helpers/subprocess.py
@@ -26,7 +26,7 @@ from typing import Any
 # it because the StreamReader will keep filling on demand.
 _STREAM_READ_SIZE = 4096
 
-_live_children: dict[int, asyncio.subprocess.Process] = {}
+_live_children: set[asyncio.subprocess.Process] = set()
 
 
 async def create_subprocess_exec(
@@ -45,14 +45,14 @@ async def create_subprocess_exec(
     kwargs["close_fds"] = False
     proc = await asyncio.create_subprocess_exec(*args, **kwargs)
     _purge_reaped_children()
-    _live_children[proc.pid] = proc
+    _live_children.add(proc)
     return proc
 
 
 def live_child_pids() -> set[int]:
     """Pids of asyncio-spawned children the loop hasn't reaped yet."""
     _purge_reaped_children()
-    return set(_live_children)
+    return {proc.pid for proc in _live_children}
 
 
 def kill_quietly(proc: asyncio.subprocess.Process) -> None:
@@ -259,6 +259,6 @@ async def _write_stdin(proc: asyncio.subprocess.Process, data: bytes) -> None:
 
 
 def _purge_reaped_children() -> None:
-    for pid, proc in list(_live_children.items()):
-        if proc.returncode is not None:
-            _live_children.pop(pid, None)
+    _live_children.difference_update(
+        [proc for proc in _live_children if proc.returncode is not None]
+    )

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -914,6 +914,28 @@ def test_reads_pass_no_optional_locks(tmp_path: Path, monkeypatch: pytest.Monkey
     assert all(cmd[1] == "--no-optional-locks" for cmd in calls)
 
 
+def test_auto_maintenance_stays_foreground(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every git invocation disables detached auto gc/maintenance."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    calls: list[list[str]] = []
+    real_run = subprocess.run
+
+    def _record(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        return real_run(cmd, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.git_repo.subprocess.run", _record
+    )
+    repo.log_file(tmp_path / "kitchen.yaml")
+
+    assert calls
+    for cmd in calls:
+        assert "gc.autoDetach=false" in cmd
+        assert "maintenance.autoDetach=false" in cmd
+
+
 def test_run_surfaces_git_stderr_on_failure(tmp_path: Path) -> None:
     """A checked git failure raises with the ``fatal:`` stderr line in ``str``.
 

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -20,7 +20,10 @@ from pathlib import Path
 import pytest
 
 from esphome_device_builder.controllers.version_history import git_repo as git_repo_mod
-from esphome_device_builder.controllers.version_history.git_repo import GitRepo
+from esphome_device_builder.controllers.version_history.git_repo import (
+    _GLOBAL_GIT_ARGS,
+    GitRepo,
+)
 
 _GIT = shutil.which("git") or "git"
 
@@ -894,8 +897,10 @@ def test_index_lock_path_none_when_rev_parse_fails(
     assert repo._index_lock_path() is None
 
 
-def test_reads_pass_no_optional_locks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Every git invocation carries ``--no-optional-locks`` so reads can't grab index.lock."""
+def test_every_invocation_passes_global_git_args(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every git invocation carries the policy flags right after the binary."""
     repo = GitRepo(config_dir=tmp_path)
     repo.discover_or_init()
     calls: list[list[str]] = []
@@ -911,29 +916,7 @@ def test_reads_pass_no_optional_locks(tmp_path: Path, monkeypatch: pytest.Monkey
     repo.log_file(tmp_path / "kitchen.yaml")
 
     assert calls
-    assert all(cmd[1] == "--no-optional-locks" for cmd in calls)
-
-
-def test_auto_maintenance_stays_foreground(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Every git invocation disables detached auto gc/maintenance."""
-    repo = GitRepo(config_dir=tmp_path)
-    repo.discover_or_init()
-    calls: list[list[str]] = []
-    real_run = subprocess.run
-
-    def _record(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        calls.append(cmd)
-        return real_run(cmd, **kwargs)  # type: ignore[arg-type]
-
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.version_history.git_repo.subprocess.run", _record
-    )
-    repo.log_file(tmp_path / "kitchen.yaml")
-
-    assert calls
-    for cmd in calls:
-        assert "gc.autoDetach=false" in cmd
-        assert "maintenance.autoDetach=false" in cmd
+    assert all(cmd[1 : 1 + len(_GLOBAL_GIT_ARGS)] == list(_GLOBAL_GIT_ARGS) for cmd in calls)
 
 
 def test_run_surfaces_git_stderr_on_failure(tmp_path: Path) -> None:

--- a/tests/helpers/test_orphan_reaper.py
+++ b/tests/helpers/test_orphan_reaper.py
@@ -1,0 +1,82 @@
+"""Tests for helpers.orphan_reaper."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+from esphome_device_builder.helpers import orphan_reaper
+from esphome_device_builder.helpers import subprocess as helper_subprocess
+
+pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="/proc and fork semantics")
+
+
+def _spawn_zombie() -> int:
+    """Fork a child that exits immediately; return its pid, unreaped."""
+    pid = os.fork()
+    if pid == 0:
+        os._exit(0)
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if pid in orphan_reaper._zombie_children(os.getpid()):
+            return pid
+        time.sleep(0.01)
+    raise AssertionError("child never became a zombie")
+
+
+def test_reaps_zombie_on_second_scan() -> None:
+    """A zombie is detected on the first scan and waited on the second."""
+    pid = _spawn_zombie()
+    me = os.getpid()
+
+    pending = orphan_reaper.reap_once(me, set(), set())
+    assert pid in pending
+    assert pid in orphan_reaper._zombie_children(me)
+
+    orphan_reaper.reap_once(me, pending, set())
+    assert pid not in orphan_reaper._zombie_children(me)
+    with pytest.raises(ChildProcessError):
+        os.waitpid(pid, os.WNOHANG)
+
+
+def test_live_child_is_never_reaped() -> None:
+    """A running child is not a zombie and stays untouched."""
+    with subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"]) as proc:
+        me = os.getpid()
+        try:
+            pending = orphan_reaper.reap_once(me, set(), set())
+            assert proc.pid not in pending
+            orphan_reaper.reap_once(me, {proc.pid}, set())
+            assert proc.poll() is None
+        finally:
+            proc.kill()
+
+
+def test_excluded_zombie_is_never_reaped() -> None:
+    """A pid in the exclusion set stays unreaped across scans."""
+    pid = _spawn_zombie()
+    me = os.getpid()
+
+    pending = orphan_reaper.reap_once(me, set(), {pid})
+    assert pid not in pending
+    orphan_reaper.reap_once(me, {pid}, {pid})
+    assert pid in orphan_reaper._zombie_children(me)
+
+    os.waitpid(pid, 0)
+
+
+async def test_asyncio_children_are_registered_until_reaped() -> None:
+    """An asyncio spawn is excluded while live and drops out once the loop reaps it."""
+    proc = await helper_subprocess.create_subprocess_exec(sys.executable, "-c", "pass")
+    assert proc.pid in helper_subprocess.live_child_pids()
+    await proc.wait()
+    assert proc.pid not in helper_subprocess.live_child_pids()
+
+
+def test_zombie_children_missing_proc_entry() -> None:
+    """A pid with no /proc children file yields an empty set."""
+    assert orphan_reaper._zombie_children(2**22 + 12345) == set()

--- a/tests/helpers/test_orphan_reaper.py
+++ b/tests/helpers/test_orphan_reaper.py
@@ -71,3 +71,47 @@ def test_excluded_zombie_is_never_reaped() -> None:
 def test_zombie_children_missing_proc_entry() -> None:
     """A pid with no /proc children file yields an empty set."""
     assert orphan_reaper._zombie_children(2**22 + 12345) == set()
+
+
+def test_zombie_children_child_vanished_before_stat(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A child listed but gone by the stat read is skipped."""
+
+    class _FakePath:
+        def __init__(self, path: str) -> None:
+            self._path = path
+
+        def read_text(self, encoding: str) -> str:
+            if self._path.endswith("/children"):
+                return "4194321"
+            raise FileNotFoundError(self._path)
+
+    monkeypatch.setattr(orphan_reaper, "Path", _FakePath)
+    assert orphan_reaper._zombie_children(os.getpid()) == set()
+
+
+def test_reap_once_tolerates_waitpid_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A pid that can't be waited on is skipped."""
+    fake = 2**22 + 54321
+    monkeypatch.setattr(orphan_reaper, "_zombie_children", lambda pid, exclude: {fake})
+    assert orphan_reaper._reap_once(os.getpid(), {fake}, set()) == set()
+
+
+def test_should_reap_orphans_requires_pid1(monkeypatch: pytest.MonkeyPatch) -> None:
+    """True only when running as PID 1."""
+    monkeypatch.setattr(orphan_reaper.os, "getpid", lambda: 1)
+    assert orphan_reaper.should_reap_orphans()
+    monkeypatch.setattr(orphan_reaper.os, "getpid", lambda: 4242)
+    assert not orphan_reaper.should_reap_orphans()
+
+
+async def test_reaper_loop_work_carries_pending() -> None:
+    """One tick records the zombie as pending; the next tick reaps it."""
+    reaper = orphan_reaper.OrphanReaperLoop()
+    pid = _spawn_zombie()
+
+    await reaper._work()
+    assert pid in reaper._pending
+
+    await reaper._work()
+    assert pid not in reaper._pending
+    assert pid not in orphan_reaper._zombie_children(os.getpid())

--- a/tests/helpers/test_orphan_reaper.py
+++ b/tests/helpers/test_orphan_reaper.py
@@ -49,7 +49,7 @@ def test_reaps_zombie_on_second_scan() -> None:
     assert pid in pending
     assert pid in orphan_reaper._zombie_children(me)
 
-    orphan_reaper._reap_once(me, pending, set())
+    orphan_reaper._reap_once(me, {pid}, set())
     assert pid not in orphan_reaper._zombie_children(me)
     with pytest.raises(ChildProcessError):
         os.waitpid(pid, os.WNOHANG)
@@ -103,10 +103,52 @@ def test_zombie_children_child_vanished_before_stat(monkeypatch: pytest.MonkeyPa
 
 
 def test_reap_once_tolerates_waitpid_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A pid that can't be waited on is skipped."""
+    """A pid that was already reaped elsewhere is skipped silently."""
     fake = 2**22 + 54321
     monkeypatch.setattr(orphan_reaper, "_zombie_children", lambda pid, exclude: {fake})
     assert orphan_reaper._reap_once(os.getpid(), {fake}, set()) == set()
+
+
+def test_reap_once_logs_unexpected_waitpid_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A waitpid failure other than already-reaped is skipped and logged."""
+    fake = 2**22 + 54321
+    monkeypatch.setattr(orphan_reaper, "_zombie_children", lambda pid, exclude: {fake})
+
+    def _raise(pid: int, options: int) -> tuple[int, int]:
+        raise PermissionError(pid)
+
+    monkeypatch.setattr(orphan_reaper.os, "waitpid", _raise)
+    assert orphan_reaper._reap_once(os.getpid(), {fake}, set()) == set()
+
+
+def test_reap_once_skips_log_when_nothing_was_reaped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ``(0, 0)`` waitpid result claims no reap."""
+    fake = 2**22 + 54321
+    monkeypatch.setattr(orphan_reaper, "_zombie_children", lambda pid, exclude: {fake})
+    monkeypatch.setattr(orphan_reaper.os, "waitpid", lambda pid, options: (0, 0))
+    assert orphan_reaper._reap_once(os.getpid(), {fake}, set()) == set()
+
+
+async def test_prepare_probes_children_listing() -> None:
+    """The loop stays enabled when the /proc children listing is readable."""
+    assert await orphan_reaper.OrphanReaperLoop()._prepare() is True
+
+
+async def test_prepare_disables_loudly_without_children_listing(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An unreadable children listing disables the loop with a warning."""
+
+    class _UnreadablePath:
+        def __init__(self, path: str) -> None:
+            pass
+
+        def read_text(self, encoding: str) -> str:
+            raise PermissionError(encoding)
+
+    monkeypatch.setattr(orphan_reaper, "Path", _UnreadablePath)
+    assert await orphan_reaper.OrphanReaperLoop()._prepare() is False
+    assert "orphan reaping disabled" in caplog.text
 
 
 def test_should_reap_orphans_requires_pid1(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/helpers/test_orphan_reaper.py
+++ b/tests/helpers/test_orphan_reaper.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import subprocess
 import sys
@@ -14,17 +15,29 @@ from esphome_device_builder.helpers import orphan_reaper
 pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="/proc and fork semantics")
 
 
-def _spawn_zombie() -> int:
-    """Fork a child that exits immediately; return its pid, unreaped."""
+def _fork_exiting_child() -> int:
+    """Fork a child from the main thread that exits immediately; return its pid, unreaped."""
     pid = os.fork()
     if pid == 0:
         os._exit(0)
+    return pid
+
+
+def _wait_until_zombie(pid: int) -> None:
+    """Poll until *pid* shows up as a zombie child of this process."""
     deadline = time.monotonic() + 5
     while time.monotonic() < deadline:
         if pid in orphan_reaper._zombie_children(os.getpid()):
-            return pid
+            return
         time.sleep(0.01)
     raise AssertionError("child never became a zombie")
+
+
+def _spawn_zombie() -> int:
+    """Fork a child that exits immediately; return its pid once zombied, unreaped."""
+    pid = _fork_exiting_child()
+    _wait_until_zombie(pid)
+    return pid
 
 
 def test_reaps_zombie_on_second_scan() -> None:
@@ -107,11 +120,12 @@ def test_should_reap_orphans_requires_pid1(monkeypatch: pytest.MonkeyPatch) -> N
 async def test_reaper_loop_work_carries_pending() -> None:
     """One tick records the zombie as pending; the next tick reaps it."""
     reaper = orphan_reaper.OrphanReaperLoop()
-    pid = _spawn_zombie()
+    pid = _fork_exiting_child()
+    await asyncio.to_thread(_wait_until_zombie, pid)
 
     await reaper._work()
     assert pid in reaper._pending
 
     await reaper._work()
     assert pid not in reaper._pending
-    assert pid not in orphan_reaper._zombie_children(os.getpid())
+    assert pid not in await asyncio.to_thread(orphan_reaper._zombie_children, os.getpid())

--- a/tests/helpers/test_orphan_reaper.py
+++ b/tests/helpers/test_orphan_reaper.py
@@ -10,7 +10,6 @@ import time
 import pytest
 
 from esphome_device_builder.helpers import orphan_reaper
-from esphome_device_builder.helpers import subprocess as helper_subprocess
 
 pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="/proc and fork semantics")
 
@@ -33,11 +32,11 @@ def test_reaps_zombie_on_second_scan() -> None:
     pid = _spawn_zombie()
     me = os.getpid()
 
-    pending = orphan_reaper.reap_once(me, set(), set())
+    pending = orphan_reaper._reap_once(me, set(), set())
     assert pid in pending
     assert pid in orphan_reaper._zombie_children(me)
 
-    orphan_reaper.reap_once(me, pending, set())
+    orphan_reaper._reap_once(me, pending, set())
     assert pid not in orphan_reaper._zombie_children(me)
     with pytest.raises(ChildProcessError):
         os.waitpid(pid, os.WNOHANG)
@@ -45,12 +44,12 @@ def test_reaps_zombie_on_second_scan() -> None:
 
 def test_live_child_is_never_reaped() -> None:
     """A running child is not a zombie and stays untouched."""
-    with subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"]) as proc:
+    with subprocess.Popen(["/bin/sleep", "30"]) as proc:
         me = os.getpid()
         try:
-            pending = orphan_reaper.reap_once(me, set(), set())
+            pending = orphan_reaper._reap_once(me, set(), set())
             assert proc.pid not in pending
-            orphan_reaper.reap_once(me, {proc.pid}, set())
+            orphan_reaper._reap_once(me, {proc.pid}, set())
             assert proc.poll() is None
         finally:
             proc.kill()
@@ -61,20 +60,12 @@ def test_excluded_zombie_is_never_reaped() -> None:
     pid = _spawn_zombie()
     me = os.getpid()
 
-    pending = orphan_reaper.reap_once(me, set(), {pid})
+    pending = orphan_reaper._reap_once(me, set(), {pid})
     assert pid not in pending
-    orphan_reaper.reap_once(me, {pid}, {pid})
+    orphan_reaper._reap_once(me, {pid}, {pid})
     assert pid in orphan_reaper._zombie_children(me)
 
     os.waitpid(pid, 0)
-
-
-async def test_asyncio_children_are_registered_until_reaped() -> None:
-    """An asyncio spawn is excluded while live and drops out once the loop reaps it."""
-    proc = await helper_subprocess.create_subprocess_exec(sys.executable, "-c", "pass")
-    assert proc.pid in helper_subprocess.live_child_pids()
-    await proc.wait()
-    assert proc.pid not in helper_subprocess.live_child_pids()
 
 
 def test_zombie_children_missing_proc_entry() -> None:

--- a/tests/test_device_builder_lifecycle.py
+++ b/tests/test_device_builder_lifecycle.py
@@ -26,6 +26,7 @@ import pytest
 from esphome_device_builder.api.ws import close_active_websockets
 from esphome_device_builder.controllers.components import ComponentCatalog
 from esphome_device_builder.device_builder import DeviceBuilder
+from esphome_device_builder.helpers.orphan_reaper import OrphanReaperLoop
 
 from .conftest import MakeSettingsFactory
 
@@ -190,6 +191,28 @@ async def test_start_spawns_background_polling_task(
 
         assert db._bg_task is not None
         assert not db._bg_task.done()
+    finally:
+        await db.stop()
+
+
+async def test_start_spawns_orphan_reaper_when_pid1(
+    make_settings: MakeSettingsFactory,
+    _hermetic_lifecycle: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The orphan-reaper loop runs as a tracked background task when the PID-1 gate opens."""
+    started = asyncio.Event()
+
+    async def _fake_run(self: OrphanReaperLoop) -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr("esphome_device_builder.device_builder.should_reap_orphans", lambda: True)
+    monkeypatch.setattr(OrphanReaperLoop, "run", _fake_run)
+    db = DeviceBuilder(make_settings(with_core_path=True))
+    try:
+        await db.start()
+        await asyncio.wait_for(started.wait(), timeout=5)
     finally:
         await db.stop()
 

--- a/tests/test_subprocess_helper.py
+++ b/tests/test_subprocess_helper.py
@@ -226,7 +226,14 @@ def test_no_call_site_uses_asyncio_create_subprocess_exec_directly() -> None:
 
 async def test_live_child_pids_tracks_until_reaped() -> None:
     """A spawn is listed while live and drops out once the loop reaps it."""
-    proc = await subprocess_helper.create_subprocess_exec(sys.executable, "-c", "pass")
+    proc = await subprocess_helper.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        "import sys; sys.stdin.read()",
+        stdin=asyncio.subprocess.PIPE,
+    )
     assert proc.pid in subprocess_helper.live_child_pids()
+    assert proc.stdin is not None
+    proc.stdin.close()
     await proc.wait()
     assert proc.pid not in subprocess_helper.live_child_pids()

--- a/tests/test_subprocess_helper.py
+++ b/tests/test_subprocess_helper.py
@@ -222,3 +222,11 @@ def test_no_call_site_uses_asyncio_create_subprocess_exec_directly() -> None:
         "esphome_device_builder.helpers.subprocess.create_subprocess_exec "
         "instead so close_fds=False is applied:\n  " + "\n  ".join(offenders)
     )
+
+
+async def test_live_child_pids_tracks_until_reaped() -> None:
+    """A spawn is listed while live and drops out once the loop reaps it."""
+    proc = await subprocess_helper.create_subprocess_exec(sys.executable, "-c", "pass")
+    assert proc.pid in subprocess_helper.live_child_pids()
+    await proc.wait()
+    assert proc.pid not in subprocess_helper.live_child_pids()


### PR DESCRIPTION
# What does this implement/fix?

In the plain Docker container the dashboard runs as PID 1 with no init in front, so any orphaned process gets reparented to it and nothing ever waits on it; it stays defunct forever. Two producers were leaving `[git] <defunct>` rows: git auto-maintenance daemonizes itself out of the version-history commits (`gc.autoDetach` defaults to true), and cancelled compile trees can leave grandchildren behind.

Two fixes:

- When running as Linux PID 1, a 30s background loop scans `/proc` for zombie children and waits on them. It only reaps a pid seen in zombie state on two consecutive scans, and never one belonging to an asyncio spawn the event loop still owns (tracked at the single `create_subprocess_exec` chokepoint), so it can never steal a return code from an in-process waiter. Executor-thread `subprocess.run` children are forked from non-main threads and never appear in the scanned main-thread children list, so they are structurally out of reach.
- The version-history git wrapper now passes `-c gc.autoDetach=false -c maintenance.autoDetach=false` on every invocation, so auto-maintenance runs in the foreground and is reaped by the same `subprocess.run` that spawned git.

Considered shipping `tini` in the entrypoint instead; the entrypoint is baked into the upstream `esphome/esphome` image and the add-on runs under s6, so an in-process reaper covers the affected deployment without cross-repo coordination.

Keeping the git flags on every invocation is a deliberate trade-off: when auto-gc eventually triggers it now runs in the foreground of that save's executor call instead of detaching. The history repo holds small YAML text objects, so the occasional repack is short, and in exchange no detached gc ever exists for the reaper (or a real init) to have to clean up.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2635

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
