### PR TITLE
Serialise non-string keys in /json-config

### DIFF
--- a/esphome_device_builder/api/legacy.py
+++ b/esphome_device_builder/api/legacy.py
@@ -40,6 +40,7 @@ from ..helpers.event_bus import Event, StreamControls, stream_events
 from ..helpers.json import (
     JSONDecodeError,
     dumps_str,
+    dumps_str_non_str_keys,
     json_response,
     loads,
 )
@@ -336,7 +337,8 @@ async def _json_config_response(db: DeviceBuilder, configuration: str) -> web.Re
         return json_response({"error": "esphome config unavailable"}, status=503)
     if config is None:
         return json_response({"error": "Configuration is invalid"}, status=422)
-    return json_response(config)
+    # User YAML maps can carry ``int`` keys (effect / mode maps); strict orjson rejects them.
+    return web.json_response(config, dumps=dumps_str_non_str_keys)
 
 
 def _parse_encryption_key_payload(raw: bytes) -> tuple[str, str, str]:

--- a/esphome_device_builder/api/legacy.py
+++ b/esphome_device_builder/api/legacy.py
@@ -39,8 +39,8 @@ from ..helpers.device_yaml import EsphomeConfigUnavailableError, run_esphome_con
 from ..helpers.event_bus import Event, StreamControls, stream_events
 from ..helpers.json import (
     JSONDecodeError,
+    dumps_non_str_keys,
     dumps_str,
-    dumps_str_non_str_keys,
     json_response,
     loads,
 )
@@ -338,7 +338,7 @@ async def _json_config_response(db: DeviceBuilder, configuration: str) -> web.Re
     if config is None:
         return json_response({"error": "Configuration is invalid"}, status=422)
     # User YAML maps can carry ``int`` keys (effect / mode maps); strict orjson rejects them.
-    return web.json_response(config, dumps=dumps_str_non_str_keys)
+    return json_response(config, dumps=dumps_non_str_keys)
 
 
 def _parse_encryption_key_payload(raw: bytes) -> tuple[str, str, str]:

--- a/esphome_device_builder/helpers/json.py
+++ b/esphome_device_builder/helpers/json.py
@@ -11,6 +11,7 @@ change.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from typing import Any
 
 import orjson
@@ -49,9 +50,9 @@ def dumps_str(obj: Any) -> str:
     return orjson.dumps(obj).decode()
 
 
-def dumps_str_non_str_keys(obj: Any) -> str:
-    """Serialise *obj* to a JSON ``str``, stringifying non-``str`` dict keys."""
-    return orjson.dumps(obj, option=orjson.OPT_NON_STR_KEYS).decode()
+def dumps_non_str_keys(obj: Any) -> bytes:
+    """Serialise *obj* to compact JSON ``bytes``, stringifying non-``str`` dict keys."""
+    return orjson.dumps(obj, option=orjson.OPT_NON_STR_KEYS)
 
 
 def dumps_indent(obj: Any) -> bytes:
@@ -59,7 +60,9 @@ def dumps_indent(obj: Any) -> bytes:
     return orjson.dumps(obj, option=orjson.OPT_INDENT_2)
 
 
-def json_response(data: Any, status: int = 200) -> web.Response:
+def json_response(
+    data: Any, status: int = 200, *, dumps: Callable[[Any], bytes] = dumps
+) -> web.Response:
     """Return a JSON response, serialising dataclasses via mashumaro."""
     body = data.to_dict() if hasattr(data, "to_dict") else data
     return web.Response(

--- a/esphome_device_builder/helpers/json.py
+++ b/esphome_device_builder/helpers/json.py
@@ -49,6 +49,11 @@ def dumps_str(obj: Any) -> str:
     return orjson.dumps(obj).decode()
 
 
+def dumps_str_non_str_keys(obj: Any) -> str:
+    """Serialise *obj* to a JSON ``str``, stringifying non-``str`` dict keys."""
+    return orjson.dumps(obj, option=orjson.OPT_NON_STR_KEYS).decode()
+
+
 def dumps_indent(obj: Any) -> bytes:
     """Serialise *obj* with two-space indentation — for human-readable files."""
     return orjson.dumps(obj, option=orjson.OPT_INDENT_2)

--- a/tests/api/test_legacy.py
+++ b/tests/api/test_legacy.py
@@ -495,6 +495,26 @@ async def test_json_config_returns_resolved_config(
     assert body["sensor"][0]["delta"] == 0.1
 
 
+async def test_json_config_serialises_int_keyed_maps(
+    tmp_path: Path, aiohttp_client: AiohttpClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A resolved config with ``int``-keyed maps returns 200 with string keys."""
+    (tmp_path / "lamp.yaml").write_text("esphome:\n  name: lamp\n", encoding="utf-8")
+    resolved = {
+        "esphome": {"name": "lamp"},
+        "light": [{"effects_map": {0: "Indicator", 1: "Constant"}, "widths": {6: 1, 26: 1}}],
+    }
+    monkeypatch.setattr(legacy, "run_esphome_config", AsyncMock(return_value=resolved))
+    client = await aiohttp_client(_make_json_config_app(tmp_path))
+
+    resp = await client.get("/json-config", params={"configuration": "lamp.yaml"})
+
+    assert resp.status == 200
+    body = await resp.json()
+    assert body["light"][0]["effects_map"] == {"0": "Indicator", "1": "Constant"}
+    assert body["light"][0]["widths"] == {"6": 1, "26": 1}
+
+
 @pytest.mark.parametrize(
     "payload",
     ["../etc/passwd", "../../etc/passwd", "/absolute/path"],

--- a/tests/api/test_legacy.py
+++ b/tests/api/test_legacy.py
@@ -510,6 +510,7 @@ async def test_json_config_serialises_int_keyed_maps(
     resp = await client.get("/json-config", params={"configuration": "lamp.yaml"})
 
     assert resp.status == 200
+    assert resp.headers["Content-Type"] == "application/json"
     body = await resp.json()
     assert body["light"][0]["effects_map"] == {"0": "Indicator", "1": "Constant"}
     assert body["light"][0]["widths"] == {"6": 1, "26": 1}

--- a/tests/real_compile/test_json_config_resolution.py
+++ b/tests/real_compile/test_json_config_resolution.py
@@ -2,8 +2,8 @@
 
 Spawns a real ``esphome config --show-secrets`` to prove the end-to-end
 contract HA depends on: substitutions expanded, packages merged, secrets
-resolved, floats/lambdas serialisable — none of which a raw ``load_yaml``
-produces.
+resolved, floats/lambdas serialisable, int-keyed maps kept as ``int`` — none of
+which a raw ``load_yaml`` produces.
 """
 
 from __future__ import annotations
@@ -13,14 +13,16 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 from esphome_device_builder.helpers.device_yaml import run_esphome_config
-from esphome_device_builder.helpers.json import dumps_str
+from esphome_device_builder.helpers.json import dumps, dumps_non_str_keys, loads
 
 
 async def test_run_esphome_config_resolves_substitutions_packages_and_secrets(
     tmp_path: Path,
 ) -> None:
-    """Resolved JSON carries the real key (package + secret), expanded name, float."""
+    """Resolved config carries the real key, expanded name, float, and int-keyed map."""
     key = base64.b64encode(os.urandom(32)).decode()
     (tmp_path / "secrets.yaml").write_text(
         f'api_key: "{key}"\nwifi_pw: "wifipass8"\n', encoding="utf-8"
@@ -35,7 +37,11 @@ async def test_run_esphome_config_resolves_substitutions_packages_and_secrets(
         "esp32:\n  variant: esp32c3\n  framework:\n    type: esp-idf\n"
         "wifi:\n  ssid: myssid\n  password: !secret wifi_pw\n"
         "sensor:\n  - platform: adc\n    pin: GPIO01\n    id: test_adc\n"
-        "    filters:\n      - delta: 0.1\n",
+        "    filters:\n      - delta: 0.1\n"
+        "uart:\n  rx_pin: GPIO20\n  tx_pin: GPIO21\n  baud_rate: 9600\n"
+        "tuya:\n"
+        "select:\n  - platform: tuya\n    name: Mode\n    enum_datapoint: 4\n"
+        "    options:\n      0: 'Off'\n      1: Constant\n",
         encoding="utf-8",
     )
 
@@ -45,4 +51,10 @@ async def test_run_esphome_config_resolves_substitutions_packages_and_secrets(
     assert config["esphome"]["name"] == "livingroom"  # substitution expanded
     assert config["api"]["encryption"]["key"] == key  # package merged + secret resolved
     assert config["sensor"][0]["filters"][0]["delta"] == 0.1  # float, not a 500
-    assert dumps_str(config)  # serialises with plain orjson
+    assert config["select"][0]["options"] == {0: "Off", 1: "Constant"}  # int keys survive
+    with pytest.raises(TypeError, match="Dict key must be str"):
+        dumps(config)
+    assert loads(dumps_non_str_keys(config))["select"][0]["options"] == {
+        "0": "Off",
+        "1": "Constant",
+    }

--- a/tests/test_helpers_json.py
+++ b/tests/test_helpers_json.py
@@ -11,7 +11,7 @@ from pytest_aiohttp.plugin import AiohttpClient
 from esphome_device_builder.helpers.json import (
     cors_middleware,
     dumps,
-    dumps_str_non_str_keys,
+    dumps_non_str_keys,
     loads,
 )
 
@@ -31,10 +31,10 @@ def test_dumps_rejects_str_subclass_keys() -> None:
         dumps({_StrSubclass("hello"): "world"})
 
 
-def test_dumps_str_non_str_keys_stringifies_int_keys() -> None:
-    """``dumps_str_non_str_keys`` emits ``int`` and ``str``-subclass keys as JSON strings."""
-    out = dumps_str_non_str_keys({6: 1, _StrSubclass("a"): {7: 2}, "plain": 3})
-    assert isinstance(out, str)
+def test_dumps_non_str_keys_stringifies_int_keys() -> None:
+    """``dumps_non_str_keys`` emits ``int`` and ``str``-subclass keys as JSON strings."""
+    out = dumps_non_str_keys({6: 1, _StrSubclass("a"): {7: 2}, "plain": 3})
+    assert isinstance(out, bytes)
     assert loads(out) == {"6": 1, "a": {"7": 2}, "plain": 3}
 
 

--- a/tests/test_helpers_json.py
+++ b/tests/test_helpers_json.py
@@ -8,7 +8,12 @@ import pytest
 from aiohttp import web
 from pytest_aiohttp.plugin import AiohttpClient
 
-from esphome_device_builder.helpers.json import cors_middleware, dumps
+from esphome_device_builder.helpers.json import (
+    cors_middleware,
+    dumps,
+    dumps_str_non_str_keys,
+    loads,
+)
 
 
 class _StrSubclass(str):
@@ -24,6 +29,13 @@ def test_dumps_rejects_str_subclass_keys() -> None:
     """
     with pytest.raises(TypeError, match="Dict key must be str"):
         dumps({_StrSubclass("hello"): "world"})
+
+
+def test_dumps_str_non_str_keys_stringifies_int_keys() -> None:
+    """``dumps_str_non_str_keys`` emits ``int`` and ``str``-subclass keys as JSON strings."""
+    out = dumps_str_non_str_keys({6: 1, _StrSubclass("a"): {7: 2}, "plain": 3})
+    assert isinstance(out, str)
+    assert loads(out) == {"6": 1, "a": {"7": 2}, "plain": 3}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

`GET /json-config` returned 500 for any configuration whose resolved form has a mapping with integer keys (light effect maps, `miot` mode maps, external component width maps). The endpoint serialised with strict orjson, which rejects non-string dict keys; #1767 dropped the `OPT_NON_STR_KEYS` wrapper that used to cover this.

Restores `dumps_str_non_str_keys` in `helpers/json.py` and uses it for the endpoint's success response only, so integer keys become their decimal strings, the same shape the legacy dashboard emitted via stdlib json. Error responses keep the strict serialiser. Adds a helper test and an endpoint test with an integer keyed map.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2659

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
