### PR TITLE
Pass core.fileMode=false on version-history git invocations

### DIFF
--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -61,12 +61,16 @@ _COMMIT_EMAIL = "device-builder@esphome.io"
 # contend with a commit; the required lock add/commit take is unaffected.
 # autoDetach=false keeps auto gc/maintenance in the foreground so ``_run``
 # reaps it instead of git daemonizing a child we never wait on.
+# fileMode=false keeps Samba's fake exec bit (the DOS archive attribute
+# mapped onto owner-execute) out of recorded modes and diffs.
 _GLOBAL_GIT_ARGS = (
     "--no-optional-locks",
     "-c",
     "gc.autoDetach=false",
     "-c",
     "maintenance.autoDetach=false",
+    "-c",
+    "core.fileMode=false",
 )
 
 # Files Device Builder must never let into git history: its own

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -999,6 +999,30 @@ def test_commit_paths_no_change_returns_none(tmp_path: Path) -> None:
     assert repo.commit_paths([yaml], "Update kitchen.yaml") is None
 
 
+def test_commit_paths_exec_bit_flip_alone_is_noop(tmp_path: Path) -> None:
+    """A bare exec-bit flip on an unchanged file commits nothing."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+    repo.commit_paths([yaml], "Create kitchen.yaml")
+    yaml.chmod(0o755)
+
+    assert repo.commit_paths([yaml], "Update kitchen.yaml") is None
+
+
+def test_commit_paths_executable_file_records_regular_mode(tmp_path: Path) -> None:
+    """A new file carrying the exec bit is recorded as 100644."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+    yaml.chmod(0o755)
+    repo.commit_paths([yaml], "Create kitchen.yaml")
+
+    assert _git(tmp_path, "ls-files", "-s", "kitchen.yaml").startswith("100644 ")
+
+
 def test_commit_paths_untracked_and_deleted_returns_none(tmp_path: Path) -> None:
     """Deleting a file the work tree/index never held is a no-op, not a git error."""
     repo = GitRepo(config_dir=tmp_path)


### PR DESCRIPTION
# What does this implement/fix?

Version history now runs every git command with `-c core.fileMode=false`. Files edited from Windows over the Samba add-on carry a fake exec bit (Samba maps the DOS archive attribute onto owner execute), so automatic commits recorded YAMLs as mode `100755`; the same repo viewed from Windows reads them as `100644`, leaving a permanent mode change in every diff, and a bare attribute flip alone could even produce an empty commit. The flag is passed per invocation like the commit identity, so the config of a repo we do not own is never touched; history diffs also stop showing mode noise.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2642

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
