### PR TITLE
Keep a key Home Assistant pushes while an adoption splice is in flight

### DIFF
--- a/esphome_device_builder/controllers/devices/_pending_keys_store.py
+++ b/esphome_device_builder/controllers/devices/_pending_keys_store.py
@@ -91,6 +91,13 @@ class PendingKeysStore:
         self._state[name] = entry
         self._store.async_delay_save(self._snapshot, delay=_SAVE_DELAY)
 
+    def pop_if(self, name: str, key: str) -> dict[str, str] | None:
+        """Drop *name*'s entry only while it still holds *key*; a newer push survives."""
+        entry = self._state.get(name)
+        if entry is None or entry["key"] != key:
+            return None
+        return self.pop(name)
+
     def pop(self, name: str) -> dict[str, str] | None:
         """Drop and return *name*'s pending entry, or ``None``."""
         entry = self._state.pop(name, None)

--- a/esphome_device_builder/controllers/devices/encryption_key.py
+++ b/esphome_device_builder/controllers/devices/encryption_key.py
@@ -72,7 +72,10 @@ async def set_encryption_key(
         outcomes.add(outcome)
         reason = reason or why
     if outcomes & {KeyHandoffResult.UPDATED, KeyHandoffResult.UNCHANGED}:
-        # Consume the pending entry only once the key actually landed.
+        # Consume the pending entry only once the key actually landed. Unconditional
+        # on purpose: the device is configured now, so an older entry is stale cruft
+        # to clear, which pop_if would keep; adoption is the side that must not drop
+        # a push that overtook the key it spliced.
         controller._pending_keys.pop(name)
     else:
         # Nothing accepted the key — keep a copy so a later push, the

--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -291,8 +291,10 @@ async def _finalize_adoption_key(
             warning = await _splice_pending_key_or_cleanup(
                 controller, path, content, fresh["key"], cleanup
             )
+        # A push that landed during the validate or write is newer than the
+        # key that was spliced; leave it for the next handoff.
         if warning is None:
-            controller._pending_keys.pop(name)
+            controller._pending_keys.pop_if(name, fresh["key"])
         return warning
     if encryption and not full_config_import:
         return await _mint_key_unless_package_encrypts(controller, path, content, cleanup)

--- a/tests/controllers/devices/test_encryption_key.py
+++ b/tests/controllers/devices/test_encryption_key.py
@@ -765,6 +765,16 @@ async def test_pending_keys_store_set_same_entry_skips_save(tmp_path: Path) -> N
     assert saves == []
 
 
+async def test_pending_keys_store_pop_if_keeps_a_newer_key(tmp_path: Path) -> None:
+    """``pop_if`` consumes the entry only while it still holds the key that was handled."""
+    store = PendingKeysStore(data_dir=tmp_path, shutdown_register=lambda cb: None)
+    store.set("kitchen", KEY)
+    assert store.pop_if("kitchen", OTHER_KEY) is None
+    assert store.get("kitchen") == {"key": KEY}
+    assert store.pop_if("kitchen", KEY) == {"key": KEY}
+    assert store.pop_if("kitchen", KEY) is None
+
+
 async def test_pending_keys_store_set_and_pop_roundtrip(tmp_path: Path) -> None:
     """RAM semantics: set overwrites, pop returns and clears, mac optional."""
     store = PendingKeysStore(data_dir=tmp_path, shutdown_register=lambda cb: None)

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.controllers.devices import DevicesController, importable
 from esphome_device_builder.controllers.editor import ValidatorUnavailableError
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.helpers.device_yaml import EsphomeConfigUnavailableError
@@ -292,6 +292,7 @@ async def test_import_device_full_config_url_delegates_to_dashboard_import(
     assert captured["args"][4] == "github://x/y.yaml@main?full_config"
 
 
+OTHER_KEY = "b3RoZXJrZXlvdGhlcmtleW90aGVya2V5b3RoZXJrZXlvdA=="
 PENDING_KEY = base64.b64encode(b"p" * 32).decode()
 
 
@@ -577,6 +578,39 @@ async def test_import_device_full_config_indirected_key_warns_and_keeps_pending(
     content = (tmp_path / "kitchen.yaml").read_text(encoding="utf-8")
     assert "!secret api_key" in content
     assert ctrl._pending_keys.get("kitchen") == {"key": PENDING_KEY}
+
+
+async def test_import_device_keeps_a_key_pushed_while_the_splice_was_in_flight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A push that lands mid-splice is newer than the spliced key and must survive the pop."""
+    monkeypatch.setattr(
+        "esphome.components.dashboard_import.import_config",
+        _full_config_stub('api:\n  encryption:\n    key: "OLDKEY=="\n'),
+    )
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    _seed_import_state(ctrl)
+    ctrl._pending_keys.set("kitchen", PENDING_KEY)
+    real_splice = importable._splice_pending_key_or_cleanup
+
+    async def splice_then_push(*args, **kwargs):
+        warning = await real_splice(*args, **kwargs)
+        ctrl._pending_keys.set("kitchen", OTHER_KEY)
+        return warning
+
+    monkeypatch.setattr(importable, "_splice_pending_key_or_cleanup", splice_then_push)
+
+    result = await ctrl.import_device(
+        name="kitchen",
+        project_name="x",
+        package_import_url="github://x/y.yaml@main?full_config",
+    )
+
+    assert "warning" not in result
+    assert f'key: "{PENDING_KEY}"' in (tmp_path / "kitchen.yaml").read_text(encoding="utf-8")
+    assert ctrl._pending_keys.get("kitchen") == {"key": OTHER_KEY}
 
 
 async def test_import_device_full_config_keeps_an_own_ota_key_and_the_pending_key(

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -292,7 +292,7 @@ async def test_import_device_full_config_url_delegates_to_dashboard_import(
     assert captured["args"][4] == "github://x/y.yaml@main?full_config"
 
 
-OTHER_KEY = "b3RoZXJrZXlvdGhlcmtleW90aGVya2V5b3RoZXJrZXlvdA=="
+OTHER_KEY = base64.b64encode(b"o" * 32).decode()
 PENDING_KEY = base64.b64encode(b"p" * 32).decode()
 
 
@@ -595,7 +595,7 @@ async def test_import_device_keeps_a_key_pushed_while_the_splice_was_in_flight(
     ctrl._pending_keys.set("kitchen", PENDING_KEY)
     real_splice = importable._splice_pending_key_or_cleanup
 
-    async def splice_then_push(*args, **kwargs):
+    async def splice_then_push(*args: Any, **kwargs: Any) -> str | None:
         warning = await real_splice(*args, **kwargs)
         ctrl._pending_keys.set("kitchen", OTHER_KEY)
         return warning


### PR DESCRIPTION
# What does this implement/fix?

Adoption consumes the pending Home Assistant key with an unconditional pop after the splice returns. The splice awaits a validate and a write, and Home Assistant re-pushes its key on every connect, so a push that lands inside that window is newer than the key that was just spliced and gets discarded with it. The next handoff then has nothing to apply.

`PendingKeysStore.pop_if` drops the entry only while it still holds the key that was handled, and the adoption finalize uses it. The handoff endpoint keeps its unconditional pop: a landed push makes any pending entry for that name stale by definition. A test pushes a different key while the splice is in flight and asserts the newer entry survives.

**Related issue or feature (if applicable):**

- found while working on #2684, closed as not a real case

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
