### PR TITLE
Move peer-link client mDNS wake listener into _wake.py

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link_client/_wake.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/_wake.py
@@ -1,0 +1,37 @@
+"""mDNS-record wake trigger for the peer-link client's reconnect wait."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import ipaddress
+from typing import Any
+
+from zeroconf import RecordUpdateListener, Zeroconf
+from zeroconf.const import _TYPE_A, _TYPE_AAAA
+
+
+def _mdns_record_name(hostname: str) -> str | None:
+    """Return the lowercase trailing-dot record name, or ``None`` for an IP."""
+    bare = hostname.rstrip(".")
+    with contextlib.suppress(ValueError):
+        ipaddress.ip_address(bare)
+        return None
+    return f"{bare.lower()}."
+
+
+class _ReceiverWakeListener(RecordUpdateListener):
+    """One-shot wake on an A/AAAA record for the receiver's hostname."""
+
+    def __init__(self, record_name: str, wake: asyncio.Event) -> None:
+        self._record_name = record_name
+        self._wake = wake
+
+    def async_update_records(self, zc: Zeroconf, now: float, records: list[Any]) -> None:
+        if self._wake.is_set():
+            return
+        for update in records:
+            new = update.new
+            if new.type in (_TYPE_A, _TYPE_AAAA) and new.name.lower() == self._record_name:
+                self._wake.set()
+                return

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -19,15 +19,13 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import ipaddress
 import logging
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any, Literal
 
 import aiohttp
 from yarl import URL
-from zeroconf import RecordUpdateListener, Zeroconf
-from zeroconf.const import _TYPE_A, _TYPE_AAAA
+from zeroconf import Zeroconf
 
 from ....helpers import json as _json
 from ....helpers.async_ import drain_tasks
@@ -60,6 +58,7 @@ from ..peer_link import (
     run_peer_link_heartbeat,
 )
 from . import _dispatch, _submit
+from ._wake import _mdns_record_name, _ReceiverWakeListener
 from .one_shot import (
     _DEFAULT_TIMEOUT_SECONDS,
     _drive_initiator_handshake_and_read_response,
@@ -129,32 +128,6 @@ _LOCAL_CLOSE_RECEIVER_REJECTED = "receiver_rejected"
 # reconnect loop doesn't hammer the wrong endpoint; operator
 # recovery is re-pair or unpair.
 _LOCAL_CLOSE_PIN_MISMATCH = "pin_mismatch"
-
-
-def _mdns_record_name(hostname: str) -> str | None:
-    """Return the lowercase trailing-dot record name, or ``None`` for an IP."""
-    bare = hostname.rstrip(".")
-    with contextlib.suppress(ValueError):
-        ipaddress.ip_address(bare)
-        return None
-    return f"{bare.lower()}."
-
-
-class _ReceiverWakeListener(RecordUpdateListener):
-    """One-shot wake on an A/AAAA record for the receiver's hostname."""
-
-    def __init__(self, record_name: str, wake: asyncio.Event) -> None:
-        self._record_name = record_name
-        self._wake = wake
-
-    def async_update_records(self, zc: Zeroconf, now: float, records: list[Any]) -> None:
-        if self._wake.is_set():
-            return
-        for update in records:
-            new = update.new
-            if new.type in (_TYPE_A, _TYPE_AAAA) and new.name.lower() == self._record_name:
-                self._wake.set()
-                return
 
 
 class PeerLinkClient:

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -77,10 +77,12 @@ from esphome_device_builder.controllers.remote_build.peer_link_client import (
     preview_pair,
     request_pair,
 )
+from esphome_device_builder.controllers.remote_build.peer_link_client._wake import (
+    _mdns_record_name,
+)
 from esphome_device_builder.controllers.remote_build.peer_link_client.client import (
     _LOCAL_CLOSE_AUTH_REJECTED,
     _LOCAL_CLOSE_RECEIVER_REJECTED,
-    _mdns_record_name,
 )
 from esphome_device_builder.controllers.remote_build.peer_link_lifecycle import (
     spawn_peer_link_client,


### PR DESCRIPTION
# What does this implement/fix?

Mechanical move of the mDNS wake listener helpers (`_mdns_record_name`, `_ReceiverWakeListener`) out of `peer_link_client/client.py` into a new `peer_link_client/_wake.py`; client.py was over the 800 line soft cap, this brings it back under before a follow-up PR touches it. No behaviour change.

**Related issue or feature (if applicable):**

- none

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
