### PR TITLE
Drop platform-scoped trigger twins of domain-level triggers in the sync

### DIFF
--- a/esphome_device_builder/controllers/automations/catalog.py
+++ b/esphome_device_builder/controllers/automations/catalog.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any, TypedDict
 
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
+from ...helpers.automation_keys import bare_trigger_key
 from ...helpers.json import loads as json_loads
 from ...helpers.lazy_catalog import LazyBodyStore, is_unsafe_catalog_id
 from ...models.automations import (
@@ -242,7 +243,7 @@ def _component_trigger_index() -> dict[tuple[str, str], str]:
     for trigger in _slim_triggers():
         if trigger.is_device_level:
             continue
-        key = trigger.id.rsplit(".", 1)[-1]
+        key = bare_trigger_key(trigger.id)
         for scope in trigger.applies_to:
             out[(scope, key)] = trigger.id
     return out

--- a/esphome_device_builder/helpers/automation_keys.py
+++ b/esphome_device_builder/helpers/automation_keys.py
@@ -13,3 +13,8 @@ TRIGGER_KEY_PREFIXES: tuple[str, ...] = ("on_",)
 def is_trigger_key(key: str) -> bool:
     """Return True when *key* names an inline automation trigger (``on_*``)."""
     return key.startswith(TRIGGER_KEY_PREFIXES)
+
+
+def bare_trigger_key(trigger_id: str) -> str:
+    """Return the ``on_*`` YAML key a catalog trigger id ends in."""
+    return trigger_id.rsplit(".", 1)[-1]

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -9973,7 +9973,7 @@ def build_automations(  # noqa: C901
     _apply_automation_required_groups(actions, groups_by_type.get("action"))
     _apply_automation_required_groups(conditions, groups_by_type.get("condition"))
     return {
-        "triggers": _dedupe_by_id(triggers),
+        "triggers": _drop_platform_trigger_twins(_dedupe_by_id(triggers)),
         "actions": actions,
         "conditions": conditions,
         "light_effects": _dedupe_by_id(effects),
@@ -10862,6 +10862,36 @@ def _automation_label(domain: str, name: str, docs_name: str | None) -> str:
         return pretty_name
     domain_label = domain.replace("_", " ").title()
     return f"{domain_label}{_AUTOMATION_LABEL_SEPARATOR}{pretty_name}"
+
+
+def _drop_platform_trigger_twins(triggers: list[dict]) -> list[dict]:
+    """Drop platform-scoped triggers that only restate a domain-level trigger of the same key."""
+    # A driver schema re-lists its base's hooks (``xpt2046.touchscreen``
+    # carries ``on_touch``); the bare-domain entry already applies to
+    # every platform and carries the docs, so the twin only shadows it.
+    by_domain_key = {
+        (t["applies_to"][0], _bare_trigger_key(t["id"])): t
+        for t in triggers
+        if not t["is_device_level"] and len(t["applies_to"]) == 1 and "." not in t["applies_to"][0]
+    }
+    out: list[dict] = []
+    for trigger in triggers:
+        scope = trigger["applies_to"][0] if len(trigger["applies_to"]) == 1 else ""
+        twin = by_domain_key.get((scope.split(".", 1)[0], _bare_trigger_key(trigger["id"])))
+        if (
+            "." in scope
+            and twin is not None
+            and not trigger["config_entries"]
+            and trigger["supports_list"] == twin["supports_list"]
+        ):
+            continue
+        out.append(trigger)
+    return out
+
+
+def _bare_trigger_key(trigger_id: str) -> str:
+    """Return the ``on_*`` YAML key a trigger id ends in."""
+    return trigger_id.rsplit(".", 1)[-1]
 
 
 def _dedupe_by_id(entries: list[dict]) -> list[dict]:

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -10872,11 +10872,15 @@ def _drop_platform_trigger_twins(triggers: list[dict]) -> list[dict]:
     # A driver schema re-lists its base's hooks (``xpt2046.touchscreen``
     # carries ``on_touch``); the bare-domain entry already applies to
     # every platform and carries the docs, so the twin only shadows it.
-    domain_level = {
-        (t["applies_to"][0], bare_trigger_key(t["id"])): t
-        for t in triggers
-        if len(t["applies_to"]) == 1 and "." not in t["applies_to"][0]
-    }
+    domain_level: dict[tuple[str, str], dict] = {}
+    for t in triggers:
+        if len(t["applies_to"]) != 1 or "." in t["applies_to"][0]:
+            continue
+        slot = (t["applies_to"][0], bare_trigger_key(t["id"]))
+        if slot in domain_level:
+            msg = f"{domain_level[slot]['id']} and {t['id']} both host {slot[1]} on {slot[0]}"
+            raise RuntimeError(msg)
+        domain_level[slot] = t
 
     def is_twin(trigger: dict) -> bool:
         if len(trigger["applies_to"]) != 1 or "." not in trigger["applies_to"][0]:
@@ -10885,6 +10889,8 @@ def _drop_platform_trigger_twins(triggers: list[dict]) -> list[dict]:
         twin = domain_level.get((domain, bare_trigger_key(trigger["id"])))
         return (
             twin is not None
+            and not trigger["description"]
+            and trigger["docs_url"] == _CORE_AUTOMATION_DOCS
             and trigger["config_entries"] == twin["config_entries"]
             and trigger["supports_list"] == twin["supports_list"]
         )

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -126,7 +126,10 @@ from esphome_device_builder.controllers.components import (  # noqa: E402
     INTERNAL_COMPONENT_IDS as _INTERNAL_COMPONENT_IDS,
 )
 from esphome_device_builder.controllers.components import variant_to_key  # noqa: E402
-from esphome_device_builder.helpers.automation_keys import is_trigger_key  # noqa: E402
+from esphome_device_builder.helpers.automation_keys import (  # noqa: E402
+    bare_trigger_key,
+    is_trigger_key,
+)
 from esphome_device_builder.helpers.chips import normalize_chip_variant  # noqa: E402
 from esphome_device_builder.migration_rule_kinds import (  # noqa: E402
     MIGRATION_RULE_EXTRA_FIELDS,
@@ -10869,29 +10872,24 @@ def _drop_platform_trigger_twins(triggers: list[dict]) -> list[dict]:
     # A driver schema re-lists its base's hooks (``xpt2046.touchscreen``
     # carries ``on_touch``); the bare-domain entry already applies to
     # every platform and carries the docs, so the twin only shadows it.
-    by_domain_key = {
-        (t["applies_to"][0], _bare_trigger_key(t["id"])): t
+    domain_level = {
+        (t["applies_to"][0], bare_trigger_key(t["id"])): t
         for t in triggers
-        if not t["is_device_level"] and len(t["applies_to"]) == 1 and "." not in t["applies_to"][0]
+        if len(t["applies_to"]) == 1 and "." not in t["applies_to"][0]
     }
-    out: list[dict] = []
-    for trigger in triggers:
-        scope = trigger["applies_to"][0] if len(trigger["applies_to"]) == 1 else ""
-        twin = by_domain_key.get((scope.split(".", 1)[0], _bare_trigger_key(trigger["id"])))
-        if (
-            "." in scope
-            and twin is not None
-            and not trigger["config_entries"]
+
+    def is_twin(trigger: dict) -> bool:
+        if len(trigger["applies_to"]) != 1 or "." not in trigger["applies_to"][0]:
+            return False
+        domain = trigger["applies_to"][0].split(".", 1)[0]
+        twin = domain_level.get((domain, bare_trigger_key(trigger["id"])))
+        return (
+            twin is not None
+            and trigger["config_entries"] == twin["config_entries"]
             and trigger["supports_list"] == twin["supports_list"]
-        ):
-            continue
-        out.append(trigger)
-    return out
+        )
 
-
-def _bare_trigger_key(trigger_id: str) -> str:
-    """Return the ``on_*`` YAML key a trigger id ends in."""
-    return trigger_id.rsplit(".", 1)[-1]
+    return [t for t in triggers if not is_twin(t)]
 
 
 def _dedupe_by_id(entries: list[dict]) -> list[dict]:

--- a/tests/test_automations_controller.py
+++ b/tests/test_automations_controller.py
@@ -82,13 +82,28 @@ def test_infer_component_scope(key: str, expected: tuple[str, str] | None) -> No
     assert catalog.infer_component_scope(key) == expected
 
 
+def test_resolve_component_trigger_prefers_the_platform_scope(monkeypatch) -> None:
+    """A key hosted at both the platform and the domain scope resolves to the platform id."""
+    index = {
+        ("touchscreen.fake", "on_touch"): "fake.touchscreen.on_touch",
+        ("touchscreen", "on_touch"): "touchscreen.on_touch",
+    }
+    monkeypatch.setattr(catalog, "_component_trigger_index", lambda: index)
+    monkeypatch.setattr(catalog, "trigger_by_id", lambda trigger_id: trigger_id)
+    assert (
+        catalog.resolve_component_trigger("touchscreen.fake", "touchscreen", "on_touch")
+        == "fake.touchscreen.on_touch"
+    )
+    assert (
+        catalog.resolve_component_trigger(None, "touchscreen", "on_touch") == "touchscreen.on_touch"
+    )
+
+
 @pytest.mark.parametrize(
     ("catalog_id", "domain", "key", "expected"),
     [
         ("sensor.rotary_encoder", "sensor", "on_clockwise", "rotary_encoder.sensor.on_clockwise"),
         ("sensor.rotary_encoder", "sensor", "on_value", "sensor.on_value"),
-        ("touchscreen.xpt2046", "touchscreen", "on_touch", "xpt2046.touchscreen.on_touch"),
-        (None, "touchscreen", "on_touch", "touchscreen.on_touch"),
         ("binary_sensor.gpio", "binary_sensor", "on_press", "binary_sensor.on_press"),
         (None, "binary_sensor", "on_press", "binary_sensor.on_press"),
         ("sensor.aht10", "sensor", "on_value_range", "sensor.on_value_range"),

--- a/tests/test_automations_sync.py
+++ b/tests/test_automations_sync.py
@@ -933,6 +933,74 @@ def test_build_automations_merged_hub_trigger_dedupes_against_base(tmp_path: Pat
     assert len(matching) == 1
 
 
+def _trigger_section(key: str, docs: str = "") -> dict:
+    return {
+        "schemas": {
+            "CONFIG_SCHEMA": {
+                "schema": {
+                    "config_vars": {key: {"key": "Optional", "type": "trigger", "docs": docs}}
+                },
+            },
+        },
+    }
+
+
+def test_build_automations_drops_platform_twins_of_domain_level_triggers(tmp_path: Path) -> None:
+    """A driver's restated ``on_touch`` yields only the documented ``touchscreen.on_touch``."""
+    schema_dir = _write_schema(
+        tmp_path, "touchscreen.json", {"touchscreen": _trigger_section("on_touch", "Fires.")}
+    )
+    _write_schema(tmp_path, "xpt2046.json", {"xpt2046.touchscreen": _trigger_section("on_touch")})
+    _write_schema(
+        tmp_path, "rotary_encoder.json", {"rotary_encoder.sensor": _trigger_section("on_clockwise")}
+    )
+    result = sync_components.build_automations(
+        schema_dir=schema_dir,
+        component_ids={"touchscreen.xpt2046", "sensor.rotary_encoder"},
+    )
+    ids = {t["id"] for t in result["triggers"]}
+    assert "touchscreen.on_touch" in ids
+    assert "xpt2046.touchscreen.on_touch" not in ids
+    assert "rotary_encoder.sensor.on_clockwise" in ids
+
+
+def test_build_automations_keeps_platform_trigger_with_its_own_params(tmp_path: Path) -> None:
+    """A platform-scoped trigger carrying params is a specialisation, not a twin."""
+    schema_dir = _write_schema(
+        tmp_path, "touchscreen.json", {"touchscreen": _trigger_section("on_touch", "Fires.")}
+    )
+    _write_schema(
+        tmp_path,
+        "xpt2046.json",
+        {
+            "xpt2046.touchscreen": {
+                "schemas": {
+                    "CONFIG_SCHEMA": {
+                        "schema": {
+                            "config_vars": {
+                                "on_touch": {
+                                    "key": "Optional",
+                                    "type": "trigger",
+                                    "schema": {
+                                        "config_vars": {
+                                            "threshold": {"key": "Optional", "type": "integer"}
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    },
+                },
+            },
+        },
+    )
+    result = sync_components.build_automations(
+        schema_dir=schema_dir, component_ids={"touchscreen.xpt2046"}
+    )
+    ids = {t["id"] for t in result["triggers"]}
+    assert {"touchscreen.on_touch", "xpt2046.touchscreen.on_touch"} <= ids
+
+
 def _in_range_schema_dir(tmp_path: Path) -> Path:
     return _write_schema(
         tmp_path,

--- a/tests/test_automations_sync.py
+++ b/tests/test_automations_sync.py
@@ -946,7 +946,7 @@ def test_build_automations_drops_platform_twins_of_domain_level_triggers(
     tmp_path: Path, monkeypatch
 ) -> None:
     """A driver's restated ``on_touch`` yields only the documented ``touchscreen.on_touch``."""
-    monkeypatch.setattr(sync_components, "_live_trigger_singles", lambda top_key: {})
+    monkeypatch.setattr(sync_components, "_live_trigger_singles", lambda top_key: frozenset())
     schema_dir = _write_schema(
         tmp_path, "touchscreen.json", {"touchscreen": _trigger_section("on_touch", "Fires.")}
     )
@@ -1009,7 +1009,9 @@ def test_build_automations_keeps_platform_trigger_with_its_own_list_shape(
     monkeypatch.setattr(
         sync_components,
         "_live_trigger_singles",
-        lambda top_key: {"on_touch": False} if top_key == "xpt2046.touchscreen" else {},
+        lambda top_key: frozenset(
+            {("on_touch", False)} if top_key == "xpt2046.touchscreen" else ()
+        ),
     )
     schema_dir = _write_schema(
         tmp_path, "touchscreen.json", {"touchscreen": _trigger_section("on_touch", "Fires.")}

--- a/tests/test_automations_sync.py
+++ b/tests/test_automations_sync.py
@@ -964,8 +964,11 @@ def test_build_automations_drops_platform_twins_of_domain_level_triggers(
     assert "rotary_encoder.sensor.on_clockwise" in ids
 
 
-def test_build_automations_keeps_platform_trigger_with_its_own_params(tmp_path: Path) -> None:
+def test_build_automations_keeps_platform_trigger_with_its_own_params(
+    tmp_path: Path, monkeypatch
+) -> None:
     """A platform-scoped trigger carrying params is a specialisation, not a twin."""
+    monkeypatch.setattr(sync_components, "_live_trigger_singles", lambda top_key: frozenset())
     schema_dir = _write_schema(
         tmp_path, "touchscreen.json", {"touchscreen": _trigger_section("on_touch", "Fires.")}
     )
@@ -986,8 +989,11 @@ def test_build_automations_keeps_platform_trigger_with_its_own_params(tmp_path: 
     assert {"touchscreen.on_touch", "xpt2046.touchscreen.on_touch"} <= ids
 
 
-def test_build_automations_keeps_platform_trigger_with_its_own_docs(tmp_path: Path) -> None:
+def test_build_automations_keeps_platform_trigger_with_its_own_docs(
+    tmp_path: Path, monkeypatch
+) -> None:
     """A documented platform-scoped trigger is a specialisation, not a twin."""
+    monkeypatch.setattr(sync_components, "_live_trigger_singles", lambda top_key: frozenset())
     schema_dir = _write_schema(
         tmp_path, "touchscreen.json", {"touchscreen": _trigger_section("on_touch", "Fires.")}
     )

--- a/tests/test_automations_sync.py
+++ b/tests/test_automations_sync.py
@@ -16,6 +16,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 # The sync script lives under ``script/`` and isn't on the package
 # path; add it to ``sys.path`` once at module import.
 _SCRIPT_DIR = Path(__file__).parent.parent / "script"
@@ -979,6 +981,53 @@ def test_build_automations_keeps_platform_trigger_with_its_own_params(tmp_path: 
     )
     ids = {t["id"] for t in result["triggers"]}
     assert {"touchscreen.on_touch", "xpt2046.touchscreen.on_touch"} <= ids
+
+
+def test_build_automations_keeps_platform_trigger_with_its_own_docs(tmp_path: Path) -> None:
+    """A documented platform-scoped trigger is a specialisation, not a twin."""
+    schema_dir = _write_schema(
+        tmp_path, "touchscreen.json", {"touchscreen": _trigger_section("on_touch", "Fires.")}
+    )
+    _write_schema(
+        tmp_path,
+        "xpt2046.json",
+        {"xpt2046.touchscreen": _trigger_section("on_touch", "Fires on this driver.")},
+    )
+    result = sync_components.build_automations(
+        schema_dir=schema_dir, component_ids={"touchscreen.xpt2046"}
+    )
+    assert "xpt2046.touchscreen.on_touch" in {t["id"] for t in result["triggers"]}
+
+
+def test_build_automations_keeps_platform_trigger_with_its_own_list_shape(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A platform-scoped trigger whose list shape differs from the domain's is kept."""
+    monkeypatch.setattr(
+        sync_components,
+        "_live_trigger_singles",
+        lambda top_key: {"on_touch": False} if top_key == "xpt2046.touchscreen" else {},
+    )
+    schema_dir = _write_schema(
+        tmp_path, "touchscreen.json", {"touchscreen": _trigger_section("on_touch", "Fires.")}
+    )
+    _write_schema(tmp_path, "xpt2046.json", {"xpt2046.touchscreen": _trigger_section("on_touch")})
+    result = sync_components.build_automations(
+        schema_dir=schema_dir, component_ids={"touchscreen.xpt2046"}
+    )
+    kept = {t["id"]: t for t in result["triggers"]}
+    assert kept["xpt2046.touchscreen.on_touch"]["supports_list"] is True
+    assert kept["touchscreen.on_touch"]["supports_list"] is False
+
+
+def test_build_automations_fails_on_two_domain_triggers_for_one_key(tmp_path: Path) -> None:
+    """Two domain-level ids hosting one key on one domain fail the sync loudly."""
+    schema_dir = _write_schema(
+        tmp_path, "display.json", {"display": _trigger_section("on_page", "Fires.")}
+    )
+    _write_schema(tmp_path, "page.json", {"page.display": _trigger_section("on_page")})
+    with pytest.raises(RuntimeError, match="on_page"):
+        sync_components.build_automations(schema_dir=schema_dir, component_ids=set())
 
 
 def _in_range_schema_dir(tmp_path: Path) -> Path:

--- a/tests/test_automations_sync.py
+++ b/tests/test_automations_sync.py
@@ -942,8 +942,11 @@ def _trigger_section(key: str, docs: str = "", schema: dict | None = None) -> di
     return {"schemas": {"CONFIG_SCHEMA": {"schema": {"config_vars": {key: var}}}}}
 
 
-def test_build_automations_drops_platform_twins_of_domain_level_triggers(tmp_path: Path) -> None:
+def test_build_automations_drops_platform_twins_of_domain_level_triggers(
+    tmp_path: Path, monkeypatch
+) -> None:
     """A driver's restated ``on_touch`` yields only the documented ``touchscreen.on_touch``."""
+    monkeypatch.setattr(sync_components, "_live_trigger_singles", lambda top_key: {})
     schema_dir = _write_schema(
         tmp_path, "touchscreen.json", {"touchscreen": _trigger_section("on_touch", "Fires.")}
     )

--- a/tests/test_automations_sync.py
+++ b/tests/test_automations_sync.py
@@ -933,16 +933,11 @@ def test_build_automations_merged_hub_trigger_dedupes_against_base(tmp_path: Pat
     assert len(matching) == 1
 
 
-def _trigger_section(key: str, docs: str = "") -> dict:
-    return {
-        "schemas": {
-            "CONFIG_SCHEMA": {
-                "schema": {
-                    "config_vars": {key: {"key": "Optional", "type": "trigger", "docs": docs}}
-                },
-            },
-        },
-    }
+def _trigger_section(key: str, docs: str = "", schema: dict | None = None) -> dict:
+    var: dict = {"key": "Optional", "type": "trigger", "docs": docs}
+    if schema is not None:
+        var["schema"] = schema
+    return {"schemas": {"CONFIG_SCHEMA": {"schema": {"config_vars": {key: var}}}}}
 
 
 def test_build_automations_drops_platform_twins_of_domain_level_triggers(tmp_path: Path) -> None:
@@ -973,25 +968,10 @@ def test_build_automations_keeps_platform_trigger_with_its_own_params(tmp_path: 
         tmp_path,
         "xpt2046.json",
         {
-            "xpt2046.touchscreen": {
-                "schemas": {
-                    "CONFIG_SCHEMA": {
-                        "schema": {
-                            "config_vars": {
-                                "on_touch": {
-                                    "key": "Optional",
-                                    "type": "trigger",
-                                    "schema": {
-                                        "config_vars": {
-                                            "threshold": {"key": "Optional", "type": "integer"}
-                                        }
-                                    },
-                                }
-                            }
-                        },
-                    },
-                },
-            },
+            "xpt2046.touchscreen": _trigger_section(
+                "on_touch",
+                schema={"config_vars": {"threshold": {"key": "Optional", "type": "integer"}}},
+            )
         },
     )
     result = sync_components.build_automations(


### PR DESCRIPTION
# What does this implement/fix?

Stacked on #2671. Seven touchscreen drivers restate the base `on_touch` / `on_release` / `on_update` hooks in their own schema, so the sync emitted 21 platform-scoped twins (`xpt2046.touchscreen.on_touch`) of the domain-level `touchscreen.*` triggers with an empty description and the generic docs link. With #2671 the platform scope wins on resolution, so existing handlers on those drivers re-labelled to the sparser twin.

`build_automations` now drops a platform-scoped trigger that only restates a domain-level trigger: same bare key, the domain-level one applies to its bare domain, no params of its own, and the same list shape. A platform trigger with its own params, or without a domain-level twin (`rotary_encoder.sensor.on_clockwise`), is kept.

The catalog is not regenerated here: the shipped index is stamped `2026.9.0b1` and the sync refuses to run against the installed `2026.8.2`, so the twins leave the catalog on the next nightly catalog sync.

**Related issue or feature (if applicable):**

- follow-up to https://github.com/esphome/device-builder/issues/2668

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
