### PR TITLE
Resolve platform-scoped component triggers by instance platform

### DIFF
--- a/esphome_device_builder/controllers/automations/catalog.py
+++ b/esphome_device_builder/controllers/automations/catalog.py
@@ -234,6 +234,34 @@ def component_trigger_domains() -> frozenset[str]:
     return _component_trigger_domains()
 
 
+def hosts_component_triggers(domain: str, catalog_id: str | None) -> bool:
+    """Return whether *domain* or the instance's *catalog_id* scopes a component trigger."""
+    scopes = _component_trigger_domains()
+    return domain in scopes or catalog_id in scopes
+
+
+@cache
+def _component_trigger_index() -> dict[tuple[str, str], str]:
+    """``(applies_to scope, bare key) -> trigger id`` over every component trigger."""
+    out: dict[tuple[str, str], str] = {}
+    for trigger in _slim_triggers():
+        if trigger.is_device_level:
+            continue
+        key = trigger.id.rsplit(".", 1)[-1]
+        for scope in trigger.applies_to:
+            out[(scope, key)] = trigger.id
+    return out
+
+
+def component_triggers_for_key(key: str) -> list[tuple[str, str]]:
+    """``(top_level_domain, trigger_id)`` per scope hosting *key*, sorted by scope."""
+    return [
+        (scope.split(".", 1)[0], trigger_id)
+        for (scope, scope_key), trigger_id in sorted(_component_trigger_index().items())
+        if scope_key == key
+    ]
+
+
 def all_actions() -> list[AutomationActionIndex]:
     """Return the slim action catalog (picker fields, no config_entries)."""
     return list(_editable_actions())
@@ -263,6 +291,17 @@ def all_filters() -> list[FilterIndex]:
 def trigger_by_id(trigger_id: str) -> AutomationTrigger | None:
     """Look up one trigger's full body by qualified id (e.g. ``binary_sensor.on_press``)."""
     return _TRIGGER_STORE.get_sync(trigger_id)
+
+
+def resolve_component_trigger(
+    catalog_id: str | None, domain: str, key: str
+) -> AutomationTrigger | None:
+    """Trigger for an instance's ``on_*`` *key*, scoped to its platform first, then its domain."""
+    index = _component_trigger_index()
+    trigger_id = index.get((catalog_id, key)) if catalog_id else None
+    if trigger_id is None:
+        trigger_id = index.get((domain, key))
+    return trigger_by_id(trigger_id) if trigger_id else None
 
 
 def action_by_id(action_id: str) -> AutomationAction | None:

--- a/esphome_device_builder/controllers/automations/catalog.py
+++ b/esphome_device_builder/controllers/automations/catalog.py
@@ -229,11 +229,6 @@ def _component_trigger_domains() -> frozenset[str]:
     return frozenset(out)
 
 
-def component_trigger_domains() -> frozenset[str]:
-    """Domains that host inline component ``on_*`` triggers."""
-    return _component_trigger_domains()
-
-
 def hosts_component_triggers(domain: str, catalog_id: str | None) -> bool:
     """Return whether *domain* or the instance's *catalog_id* scopes a component trigger."""
     scopes = _component_trigger_domains()
@@ -253,13 +248,19 @@ def _component_trigger_index() -> dict[tuple[str, str], str]:
     return out
 
 
-def component_triggers_for_key(key: str) -> list[tuple[str, str]]:
-    """``(top_level_domain, trigger_id)`` per scope hosting *key*, sorted by scope."""
-    return [
-        (scope.split(".", 1)[0], trigger_id)
-        for (scope, scope_key), trigger_id in sorted(_component_trigger_index().items())
+def infer_component_scope(key: str) -> tuple[str, str] | None:
+    """``(top_level_domain, trigger_id)`` of the alphabetically-first scope hosting *key*."""
+    # Several domains can host one key (``on_turn_on`` on ``fan`` and
+    # ``switch``); the first scope keeps the guess deterministic.
+    matches = sorted(
+        (scope, trigger_id)
+        for (scope, scope_key), trigger_id in _component_trigger_index().items()
         if scope_key == key
-    ]
+    )
+    if not matches:
+        return None
+    scope, trigger_id = matches[0]
+    return scope.split(".", 1)[0], trigger_id
 
 
 def all_actions() -> list[AutomationActionIndex]:

--- a/esphome_device_builder/controllers/automations/controller.py
+++ b/esphome_device_builder/controllers/automations/controller.py
@@ -320,7 +320,9 @@ def _scope_from_yaml(text: str) -> _ScopedYaml:
         if isinstance(section, list):
             domains.update(_qualified_domains(domain, section))
             devices.extend(_scope_component_instances(domain, section))
-        elif isinstance(section, dict) and catalog.hosts_component_triggers(domain, None):
+        elif isinstance(section, dict) and catalog.hosts_component_triggers(
+            domain, parsing.catalog_id(domain, section.get("platform"))
+        ):
             devices.extend(_scope_singleton_instance(domain, section))
     return _ScopedYaml(domains=domains, scripts=scripts, devices=devices)
 

--- a/esphome_device_builder/controllers/automations/controller.py
+++ b/esphome_device_builder/controllers/automations/controller.py
@@ -307,7 +307,6 @@ def _scope_from_yaml(text: str) -> _ScopedYaml:
     if not isinstance(data, dict):
         return _ScopedYaml(domains=set(), scripts=[], devices=[])
 
-    component_domains = _component_trigger_domains()
     scripts: list[AvailableScript] = []
     devices: list[AvailableComponentInstance] = []
     domains: set[str] = set(data.keys())
@@ -320,9 +319,8 @@ def _scope_from_yaml(text: str) -> _ScopedYaml:
         section = data.get(domain)
         if isinstance(section, list):
             domains.update(_qualified_domains(domain, section))
-            if domain in component_domains:
-                devices.extend(_scope_component_instances(domain, section))
-        elif isinstance(section, dict) and domain in component_domains:
+            devices.extend(_scope_component_instances(domain, section))
+        elif isinstance(section, dict) and catalog.hosts_component_triggers(domain, None):
             devices.extend(_scope_singleton_instance(domain, section))
     return _ScopedYaml(domains=domains, scripts=scripts, devices=devices)
 
@@ -333,19 +331,9 @@ def _qualified_domains(domain: str, section: list) -> set[str]:
     for item in section:
         if not isinstance(item, dict):
             continue
-        platform = item.get("platform")
-        if isinstance(platform, str) and platform:
-            out.add(f"{domain}.{platform}")
-    return out
-
-
-def _component_trigger_domains() -> set[str]:
-    """Return every domain that hosts component-level triggers."""
-    out: set[str] = set()
-    for trigger in catalog.all_triggers():
-        if trigger.is_device_level:
-            continue
-        out.update(trigger.applies_to)
+        cat_id = parsing.catalog_id(domain, item.get("platform"))
+        if cat_id != domain:
+            out.add(cat_id)
     return out
 
 
@@ -371,7 +359,7 @@ def _scope_component_instances(
     section: list,
 ) -> list[AvailableComponentInstance]:
     """
-    Pick configured component instance ids under one domain.
+    Pick configured instance ids under one domain whose domain or platform hosts triggers.
 
     A multi-entity platform surfaces each configured sub-entity
     (``parent_id`` set) and flags the container ``is_entity_container``.
@@ -381,6 +369,8 @@ def _scope_component_instances(
         if not isinstance(item, dict):
             continue
         catalog_id = parsing.catalog_id(domain, item.get("platform"))
+        if not catalog.hosts_component_triggers(domain, catalog_id):
+            continue
         # An id-less instance keys on the parser and writer's declared-or-
         # positional id, so it round-trips. Container-ness comes from the
         # catalog definition, not from which sub-blocks the YAML happens to

--- a/esphome_device_builder/controllers/automations/parsing.py
+++ b/esphome_device_builder/controllers/automations/parsing.py
@@ -464,7 +464,7 @@ def _parse_inline_component_triggers(root: Any) -> list[ParsedAutomation]:
         if not catalog.hosts_component_triggers(domain, target.trigger_scope):
             continue
         out.extend(
-            _parse_instance_triggers(domain, instance, comp_id, catalog_id=target.trigger_scope)
+            _parse_instance_triggers(domain, instance, comp_id, trigger_scope=target.trigger_scope)
         )
     return out
 
@@ -657,7 +657,7 @@ def _parse_instance_triggers(
     instance: dict,
     comp_id: str,
     *,
-    catalog_id: str | None,
+    trigger_scope: str | None,
 ) -> list[ParsedAutomation]:
     """Emit every recognised inline ``on_*:`` handler on one component instance."""
     comp_name = str(instance.get("name") or comp_id)
@@ -665,7 +665,7 @@ def _parse_instance_triggers(
     for key, body in list(instance.items()):
         if not is_trigger_key(key):
             continue
-        trigger = catalog.resolve_component_trigger(catalog_id, domain, key)
+        trigger = catalog.resolve_component_trigger(trigger_scope, domain, key)
         if trigger is None:
             # Not a known component trigger — skip rather than surface
             # as a parse error. Component schemas occasionally carry

--- a/esphome_device_builder/controllers/automations/parsing.py
+++ b/esphome_device_builder/controllers/automations/parsing.py
@@ -385,9 +385,9 @@ def _iter_instance_targets(
     """
     Yield ``(domain, instance, comp_id, target)`` for every instance + sub-entity.
 
-    The one document walk shared by :func:`_iter_component_instances` and
-    :func:`resolve_component_target` (list instances, flat singletons, nested
-    sub-entities).
+    The one document walk shared by :func:`_parse_inline_component_triggers`
+    and :func:`resolve_component_target` (list instances, flat singletons,
+    nested sub-entities).
     """
     if not isinstance(root, dict):
         return
@@ -425,14 +425,6 @@ def _iter_instance_targets(
                 )
 
 
-def _iter_component_instances(
-    root: Any,
-) -> Iterator[tuple[str, dict, str]]:
-    """Yield ``(domain, instance, comp_id)`` for every instance + sub-entity."""
-    for domain, instance, comp_id, _target in _iter_instance_targets(root):
-        yield domain, instance, comp_id
-
-
 def catalog_id(domain: str, platform: Any) -> str:
     """Return the component's catalog id: ``<domain>.<platform>``, or the bare domain."""
     return f"{domain}.{platform}" if isinstance(platform, str) and platform else domain
@@ -462,12 +454,13 @@ def iter_subentities(
 
 def _parse_inline_component_triggers(root: Any) -> list[ParsedAutomation]:
     """Walk component instances for inline ``on_*:`` handlers."""
-    trigger_domains = catalog.component_trigger_domains()
     out: list[ParsedAutomation] = []
-    for domain, instance, comp_id in _iter_component_instances(root):
-        if domain not in trigger_domains:
+    for domain, instance, comp_id, target in _iter_instance_targets(root):
+        if not catalog.hosts_component_triggers(domain, target.catalog_id):
             continue
-        out.extend(_parse_instance_triggers(domain, instance, comp_id))
+        out.extend(
+            _parse_instance_triggers(domain, instance, comp_id, catalog_id=target.catalog_id)
+        )
     return out
 
 
@@ -658,6 +651,8 @@ def _parse_instance_triggers(
     domain: str,
     instance: dict,
     comp_id: str,
+    *,
+    catalog_id: str | None,
 ) -> list[ParsedAutomation]:
     """Emit every recognised inline ``on_*:`` handler on one component instance."""
     comp_name = str(instance.get("name") or comp_id)
@@ -665,7 +660,7 @@ def _parse_instance_triggers(
     for key, body in list(instance.items()):
         if not is_trigger_key(key):
             continue
-        trigger = catalog.trigger_by_id(f"{domain}.{key}")
+        trigger = catalog.resolve_component_trigger(catalog_id, domain, key)
         if trigger is None:
             # Not a known component trigger — skip rather than surface
             # as a parse error. Component schemas occasionally carry

--- a/esphome_device_builder/controllers/automations/parsing.py
+++ b/esphome_device_builder/controllers/automations/parsing.py
@@ -459,7 +459,12 @@ def _parse_inline_component_triggers(root: Any) -> list[ParsedAutomation]:
         if not catalog.hosts_component_triggers(domain, target.catalog_id):
             continue
         out.extend(
-            _parse_instance_triggers(domain, instance, comp_id, catalog_id=target.catalog_id)
+            _parse_instance_triggers(
+                domain,
+                instance,
+                comp_id,
+                catalog_id=None if target.is_sub_entity else target.catalog_id,
+            )
         )
     return out
 

--- a/esphome_device_builder/controllers/automations/parsing.py
+++ b/esphome_device_builder/controllers/automations/parsing.py
@@ -317,6 +317,11 @@ class ComponentTarget(NamedTuple):
     sub_key: str | None = None
     catalog_id: str | None = None
 
+    @property
+    def trigger_scope(self) -> str | None:
+        """Catalog id scoping this target's triggers; a sub-entity hosts only domain-level ones."""
+        return None if self.is_sub_entity else self.catalog_id
+
 
 def resolve_component_domain(yaml_text: str, component_id: str) -> str | None:
     """
@@ -456,15 +461,10 @@ def _parse_inline_component_triggers(root: Any) -> list[ParsedAutomation]:
     """Walk component instances for inline ``on_*:`` handlers."""
     out: list[ParsedAutomation] = []
     for domain, instance, comp_id, target in _iter_instance_targets(root):
-        if not catalog.hosts_component_triggers(domain, target.catalog_id):
+        if not catalog.hosts_component_triggers(domain, target.trigger_scope):
             continue
         out.extend(
-            _parse_instance_triggers(
-                domain,
-                instance,
-                comp_id,
-                catalog_id=None if target.is_sub_entity else target.catalog_id,
-            )
+            _parse_instance_triggers(domain, instance, comp_id, catalog_id=target.trigger_scope)
         )
     return out
 

--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -249,8 +249,7 @@ def _upsert_component_on(
     target = resolve_component_target(yaml_text, location.component_id)
     if target is not None and target.is_sub_entity:
         return _upsert_subentity_on(yaml_text, tree, location, target)
-    instance_domain = target.domain if target is not None else _component_domain(location)
-    trigger = _require_trigger(instance_domain, location)
+    instance_domain, trigger = _resolve_location_trigger(target, location)
     if location.index is not None:
         return upsert_component_on_entry(
             yaml_text,
@@ -261,11 +260,10 @@ def _upsert_component_on(
             trigger=trigger,
             index=location.index,
         )
-    domain = trigger.applies_to[0] if trigger.applies_to else ""
     rendered = render_trigger_handler(tree, key=location.trigger)
     res = upsert_inline_handler(
         yaml_text,
-        component_domain=domain,
+        component_domain=instance_domain,
         component_id=location.component_id,
         handler_key=location.trigger,
         rendered_yaml=rendered,
@@ -273,7 +271,7 @@ def _upsert_component_on(
     if res is None:
         msg = (
             f"Component instance id={location.component_id!r} not found "
-            f"under {domain!r}; can't splice handler {location.trigger!r}"
+            f"under {instance_domain!r}; can't splice handler {location.trigger!r}"
         )
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     new_text, from_line, to_line, replacement = res
@@ -292,7 +290,7 @@ def _upsert_subentity_on(
 ) -> tuple[str, YamlDiff]:
     """Splice an ``on_*:`` handler under a nested sub-entity (``aht20_temperature``)."""
     ref = _subentity_context(target)
-    trigger = _require_trigger(target.domain, location)
+    _, trigger = _resolve_location_trigger(target, location)
     try:
         if location.index is not None:
             return upsert_subentity_on_entry(
@@ -700,7 +698,7 @@ def _delete_component_on(
     target = resolve_component_target(yaml_text, location.component_id)
     if target is not None and target.is_sub_entity:
         return _delete_subentity_on(yaml_text, location, target)
-    instance_domain = target.domain if target is not None else _component_domain(location)
+    instance_domain = target.domain if target is not None else _infer_component_scope(location)[0]
     if location.index is not None:
         return delete_list_entry(
             yaml_text,
@@ -709,18 +707,16 @@ def _delete_component_on(
             handler_key=location.trigger,
             index=location.index,
         )
-    trigger = catalog.trigger_by_id(f"{instance_domain}.{location.trigger}")
-    domain = trigger.applies_to[0] if trigger and trigger.applies_to else ""
     res = remove_inline_handler(
         yaml_text,
-        component_domain=domain,
+        component_domain=instance_domain,
         component_id=location.component_id,
         handler_key=location.trigger,
     )
     if res is None:
         msg = (
             f"Component instance id={location.component_id!r} not found "
-            f"under {domain!r}; can't delete handler {location.trigger!r}"
+            f"under {instance_domain!r}; can't delete handler {location.trigger!r}"
         )
         raise CommandError(ErrorCode.NOT_FOUND, msg)
     new_text, from_line, to_line = res
@@ -845,13 +841,22 @@ def _delete_api_action(
 # ---------------------------------------------------------------------------
 
 
-def _require_trigger(domain: str, location: ComponentOnLocation) -> AutomationTrigger:
-    """Look up the catalog trigger for ``<domain>.<trigger>``; raise if unknown."""
-    trigger = catalog.trigger_by_id(f"{domain}.{location.trigger}")
+def _resolve_location_trigger(
+    target: ComponentTarget | None, location: ComponentOnLocation
+) -> tuple[str, AutomationTrigger]:
+    """``(top_level_domain, trigger)`` for *location*; raise if the trigger is unknown."""
+    if target is None:
+        domain, trigger_id = _infer_component_scope(location)
+        trigger = catalog.trigger_by_id(trigger_id) if trigger_id else None
+    else:
+        domain = target.domain
+        trigger = catalog.resolve_component_trigger(
+            target.catalog_id, target.domain, location.trigger
+        )
     if trigger is None:
         msg = f"Unknown trigger id {location.trigger!r} on component {location.component_id!r}"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
-    return trigger
+    return domain, trigger
 
 
 def _subentity_context(target: ComponentTarget) -> SubEntityRef:
@@ -862,35 +867,11 @@ def _subentity_context(target: ComponentTarget) -> SubEntityRef:
     return SubEntityRef(target.parent_domain, target.parent_id, target.sub_key)
 
 
-def _component_domain(location: ComponentOnLocation) -> str:
-    """Return the inferred domain from a ComponentOnLocation.
-
-    The location object carries ``component_id`` (a YAML id) and a
-    trigger key, but not a domain. The trigger catalog maps the
-    trigger key + domain to a full id; we resolve by enumerating
-    every domain a known trigger of that key applies to and picking
-    the first one. ``binary_sensor.on_press`` and ``switch.on_press``
-    don't collide because their applies_to lists are disjoint.
-
-    Catalog-only fallback for when ``location.component_id`` isn't found in
-    the YAML (``resolve_component_target`` returned ``None``); the writer
-    prefers the resolved instance's actual domain when it has one. Picking
-    alphabetically here can mis-attribute a shared trigger key (``on_turn_on``
-    on ``fan`` vs ``switch``), but the upsert then surfaces a clear
-    "id not found" error.
-    """
-    matches = [
-        t
-        for t in catalog.all_triggers()
-        if not t.is_device_level and t.id.endswith("." + location.trigger)
-    ]
-    if not matches:
-        return ""
-    if len(matches) > 1:
-        # Multiple domains share this trigger key. We don't know
-        # which one the caller intended; the caller must disambiguate
-        # via the trigger.applies_to list on a fully-qualified
-        # location. For now pick the alphabetically-first domain so
-        # tests are deterministic.
-        matches.sort(key=lambda t: t.applies_to[0] if t.applies_to else "")
-    return matches[0].applies_to[0] if matches[0].applies_to else ""
+def _infer_component_scope(location: ComponentOnLocation) -> tuple[str, str | None]:
+    """Catalog-only ``(top_level_domain, trigger_id)`` for an instance the YAML doesn't contain."""
+    # The location carries a YAML id and a trigger key but no domain. Picking
+    # the alphabetically-first scope hosting that key keeps tests deterministic
+    # but can mis-attribute a shared key (``on_turn_on`` on ``fan`` vs
+    # ``switch``); the upsert then surfaces a clear "id not found" error.
+    matches = catalog.component_triggers_for_key(location.trigger)
+    return matches[0] if matches else ("", None)

--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -730,6 +730,7 @@ def _delete_subentity_on(
 ) -> tuple[str, YamlDiff]:
     """Drop an ``on_*:`` handler from a nested sub-entity (``aht20_temperature``)."""
     ref = _subentity_context(target)
+    _resolve_location_trigger(target, location)
     try:
         if location.index is not None:
             return delete_subentity_list_entry(

--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -850,7 +850,7 @@ def _resolve_location_trigger(
         domain, trigger_id = _infer_component_scope(location)
         trigger = catalog.trigger_by_id(trigger_id) if trigger_id else None
     else:
-        domain = target.domain
+        domain = target.parent_domain or target.domain
         trigger = catalog.resolve_component_trigger(
             target.trigger_scope, target.domain, location.trigger
         )

--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -850,8 +850,10 @@ def _resolve_location_trigger(
         trigger = catalog.trigger_by_id(trigger_id) if trigger_id else None
     else:
         domain = target.domain
+        # A sub-entity hosts only domain-level triggers; the parent's
+        # platform scope must not resolve onto its nested block.
         trigger = catalog.resolve_component_trigger(
-            target.catalog_id, target.domain, location.trigger
+            None if target.is_sub_entity else target.catalog_id, target.domain, location.trigger
         )
     if trigger is None:
         msg = f"Unknown trigger id {location.trigger!r} on component {location.component_id!r}"
@@ -869,9 +871,6 @@ def _subentity_context(target: ComponentTarget) -> SubEntityRef:
 
 def _infer_component_scope(location: ComponentOnLocation) -> tuple[str, str | None]:
     """Catalog-only ``(top_level_domain, trigger_id)`` for an instance the YAML doesn't contain."""
-    # The location carries a YAML id and a trigger key but no domain. Picking
-    # the alphabetically-first scope hosting that key keeps tests deterministic
-    # but can mis-attribute a shared key (``on_turn_on`` on ``fan`` vs
-    # ``switch``); the upsert then surfaces a clear "id not found" error.
-    matches = catalog.component_triggers_for_key(location.trigger)
-    return matches[0] if matches else ("", None)
+    # A mis-attributed shared key surfaces as a clear "id not found" error
+    # from the splice, never as a silent write under the wrong domain.
+    return catalog.infer_component_scope(location.trigger) or ("", None)

--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -850,10 +850,8 @@ def _resolve_location_trigger(
         trigger = catalog.trigger_by_id(trigger_id) if trigger_id else None
     else:
         domain = target.domain
-        # A sub-entity hosts only domain-level triggers; the parent's
-        # platform scope must not resolve onto its nested block.
         trigger = catalog.resolve_component_trigger(
-            None if target.is_sub_entity else target.catalog_id, target.domain, location.trigger
+            target.trigger_scope, target.domain, location.trigger
         )
     if trigger is None:
         msg = f"Unknown trigger id {location.trigger!r} on component {location.component_id!r}"

--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -698,7 +698,7 @@ def _delete_component_on(
     target = resolve_component_target(yaml_text, location.component_id)
     if target is not None and target.is_sub_entity:
         return _delete_subentity_on(yaml_text, location, target)
-    instance_domain = target.domain if target is not None else _infer_component_scope(location)[0]
+    instance_domain, _trigger = _resolve_location_trigger(target, location)
     if location.index is not None:
         return delete_list_entry(
             yaml_text,

--- a/tests/fixtures/automation_yamls/rotary_encoder_triggers.yaml
+++ b/tests/fixtures/automation_yamls/rotary_encoder_triggers.yaml
@@ -1,0 +1,35 @@
+esphome:
+  name: dimmer
+output:
+  - platform: ledc
+    id: output_ledc_1
+    pin: GPIO4
+  - platform: ledc
+    id: output_ledc_2
+    pin: GPIO5
+light:
+  - platform: monochromatic
+    id: light_monochromatic_1
+    name: Lamp 1
+    output: output_ledc_1
+  - platform: monochromatic
+    id: light_monochromatic_2
+    name: Lamp 2
+    output: output_ledc_2
+sensor:
+  - platform: rotary_encoder
+    id: sensor_rotary_encoder_1
+    name: Dial
+    pin_a: GPIO18
+    pin_b: GPIO19
+    on_clockwise:
+      - logger.log: clockwise
+      - light.dim_relative:
+          id: light_monochromatic_1
+          relative_brightness: 5%
+    on_anticlockwise:
+      then:
+        - logger.log: anticlockwise
+        - light.dim_relative:
+            id: light_monochromatic_1
+            relative_brightness: -5%

--- a/tests/test_automations_controller.py
+++ b/tests/test_automations_controller.py
@@ -70,6 +70,19 @@ def test_catalog_has_no_action_field_triggers() -> None:
 
 
 @pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        ("on_clockwise", ("sensor", "rotary_encoder.sensor.on_clockwise")),
+        ("on_turn_on", ("fan", "fan.on_turn_on")),
+        ("on_nope", None),
+    ],
+)
+def test_infer_component_scope(key: str, expected: tuple[str, str] | None) -> None:
+    """The alphabetically-first scope hosting a key wins; an unknown key infers nothing."""
+    assert catalog.infer_component_scope(key) == expected
+
+
+@pytest.mark.parametrize(
     ("catalog_id", "domain", "key", "expected"),
     [
         ("sensor.rotary_encoder", "sensor", "on_clockwise", "rotary_encoder.sensor.on_clockwise"),

--- a/tests/test_automations_controller.py
+++ b/tests/test_automations_controller.py
@@ -69,6 +69,26 @@ def test_catalog_has_no_action_field_triggers() -> None:
     assert offenders == []
 
 
+@pytest.mark.parametrize(
+    ("catalog_id", "domain", "key", "expected"),
+    [
+        ("sensor.rotary_encoder", "sensor", "on_clockwise", "rotary_encoder.sensor.on_clockwise"),
+        ("sensor.rotary_encoder", "sensor", "on_value", "sensor.on_value"),
+        ("binary_sensor.gpio", "binary_sensor", "on_press", "binary_sensor.on_press"),
+        (None, "binary_sensor", "on_press", "binary_sensor.on_press"),
+        ("sensor.aht10", "sensor", "on_value_range", "sensor.on_value_range"),
+        (None, "sensor", "on_clockwise", None),
+        ("sensor.rotary_encoder", "sensor", "on_nope", None),
+    ],
+)
+def test_resolve_component_trigger(
+    catalog_id: str | None, domain: str, key: str, expected: str | None
+) -> None:
+    """Platform-scoped ids win; the domain-level id is the fallback."""
+    trigger = catalog.resolve_component_trigger(catalog_id, domain, key)
+    assert (trigger.id if trigger else None) == expected
+
+
 async def test_get_available_excludes_action_field_triggers(tmp_path: Path) -> None:
     """A ``number.template`` with ``set_action:`` offers ``on_*`` triggers, not the action-field."""
     config = tmp_path / "num.yaml"
@@ -290,6 +310,26 @@ async def test_get_available_lists_configured_component_instances(tmp_path: Path
     assert ("switch.gpio", "relay_two") in devices
     # A single-reading platform with no sub-entity blocks is never a container.
     assert devices[("switch.gpio", "relay_one")]["is_entity_container"] is False
+
+
+async def test_get_available_lists_instances_with_only_platform_scoped_triggers(
+    tmp_path: Path,
+) -> None:
+    """A ``sendspin`` image is targetable although no domain-level ``image.on_*`` exists."""
+    config = tmp_path / "device.yaml"
+    config.write_text(
+        "esphome:\n  name: d\n"
+        "image:\n"
+        "  - platform: sendspin\n"
+        "    id: art\n"
+        "  - file: logo.png\n"
+        "    id: logo\n",
+        encoding="utf-8",
+    )
+    controller = _make_controller(tmp_path)
+    result = await controller.get_available(configuration="device.yaml")
+    assert [(d["component_id"], d["id"]) for d in result["devices"]] == [("image.sendspin", "art")]
+    assert "sendspin.image.on_image_display" in {t["id"] for t in result["triggers"]}
 
 
 async def test_get_available_devices_follow_document_order(tmp_path: Path) -> None:

--- a/tests/test_automations_controller.py
+++ b/tests/test_automations_controller.py
@@ -87,6 +87,8 @@ def test_infer_component_scope(key: str, expected: tuple[str, str] | None) -> No
     [
         ("sensor.rotary_encoder", "sensor", "on_clockwise", "rotary_encoder.sensor.on_clockwise"),
         ("sensor.rotary_encoder", "sensor", "on_value", "sensor.on_value"),
+        ("touchscreen.xpt2046", "touchscreen", "on_touch", "xpt2046.touchscreen.on_touch"),
+        (None, "touchscreen", "on_touch", "touchscreen.on_touch"),
         ("binary_sensor.gpio", "binary_sensor", "on_press", "binary_sensor.on_press"),
         (None, "binary_sensor", "on_press", "binary_sensor.on_press"),
         ("sensor.aht10", "sensor", "on_value_range", "sensor.on_value_range"),

--- a/tests/test_automations_parse.py
+++ b/tests/test_automations_parse.py
@@ -1035,6 +1035,20 @@ def test_parse_subentity_trigger_resolves_domain_id_under_platform_parent() -> N
     assert [p.automation.trigger_id for p in parsed] == ["sensor.on_value_range"]
 
 
+def test_parse_subentity_never_hosts_parent_platform_trigger() -> None:
+    """A parent platform's scoped key on a nested sub-block is not a trigger."""
+    text = (
+        "sensor:\n"
+        "  - platform: ltr_als_ps\n"
+        "    id: ltr\n"
+        "    ambient_light:\n"
+        "      id: ltr_als\n"
+        "      on_ps_high_threshold:\n"
+        "        - logger.log: bright\n"
+    )
+    assert parse_device_yaml(text) == []
+
+
 def test_parse_walks_domains_with_only_platform_scoped_triggers() -> None:
     """An ``image`` instance parses although no domain-level ``image.on_*`` trigger exists."""
     text = (

--- a/tests/test_automations_parse.py
+++ b/tests/test_automations_parse.py
@@ -136,6 +136,7 @@ def test_parse_inline_on_press_with_explicit_then() -> None:
     assert item.location.kind == "component_on"
     assert item.location.component_id == "kitchen_button"
     assert item.location.trigger == "on_press"
+    assert item.automation.trigger_id == "binary_sensor.on_press"
     assert [a.action_id for a in item.automation.actions] == [
         "switch.toggle",
         "delay",
@@ -1000,6 +1001,53 @@ def test_parse_recognises_hand_authored_subentity_handler() -> None:
     assert len(parsed) == 1
     assert parsed[0].location.component_id == "aht20_temperature"
     assert parsed[0].location.trigger == "on_value_range"
+
+
+def test_parse_platform_scoped_triggers_on_rotary_encoder() -> None:
+    """``on_clockwise`` / ``on_anticlockwise`` resolve to the platform-scoped catalog ids."""
+    parsed = parse_device_yaml(_load("rotary_encoder_triggers.yaml"))
+    assert [(p.automation.trigger_id, p.location.trigger) for p in parsed] == [
+        ("rotary_encoder.sensor.on_clockwise", "on_clockwise"),
+        ("rotary_encoder.sensor.on_anticlockwise", "on_anticlockwise"),
+    ]
+    assert {p.location.component_id for p in parsed} == {"sensor_rotary_encoder_1"}
+    for item in parsed:
+        assert [a.action_id for a in item.automation.actions] == [
+            "logger.log",
+            "light.dim_relative",
+        ]
+
+
+def test_parse_subentity_trigger_resolves_domain_id_under_platform_parent() -> None:
+    """A sub-sensor's ``on_value_range`` resolves through the parent's platform to the domain id."""
+    text = (
+        "sensor:\n"
+        "  - platform: aht10\n"
+        "    id: aht20\n"
+        "    temperature:\n"
+        "      id: aht20_temperature\n"
+        "      on_value_range:\n"
+        "        above: 10\n"
+        "        then:\n"
+        "          - logger.log: hot\n"
+    )
+    parsed = parse_device_yaml(text)
+    assert [p.automation.trigger_id for p in parsed] == ["sensor.on_value_range"]
+
+
+def test_parse_walks_domains_with_only_platform_scoped_triggers() -> None:
+    """An ``image`` instance parses although no domain-level ``image.on_*`` trigger exists."""
+    text = (
+        "image:\n"
+        "  - platform: sendspin\n"
+        "    id: art\n"
+        "    on_image_display:\n"
+        "      - logger.log: shown\n"
+    )
+    parsed = parse_device_yaml(text)
+    assert [(p.automation.trigger_id, p.location.component_id) for p in parsed] == [
+        ("sendspin.image.on_image_display", "art")
+    ]
 
 
 # Nested action-list config fields (dotted ``field`` paths)

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -2867,6 +2867,31 @@ def test_delete_platform_scoped_trigger_removes_only_that_handler() -> None:
     assert [p.location.trigger for p in parse_device_yaml(new_text)] == ["on_anticlockwise"]
 
 
+def test_upsert_rejects_parent_platform_trigger_on_subentity() -> None:
+    """A parent platform's scoped key never splices under a nested sub-block."""
+    text = (
+        "esphome:\n  name: x\n"
+        "sensor:\n"
+        "  - platform: ltr_als_ps\n"
+        "    id: ltr\n"
+        "    ambient_light:\n"
+        "      id: ltr_als\n"
+    )
+    tree = AutomationTree(
+        trigger_id="ltr_als_ps.sensor.on_ps_high_threshold",
+        trigger_params={},
+        actions=[ActionNode(action_id="logger.log", params={"format": "bright"})],
+    )
+    with pytest.raises(CommandError) as excinfo:
+        render_upsert(
+            text,
+            tree=tree,
+            location=ComponentOnLocation(component_id="ltr_als", trigger="on_ps_high_threshold"),
+        )
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "Unknown trigger id 'on_ps_high_threshold'" in str(excinfo.value)
+
+
 def test_upsert_platform_scoped_trigger_without_instance_names_top_level_domain() -> None:
     """A missing instance reports the YAML domain, not the trigger's catalog id."""
     with pytest.raises(CommandError) as excinfo:

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -2774,6 +2774,19 @@ def test_round_trip_subentity_handler_is_parsed_back() -> None:
     assert [a.action_id for a in parsed[0].automation.actions] == ["light.toggle"]
 
 
+def test_delete_subentity_rejects_a_key_that_is_not_a_catalog_trigger() -> None:
+    """Sub-entity delete validates the key so a config block is never stripped."""
+    text = _AHT10.replace(
+        "      name: Kit Temperature\n",
+        "      name: Kit Temperature\n      filters:\n        - offset: 1\n",
+    )
+    with pytest.raises(CommandError) as excinfo:
+        render_delete(
+            text, location=ComponentOnLocation(component_id="aht20_temperature", trigger="filters")
+        )
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+
+
 def test_delete_subentity_handler_round_trips_to_original() -> None:
     """Deleting the sub-entity handler restores the byte-identical original."""
     loc = ComponentOnLocation(component_id="aht20_temperature", trigger="on_value_range")

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -2799,6 +2799,86 @@ def test_two_subsensors_on_one_platform_target_independently() -> None:
     assert ("aht20_humidity", "on_value_range") in targeted
 
 
+_ROTARY = _load("rotary_encoder_triggers.yaml")
+_ROTARY_LOC = ComponentOnLocation(component_id="sensor_rotary_encoder_1", trigger="on_clockwise")
+_ROTARY_ANTI_LOC = ComponentOnLocation(
+    component_id="sensor_rotary_encoder_1", trigger="on_anticlockwise"
+)
+
+
+def _clockwise_tree() -> AutomationTree:
+    return AutomationTree(
+        trigger_id="rotary_encoder.sensor.on_clockwise",
+        trigger_params={},
+        actions=[ActionNode(action_id="logger.log", params={"format": "turned"})],
+    )
+
+
+def test_upsert_platform_scoped_trigger_splices_under_top_level_domain() -> None:
+    """A ``rotary_encoder.sensor.on_clockwise`` handler lands under the ``sensor:`` instance."""
+    without = _ROTARY.replace(
+        "    on_clockwise:\n"
+        "      - logger.log: clockwise\n"
+        "      - light.dim_relative:\n"
+        "          id: light_monochromatic_1\n"
+        "          relative_brightness: 5%\n",
+        "",
+    )
+    assert "on_clockwise" not in without
+    new_text, diff = render_upsert(without, tree=_clockwise_tree(), location=_ROTARY_LOC)
+    assert "sensor.rotary_encoder:" not in new_text
+    assert "    on_clockwise:\n      then:\n        - logger.log: turned\n" in new_text
+    assert _apply_diff(without, diff) == new_text
+    parsed = parse_device_yaml(new_text)
+    assert [(p.automation.trigger_id, p.location) for p in parsed] == [
+        ("rotary_encoder.sensor.on_anticlockwise", _ROTARY_ANTI_LOC),
+        ("rotary_encoder.sensor.on_clockwise", _ROTARY_LOC),
+    ]
+
+
+def test_upsert_platform_scoped_trigger_replaces_existing_handler() -> None:
+    """Re-saving an existing ``on_clockwise`` replaces its body in place."""
+    new_text, _diff = render_upsert(_ROTARY, tree=_clockwise_tree(), location=_ROTARY_LOC)
+    assert "logger.log: clockwise" not in new_text
+    assert "logger.log: turned" in new_text
+    assert "logger.log: anticlockwise" in new_text
+
+
+def test_upsert_platform_scoped_trigger_list_entry_appends() -> None:
+    """``index=1`` on a list-capable platform trigger appends a second entry."""
+    new_text, _diff = render_upsert(
+        _ROTARY,
+        tree=_clockwise_tree(),
+        location=ComponentOnLocation(
+            component_id="sensor_rotary_encoder_1", trigger="on_clockwise", index=1
+        ),
+    )
+    clockwise = [p for p in parse_device_yaml(new_text) if p.location.trigger == "on_clockwise"]
+    assert [p.location.index for p in clockwise] == [0, 1]
+    assert [a.action_id for a in clockwise[1].automation.actions] == ["logger.log"]
+
+
+def test_delete_platform_scoped_trigger_removes_only_that_handler() -> None:
+    """Deleting ``on_clockwise`` leaves the sibling ``on_anticlockwise`` intact."""
+    new_text, diff = render_delete(_ROTARY, location=_ROTARY_LOC)
+    assert "on_clockwise" not in new_text
+    assert "on_anticlockwise:" in new_text
+    assert _apply_diff(_ROTARY, diff) == new_text
+    assert [p.location.trigger for p in parse_device_yaml(new_text)] == ["on_anticlockwise"]
+
+
+def test_upsert_platform_scoped_trigger_without_instance_names_top_level_domain() -> None:
+    """A missing instance reports the YAML domain, not the trigger's catalog id."""
+    with pytest.raises(CommandError) as excinfo:
+        render_upsert(
+            "esphome:\n  name: x\nsensor: []\n",
+            tree=_clockwise_tree(),
+            location=ComponentOnLocation(component_id="ghost", trigger="on_clockwise"),
+        )
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "not found under 'sensor'" in str(excinfo.value)
+
+
 _AHT10_IDLESS = (
     "esphome:\n  name: x\n"
     "sensor:\n"

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -2867,6 +2867,17 @@ def test_delete_platform_scoped_trigger_removes_only_that_handler() -> None:
     assert [p.location.trigger for p in parse_device_yaml(new_text)] == ["on_anticlockwise"]
 
 
+def test_delete_rejects_a_key_that_is_not_a_catalog_trigger() -> None:
+    """Delete validates the handler key so a config field is never stripped."""
+    with pytest.raises(CommandError) as excinfo:
+        render_delete(
+            _ROTARY,
+            location=ComponentOnLocation(component_id="sensor_rotary_encoder_1", trigger="pin_a"),
+        )
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "pin_a: GPIO18" in _ROTARY
+
+
 def test_upsert_rejects_parent_platform_trigger_on_subentity() -> None:
     """A parent platform's scoped key never splices under a nested sub-block."""
     text = (


### PR DESCRIPTION
# What does this implement/fix?

The catalog ships 50 platform-scoped component triggers whose id is `<platform>.<domain>.<key>` (`rotary_encoder.sensor.on_clockwise`, `applies_to: ["sensor.rotary_encoder"]`; also nextion, the touchscreen drivers, ezo, ltr501, speaker, sendspin, ble_client, ir_rf_proxy). The picker offered them, but every place that maps an instance plus a bare `on_*` key back to a trigger only knew `<domain>.<key>`: the parser skipped the handlers silently, so they never appeared as automations, and the writer raised `Unknown trigger id 'on_clockwise'` on save. The splice also used `applies_to[0]` as the YAML top-level key, which is a catalog id for these triggers.

- `catalog.resolve_component_trigger` resolves an instance's key through a cached `(applies_to scope, bare key)` index, platform scope first, then the bare domain. Parse, upsert, delete and the sub-entity path all go through it.
- `catalog.hosts_component_triggers` is the one gate for "this instance can host triggers"; the parser and the picker scoping use it, so domains with only platform-scoped triggers (`image`, `radio_frequency`) are walked too.
- The writer's no-instance fallback reads the same index and reports the top-level domain in its error.

One behaviour change outside the bug: the seven touchscreen drivers ship platform-scoped `on_touch` / `on_release` / `on_update` twins of the domain-level `touchscreen.*` triggers, and the platform scope now wins, so an existing handler on such a driver resolves to the twin. The twins have the same (empty) params and list shape, so the YAML and the editor form are unchanged, but they carry an empty description and the generic docs link. That is catalog data, so the fix belongs in the sync (inherit the domain-level description and docs link, or drop the empty duplicates) as a follow-up.

Verified in the browser with the companion frontend on the reporter's YAML: both handlers parse and open in the editor, Add automation with `On Clockwise` appends a list entry under `sensor:`, and delete removes only that handler. On `main` the same flow shows the issue's error.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2668

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#1719

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
