### PR TITLE
Treat dot-prefixed top-level keys as block boundaries in the line scanners

### DIFF
--- a/esphome_device_builder/controllers/automations/parsing.py
+++ b/esphome_device_builder/controllers/automations/parsing.py
@@ -37,6 +37,7 @@ from ...helpers.api import CommandError
 from ...helpers.automation_keys import is_trigger_key
 from ...helpers.json import loads as json_loads
 from ...helpers.lazy_catalog import is_unsafe_catalog_id
+from ...helpers.yaml.scan import is_ignored_top_level_key
 from ...models.api import ErrorCode
 from ...models.automations import (
     ApiActionLocation,
@@ -391,6 +392,8 @@ def _iter_instance_targets(
     if not isinstance(root, dict):
         return
     for domain, section in root.items():
+        if isinstance(domain, str) and is_ignored_top_level_key(domain):
+            continue
         is_list = isinstance(section, list)
         items = section if is_list else [section] if isinstance(section, dict) else []
         for idx, instance in enumerate(items):

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -22,6 +22,7 @@ from ..yaml import (
     parse_substitution_ref,
     rewrite_fallback_ap_ssid,
 )
+from ..yaml.scan import is_ignored_top_level_key
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -386,8 +387,7 @@ def extract_directly_referenced_integrations(
         return []
     out: set[str] = set()
     for key, value in config.items():
-        # esphome ignores dot-prefixed top-level keys (anchor containers).
-        if not isinstance(key, str) or key.startswith("."):
+        if not isinstance(key, str) or is_ignored_top_level_key(key):
             continue
         out.add(key)
         if isinstance(value, list):

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -386,7 +386,8 @@ def extract_directly_referenced_integrations(
         return []
     out: set[str] = set()
     for key, value in config.items():
-        if not isinstance(key, str):
+        # esphome ignores dot-prefixed top-level keys (anchor containers).
+        if not isinstance(key, str) or key.startswith("."):
             continue
         out.add(key)
         if isinstance(value, list):

--- a/esphome_device_builder/helpers/yaml/scan.py
+++ b/esphome_device_builder/helpers/yaml/scan.py
@@ -49,7 +49,9 @@ def block_end_index(lines: list[str], start: int) -> int:
     """First line after *start* that opens the next top-level block; ``len(lines)`` at EOF."""
     for idx in range(start + 1, len(lines)):
         stripped = lines[idx].rstrip("\n\r")
-        if stripped and stripped[0].isalpha() and not stripped.startswith(" "):
+        # A dot-prefixed key (esphome-ignored anchor container) opens a
+        # block too; comments deliberately don't.
+        if stripped and (stripped[0].isalpha() or stripped[0] == "."):
             return idx
     return len(lines)
 

--- a/esphome_device_builder/helpers/yaml/scan.py
+++ b/esphome_device_builder/helpers/yaml/scan.py
@@ -8,6 +8,16 @@ import re
 DASH_KEY_PREFIX = r"^\s*-\s+"
 
 
+def is_ignored_top_level_key(key: str) -> bool:
+    """Report whether esphome ignores this top-level key (dot-prefixed anchor container)."""
+    return key.startswith(".")
+
+
+def opens_top_level_block(stripped: str) -> bool:
+    """Report whether a rstripped line opens a column-0 block; comments deliberately don't."""
+    return bool(stripped) and (stripped[0].isalpha() or stripped[0] == ".")
+
+
 def key_header_re(key: str, *, indent: str = "") -> re.Pattern[str]:
     """Pattern matching a ``<key>:`` header line at exactly *indent*, bare or with a comment."""
     return key_line_res(key, prefix=f"^{re.escape(indent)}")[0]
@@ -48,10 +58,7 @@ def top_level_key_index(lines: list[str]) -> dict[str, int]:
 def block_end_index(lines: list[str], start: int) -> int:
     """First line after *start* that opens the next top-level block; ``len(lines)`` at EOF."""
     for idx in range(start + 1, len(lines)):
-        stripped = lines[idx].rstrip("\n\r")
-        # A dot-prefixed key (esphome-ignored anchor container) opens a
-        # block too; comments deliberately don't.
-        if stripped and (stripped[0].isalpha() or stripped[0] == "."):
+        if opens_top_level_block(lines[idx].rstrip("\n\r")):
             return idx
     return len(lines)
 

--- a/esphome_device_builder/helpers/yaml/writing_layout.py
+++ b/esphome_device_builder/helpers/yaml/writing_layout.py
@@ -76,7 +76,7 @@ def _locate_singleton_block(
         if not stripped:
             continue
         if not stripped.startswith(" "):
-            if stripped[0].isalpha():
+            if stripped[0].isalpha() or stripped[0] == ".":
                 end = idx
                 break
             # Column-0 comment ends the block only when the next

--- a/esphome_device_builder/helpers/yaml/writing_layout.py
+++ b/esphome_device_builder/helpers/yaml/writing_layout.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from ...models.api import ErrorCode
 from ...models.automations import YamlDiff
 from ..api import CommandError
-from .scan import block_end_index, find_block_header, top_list_item_starts
+from .scan import block_end_index, find_block_header, opens_top_level_block, top_list_item_starts
 
 
 def _indent_for_top_list(rendered_item: str) -> str:
@@ -76,7 +76,7 @@ def _locate_singleton_block(
         if not stripped:
             continue
         if not stripped.startswith(" "):
-            if stripped[0].isalpha() or stripped[0] == ".":
+            if opens_top_level_block(stripped):
                 end = idx
                 break
             # Column-0 comment ends the block only when the next

--- a/tests/test_automations_parse.py
+++ b/tests/test_automations_parse.py
@@ -124,6 +124,8 @@ def test_parse_skips_dot_prefixed_ignored_blocks() -> None:
     )
     parsed = parse_device_yaml(yaml)
     assert [p.location.component_id for p in parsed] == ["real_button"]
+    assert resolve_component_target(yaml, "parked_button") is None
+    assert resolve_component_target(yaml, "real_button") is not None
 
 
 def test_parse_inline_on_press_with_explicit_then() -> None:

--- a/tests/test_automations_parse.py
+++ b/tests/test_automations_parse.py
@@ -108,6 +108,24 @@ def test_parse_single_handler_trigger_as_one_element_list_parses() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_parse_skips_dot_prefixed_ignored_blocks() -> None:
+    """An instance parked under an esphome-ignored dot key yields no automation."""
+    yaml = (
+        "binary_sensor:\n"
+        "  - platform: gpio\n"
+        "    id: real_button\n"
+        "    on_press:\n"
+        "      - delay: 1s\n"
+        ".templates:\n"
+        "  - platform: gpio\n"
+        "    id: parked_button\n"
+        "    on_press:\n"
+        "      - delay: 2s\n"
+    )
+    parsed = parse_device_yaml(yaml)
+    assert [p.location.component_id for p in parsed] == ["real_button"]
+
+
 def test_parse_inline_on_press_with_explicit_then() -> None:
     """The explicit ``then:`` shape decomposes correctly."""
     parsed = parse_device_yaml(_load("inline_on_press.yaml"))

--- a/tests/test_directly_referenced_integrations.py
+++ b/tests/test_directly_referenced_integrations.py
@@ -37,6 +37,15 @@ def test_extracts_top_level_keys() -> None:
     ]
 
 
+def test_skips_dot_prefixed_keys() -> None:
+    """esphome-ignored anchor containers never count as integrations."""
+    config = {
+        "esphome": {"name": "x"},
+        ".defaultfilters": [{"throttle": "60s"}],
+    }
+    assert extract_directly_referenced_integrations(config) == ["esphome"]
+
+
 def test_extracts_platform_stems_from_list() -> None:
     """``- platform: <name>`` entries under a list-shaped block.
 

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -68,7 +68,12 @@ from esphome_device_builder.helpers.yaml.scalar import (
     _plain_is_fast_safe,
     _plain_is_safe,
 )
-from esphome_device_builder.helpers.yaml.scan import find_block_header, top_level_key_index
+from esphome_device_builder.helpers.yaml.scan import (
+    block_end_index,
+    find_block_header,
+    top_level_key_index,
+)
+from esphome_device_builder.helpers.yaml.writing_layout import _locate_singleton_block
 from esphome_device_builder.models import ErrorCode
 from esphome_device_builder.models.common import ConfigEntry, ConfigEntryType
 from esphome_device_builder.models.components import (
@@ -1291,6 +1296,22 @@ def test_merge_component_yaml_preserves_following_blocks_after_splice() -> None:
     assert result.count("sensor:\n") == 1
 
 
+def test_merge_component_yaml_splice_stops_at_dot_prefixed_key() -> None:
+    """A dot-prefixed anchor block after the domain block ends the splice range."""
+    component = _component(component_id="sensor.dht", category=ComponentCategory.SENSOR)
+    fields: dict[str, Any] = {"pin": "GPIO4", "name": "Inside"}
+
+    existing = (
+        "esphome:\n  name: kitchen\n\n"
+        "sensor:\n  - platform: bme280\n    address: 0x76\n\n"
+        ".defaultfilters:\n  - &throttle_time\n    throttle: 60s\n"
+    )
+    result = merge_component_yaml(existing, component, fields)
+
+    assert result.endswith(".defaultfilters:\n  - &throttle_time\n    throttle: 60s\n")
+    assert result.index("- platform: dht") < result.index(".defaultfilters:")
+
+
 def test_merge_component_yaml_appends_non_platform_component() -> None:
     """A non-platform component (e.g. ``i2c``) emits as a top-level mapping.
 
@@ -2430,6 +2451,23 @@ def test_child_block_end_trims_shallow_banner_but_keeps_deep_comment() -> None:
     text = "api:\n  actions:\n  - action: a\n    # for a\n\n  # banner\n  encryption:\n    key: k\n"
     # The deep ``# for a`` stays inside; the blank + shallow banner trim off.
     assert _cbe(text, 1, "  ") == 4
+
+
+def test_block_end_index_stops_at_dot_prefixed_key() -> None:
+    lines = ["sensor:\n", "  - platform: bme280\n", ".defaultfilters:\n", "  - &throttle\n"]
+    assert block_end_index(lines, 0) == 2
+
+
+def test_block_end_index_skips_column_zero_comments() -> None:
+    lines = ["sensor:\n", "  - platform: bme280\n", "# banner\n", "logger:\n"]
+    assert block_end_index(lines, 0) == 3
+
+
+def test_locate_singleton_block_ends_at_dot_prefixed_key() -> None:
+    lines = ["api:\n", "  reboot_timeout: 0s\n", ".anchors:\n", "  - &throttle\n"]
+    span = _locate_singleton_block(lines, "api")
+    assert span is not None
+    assert span[:2] == (0, 2)
 
 
 def test_top_level_key_index_matches_find_block_header() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Backend side of the dot-prefixed key blind spot from #2651. ESPHome ignores top-level keys starting with a dot, the documented way to park YAML anchors. Two line scanners only ended a top-level block at an alphabetic column-0 line, so a dot-prefixed key did not terminate the block above it; a component add or migration nudge on such a file could splice into the wrong place.

The rule now has one home: `is_ignored_top_level_key` and `opens_top_level_block` in `helpers/yaml/scan.py`. `block_end_index` and `_locate_singleton_block` treat a column-0 dot key as a block boundary, matching the scanners that already handled it; column-0 comments deliberately keep their current behaviour. The two resolved-config dict walks skip dot keys too: `extract_directly_referenced_integrations` (defense in depth, the loaded-integrations intersection already kept dot keys out of the drawer) and the automations `_iter_instance_targets` walk, so a dot-parked instance can no longer resolve as a `ComponentTarget`.

The editor rendering bug reported in the issue is fixed in the companion frontend PR.

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/device-builder/issues/2651

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#1689

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
